### PR TITLE
Refine CARP Sensors

### DIFF
--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -363,7 +363,7 @@ async def _compile_carp_interface_sensors(
     coordinator: OPNsenseDataUpdateCoordinator,
     state: MutableMapping[str, Any],
 ) -> list:
-    """Compile carp interface sensors.
+    """Compile CARP interface sensors.
 
     Args:
         config_entry: Config entry being exercised by the helper or test.
@@ -398,32 +398,61 @@ async def _compile_carp_interface_sensors(
                 interface_label = "unknown"
             friendly_interface_name = interface_descriptions.get(interface_label, interface_label)
 
-            description = interface.get("descr")
-            description_text = str(description).strip() if description is not None else ""
-            if description_text:
-                display_name = (
-                    f"CARP Interface Status {friendly_interface_name} {subnet} ({description_text})"
-                )
-            else:
-                display_name = f"CARP Interface Status {friendly_interface_name} {subnet}"
+            display_name = f"CARP Interface: {friendly_interface_name}: {subnet}"
             entity = OPNsenseCarpInterfaceSensor(
                 config_entry=config_entry,
                 coordinator=coordinator,
                 entity_description=SensorEntityDescription(
-                    key=f"carp.interface.{slugify(subnet)}",  # subnet is actually the ip
+                    key=_build_carp_interface_sensor_key(interface_label, subnet),
                     name=display_name,
                     native_unit_of_measurement=None,
                     device_class=None,
                     icon="mdi:check-network",
                     state_class=None,
-                    entity_registry_enabled_default=True,
-                    # entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                    entity_registry_enabled_default=False,
                 ),
             )
             entities.append(entity)
         except (AttributeError, TypeError, ValueError) as err:
             _LOGGER.debug("Skipping malformed CARP interface entry: %r (%s)", interface, err)
     return entities
+
+
+def _build_carp_interface_sensor_key(interface_name: str | None, subnet: str) -> str:
+    """Build CARP interface sensor key with interface and subnet context.
+
+    Args:
+        interface_name: Interface identifier supplied by CARP payload.
+        subnet: Virtual IP value from CARP payload.
+
+    Returns:
+        str: CARP sensor key in ``carp.interface.<interface_slug>.<subnet_slug>`` format.
+    """
+    interface_label = interface_name.strip() if isinstance(interface_name, str) else ""
+    interface_slug = slugify(interface_label) if interface_label else "unknown"
+    if not interface_slug:
+        interface_slug = "unknown"
+    subnet_slug = slugify(subnet.strip())
+    return f"carp.interface.{interface_slug}.{subnet_slug}"
+
+
+def _parse_carp_interface_sensor_key(key: str) -> tuple[str, str] | None:
+    """Parse CARP interface sensor key into interface and subnet slugs.
+
+    Args:
+        key: Sensor key from entity description.
+
+    Returns:
+        tuple[str, str] | None: Tuple of interface slug and subnet slug when valid.
+    """
+    key_parts = key.split(".")
+    if len(key_parts) != 4 or key_parts[0] != "carp" or key_parts[1] != "interface":
+        return None
+    interface_slug = key_parts[2].strip() or "unknown"
+    subnet_slug = key_parts[3].strip()
+    if not subnet_slug:
+        return None
+    return (interface_slug, subnet_slug)
 
 
 async def _compile_carp_status_sensor(
@@ -451,7 +480,7 @@ async def _compile_carp_status_sensor(
                 device_class=None,
                 icon="mdi:gauge",
                 state_class=None,
-                entity_registry_enabled_default=True,
+                entity_registry_enabled_default=False,
             ),
         )
     ]
@@ -1147,7 +1176,12 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             self._available = False
             self.async_write_ha_state()
             return
-        carp_interface_name: str = self.entity_description.key.split(".")[2]
+        key_data = _parse_carp_interface_sensor_key(self.entity_description.key)
+        if key_data is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
+        expected_interface_slug, expected_subnet_slug = key_data
         carp_interfaces = dict_get(state, "carp.interfaces", []) or []
         for i_interface in carp_interfaces:
             if not isinstance(i_interface, MutableMapping):
@@ -1160,9 +1194,19 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             if not isinstance(subnet, str) or not subnet.strip():
                 _LOGGER.debug("Skipping CARP interface entry with invalid subnet: %r", i_interface)
                 continue
-            if slugify(subnet.strip()) == carp_interface_name:
-                carp_interface = dict(i_interface)
-                break
+            if slugify(subnet.strip()) != expected_subnet_slug:
+                continue
+
+            interface_name = i_interface.get("interface")
+            interface_label = str(interface_name).strip() if interface_name is not None else ""
+            candidate_interface_slug = slugify(interface_label) if interface_label else "unknown"
+            if not candidate_interface_slug:
+                candidate_interface_slug = "unknown"
+            if candidate_interface_slug != expected_interface_slug:
+                continue
+
+            carp_interface = dict(i_interface)
+            break
         if not carp_interface:
             self._available = False
             self.async_write_ha_state()
@@ -1221,14 +1265,18 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
             return
 
         summary = dict(summary_raw)
-        summary_state = summary.get("state")
-        if not isinstance(summary_state, str) or not summary_state:
+        raw_summary_state = summary.get("state")
+        if not isinstance(raw_summary_state, str) or not raw_summary_state:
             self._available = False
             self.async_write_ha_state()
             return
 
         self._available = True
-        self._attr_native_value = summary_state
+        if raw_summary_state in ("unavailable", "unknown"):
+            self._attr_native_value = raw_summary_state
+        else:
+            summary_state = raw_summary_state.strip().replace("_", " ").title()
+            self._attr_native_value = summary_state
         self._attr_extra_state_attributes = {
             "enabled": coerce_bool(summary.get("enabled")),
             "maintenance_mode": coerce_bool(summary.get("maintenance_mode")),
@@ -1246,7 +1294,7 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
     @property
     def icon(self) -> str | None:
         """Return the icon for the sensor."""
-        state_value = str(self.native_value).lower()
+        state_value = str(self.native_value).lower().strip().replace(" ", "_")
         if state_value == "healthy":
             return "mdi:check-network"
         if state_value in {"maintenance", "not_configured"}:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -109,7 +109,7 @@ def test_carp_sensor_unavailable_variants(coord_data, desc_subnet, make_config_e
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = f"carp.interface.{sensor_module.slugify(desc_subnet)}"
+    desc.key = f"carp.interface.lan0.{sensor_module.slugify(desc_subnet)}"
     desc.name = "CARP"
 
     s = OPNsenseCarpInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
@@ -128,7 +128,7 @@ def test_carp_sensor_state_wrong_type(make_config_entry):
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = f"carp.interface.{sensor_module.slugify('10.10.10.10')}"
+    desc.key = f"carp.interface.wan.{sensor_module.slugify('10.10.10.10')}"
     desc.name = "CARP WrongType"
 
     s = OPNsenseCarpInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
@@ -142,7 +142,7 @@ def test_carp_sensor_state_wrong_type(make_config_entry):
 @pytest.mark.parametrize(
     "desc_key,cls",
     [
-        ("carp.interface.some", OPNsenseCarpInterfaceSensor),
+        ("carp.interface.some.some", OPNsenseCarpInterfaceSensor),
         ("carp.status_summary", OPNsenseCarpStatusSensor),
         ("gateway.gw1.status", OPNsenseGatewaySensor),
         ("interface.lan.status", OPNsenseInterfaceSensor),
@@ -290,7 +290,11 @@ def test_carp_sensor_attributes_and_icon(
     coord.data = {"carp": {"interfaces": [carp_entry]}}
 
     desc = MagicMock()
-    desc.key = f"carp.interface.{sensor_module.slugify(carp_entry['subnet'])}"
+    desc.key = (
+        f"carp.interface."
+        f"{sensor_module.slugify(carp_entry.get('interface', 'unknown'))}."
+        f"{sensor_module.slugify(carp_entry['subnet'])}"
+    )
     desc.name = "CARP Test"
 
     s = OPNsenseCarpInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
@@ -323,7 +327,7 @@ def test_carp_sensor_attributes_and_icon(
                 "interfaces": ["lan", "wan"],
                 "vips": [{"interface": "wan", "subnet": "1.2.3.4", "status": "MASTER"}],
             },
-            "healthy",
+            "Healthy",
             "mdi:check-network",
         ),
         (
@@ -340,7 +344,7 @@ def test_carp_sensor_attributes_and_icon(
                 "interfaces": ["wan"],
                 "vips": [],
             },
-            "maintenance",
+            "Maintenance",
             "mdi:backup-restore",
         ),
         (
@@ -357,7 +361,7 @@ def test_carp_sensor_attributes_and_icon(
                 "interfaces": ["wan"],
                 "vips": [],
             },
-            "degraded",
+            "Degraded",
             "mdi:close-network-outline",
         ),
         (
@@ -374,7 +378,7 @@ def test_carp_sensor_attributes_and_icon(
                 "interfaces": ["wan"],
                 "vips": [{"interface": "wan", "subnet": "1.2.3.5", "status": "INIT"}],
             },
-            "disabled",
+            "Disabled",
             "mdi:close-network-outline",
         ),
         (
@@ -391,7 +395,7 @@ def test_carp_sensor_attributes_and_icon(
                 "interfaces": [],
                 "vips": [],
             },
-            "not_configured",
+            "Not Configured",
             "mdi:backup-restore",
         ),
         (
@@ -468,17 +472,15 @@ async def test_compile_carp_interface_sensor_name_includes_interface(make_config
 
     entities = await sensor_module._compile_carp_interface_sensors(entry, coordinator, state)
     assert len(entities) == 1
-    assert (
-        entities[0].entity_description.name
-        == "CARP Interface Status WAN 203.0.113.10 (Primary WAN VIP)"
-    )
+    assert entities[0].entity_description.name == "CARP Interface: WAN: 203.0.113.10"
+    assert entities[0].entity_description.key == "carp.interface.wan.203_0_113_10"
 
 
 @pytest.mark.parametrize(
     ("desc_key", "cls", "main_check", "extra_check"),
     [
         (
-            f"carp.interface.{sensor_module.slugify('10.0.0.1')}",
+            f"carp.interface.{sensor_module.slugify('lan0')}.{sensor_module.slugify('10.0.0.1')}",
             OPNsenseCarpInterfaceSensor,
             lambda s: s.native_value == "MASTER",
             lambda s: s.icon == "mdi:check-network",
@@ -486,7 +488,7 @@ async def test_compile_carp_interface_sensor_name_includes_interface(make_config
         (
             "carp.status_summary",
             OPNsenseCarpStatusSensor,
-            lambda s: s.native_value == "healthy",
+            lambda s: s.native_value == "Healthy",
             lambda s: s.icon == "mdi:check-network",
         ),
         (


### PR DESCRIPTION
This pull request refactors the handling of CARP interface sensor keys in the OPNsense Home Assistant integration to provide more context and robustness. The sensor key format now includes both the interface and subnet, and new helper functions are introduced for key construction and parsing. The changes also update related logic and tests to align with the new format, and set CARP sensors to be disabled by default in the entity registry.

Key improvements and changes:

**Sensor Key Format and Handling:**
* Introduced a new helper function `_build_carp_interface_sensor_key` to generate CARP sensor keys in the format `carp.interface.<interface_slug>.<subnet_slug>`, providing clearer context for each sensor. (`custom_components/opnsense/sensor.py`)
* Added `_parse_carp_interface_sensor_key` to extract interface and subnet slugs from sensor keys, improving reliability in sensor updates. (`custom_components/opnsense/sensor.py`)
* Updated sensor creation to use the new key format and adjusted the logic in `_handle_coordinator_update` to match sensors based on both interface and subnet slugs. (`custom_components/opnsense/sensor.py`) [[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L413-R419) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L1150-R1191) [[3]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L1163-R1214)

**Sensor Defaults and Status Handling:**
* Changed CARP interface and status sensors to be disabled by default in the entity registry for better user control. (`custom_components/opnsense/sensor.py`) [[1]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L413-R419) [[2]](diffhunk://#diff-6c222ad1cb8865873293c88b1c83a85236a8a46b2d54908ea61207db4f3d2f70L454-R490)
* Improved normalization of CARP status values: now sets values like "unavailable" or "unknown" directly, and formats other statuses for readability. (`custom_components/opnsense/sensor.py`)

**Test Updates:**
* Updated all related tests to use the new sensor key format, ensuring compatibility and correctness with the refactored logic. (`tests/test_sensor.py`) [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L112-R112) [[2]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L131-R131) [[3]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L145-R145) [[4]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L293-R297) [[5]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330R479-R486)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate CARP interface matching by considering both interface and subnet; sensors gracefully handle malformed or unparsable entries.
  * CARP status and icon logic now normalizes state text for consistent display and health classification.

* **Changes**
  * CARP interface display names simplified to "CARP Interface: <friendly_interface>: <subnet>".
  * CARP interface and aggregate status sensors are disabled by default in the entity registry.

* **Tests**
  * Updated tests to expect interface-specific sensor identifiers and revised status capitalization/availability expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->