### PR TITLE
Refactor plugin check to stop firmware check spam 

### DIFF
--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Mapping, MutableMapping
+from datetime import datetime
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version as package_version
 import logging
@@ -169,6 +170,16 @@ def _add_plugin_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol
         )
         get_firmware_info: Callable[[], Any] | None = getattr(client, "get_firmware_info", None)
         safe_dict_get: Callable[[str], Any] | None = getattr(client, "_safe_dict_get", None)
+        installed_plugins_cache: set[str] | None = None
+        installed_plugins_updated_at: datetime | None = None
+        installed_plugins_refresh_succeeded = False
+        plugin_cache_ttl_seconds = int(
+            getattr(
+                client,
+                "_plugin_cache_ttl_seconds",
+                getattr(client, "_endpoint_cache_ttl_seconds", 6 * 60 * 60),
+            )
+        )
 
         async def _is_plugin_installed() -> bool:
             """Detect whether the Home Assistant OPNsense plugin is installed.
@@ -177,56 +188,91 @@ def _add_plugin_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol
                 bool: `True` when `os-homeassistant-maxit` is present, otherwise `False`.
             """
 
-            def _plugin_present_from_payload(payload: Any) -> bool:
-                """Determine plugin presence from a backend payload.
+            nonlocal installed_plugins_cache
+            nonlocal installed_plugins_updated_at
+            nonlocal installed_plugins_refresh_succeeded
+
+            def _installed_plugins_from_payload(payload: Any) -> set[str] | None:
+                """Extract installed plugin names from a backend payload.
 
                 Args:
                     payload: Firmware or plugin payload returned by backend helper methods.
 
                 Returns:
-                    bool: `True` if the payload indicates the plugin is installed.
+                    set[str] | None: Installed plugin names, or `None` when payload is invalid.
                 """
                 if isinstance(payload, Mapping):
-                    if "os-homeassistant-maxit" in payload:
-                        return True
                     package_list = payload.get("package")
                     if isinstance(package_list, list):
+                        installed_plugins: set[str] = set()
                         for pkg in package_list:
+                            name = pkg.get("name") if isinstance(pkg, Mapping) else None
                             if (
                                 isinstance(pkg, Mapping)
-                                and pkg.get("name") == "os-homeassistant-maxit"
+                                and isinstance(name, str)
                                 and str(pkg.get("installed")) == "1"
                             ):
-                                return True
-                    return False
+                                installed_plugins.add(name)
+                        return installed_plugins
+                    if "os-homeassistant-maxit" in payload:
+                        return {str(key) for key in payload}
+                    return set()
                 if isinstance(payload, list | set | tuple):
+                    installed_plugins = set()
                     for item in payload:
-                        if item == "os-homeassistant-maxit":
-                            return True
+                        if isinstance(item, str):
+                            installed_plugins.add(item)
                         if (
                             isinstance(item, Mapping)
-                            and item.get("name") == "os-homeassistant-maxit"
+                            and isinstance(item.get("name"), str)
                             and str(item.get("installed")) == "1"
                         ):
-                            return True
-                return False
+                            installed_plugins.add(item["name"])
+                    return installed_plugins
+                return None
 
-            if is_named_plugin_installed is not None:
-                result = await is_named_plugin_installed("os-homeassistant-maxit")
-                return bool(result)
-            if get_installed_plugins is not None:
-                plugins = await get_installed_plugins()
-                if _plugin_present_from_payload(plugins):
-                    return True
-            if get_firmware_info is not None:
-                firmware_info = await get_firmware_info()
-                if _plugin_present_from_payload(firmware_info):
-                    return True
-            if safe_dict_get is not None:
-                firmware_info = await safe_dict_get("/api/core/firmware/info")
-                if _plugin_present_from_payload(firmware_info):
-                    return True
-            return False
+            async def _refresh_installed_plugins() -> None:
+                """Refresh plugin names using the best available compatibility source."""
+                nonlocal installed_plugins_cache
+                nonlocal installed_plugins_updated_at
+                nonlocal installed_plugins_refresh_succeeded
+
+                now = datetime.now().astimezone()
+                cache_is_fresh = (
+                    installed_plugins_refresh_succeeded
+                    and installed_plugins_cache is not None
+                    and installed_plugins_updated_at is not None
+                    and (now - installed_plugins_updated_at).total_seconds()
+                    < plugin_cache_ttl_seconds
+                )
+                if cache_is_fresh:
+                    return
+
+                payload: Any | None = None
+                if is_named_plugin_installed is not None:
+                    installed = await is_named_plugin_installed("os-homeassistant-maxit")
+                    installed_plugins_cache = {"os-homeassistant-maxit"} if installed else set()
+                    installed_plugins_updated_at = now
+                    installed_plugins_refresh_succeeded = True
+                    return
+                if get_installed_plugins is not None:
+                    payload = await get_installed_plugins()
+                elif get_firmware_info is not None:
+                    payload = await get_firmware_info()
+                elif safe_dict_get is not None:
+                    payload = await safe_dict_get("/api/core/firmware/info")
+
+                installed_plugins = _installed_plugins_from_payload(payload)
+                if installed_plugins is None:
+                    installed_plugins_refresh_succeeded = False
+                    return
+
+                installed_plugins_cache = installed_plugins
+                installed_plugins_updated_at = now
+                installed_plugins_refresh_succeeded = True
+
+            await _refresh_installed_plugins()
+            return "os-homeassistant-maxit" in (installed_plugins_cache or set())
 
         setattr(client, "is_plugin_installed", _is_plugin_installed)
         _LOGGER.debug("Applied aiopnsense plugin compatibility shim for is_plugin_installed()")

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -145,6 +145,84 @@ async def test_add_plugin_compat_uses_firmware_info_when_plugin_helpers_missing(
 
 
 @pytest.mark.asyncio
+async def test_add_plugin_compat_caches_safe_dict_firmware_info() -> None:
+    """Plugin compatibility shim should cache firmware-info package lookups."""
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with firmware-info fallback response."""
+            self._safe_dict_get = AsyncMock(
+                return_value={
+                    "package": [
+                        {"name": "os-vnstat", "installed": "1"},
+                        {"name": "os-homeassistant-maxit", "installed": "1"},
+                    ]
+                }
+            )
+
+    client = _Client()
+    patched: Any = factory_mod._add_plugin_compat(client)
+    assert await patched.is_plugin_installed() is True
+    assert await patched.is_plugin_installed() is True
+    client._safe_dict_get.assert_awaited_once_with("/api/core/firmware/info")
+
+
+@pytest.mark.asyncio
+async def test_add_plugin_compat_caches_absent_plugin_from_firmware_info() -> None:
+    """Plugin compatibility shim should cache successful negative firmware-info lookups."""
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with firmware-info payload that lacks plugin."""
+            self._safe_dict_get = AsyncMock(
+                return_value={"package": [{"name": "os-vnstat", "installed": "1"}]}
+            )
+
+    client = _Client()
+    patched: Any = factory_mod._add_plugin_compat(client)
+    assert await patched.is_plugin_installed() is False
+    assert await patched.is_plugin_installed() is False
+    client._safe_dict_get.assert_awaited_once_with("/api/core/firmware/info")
+
+
+@pytest.mark.asyncio
+async def test_add_plugin_compat_caches_empty_direct_key_payload() -> None:
+    """Plugin compatibility shim should cache direct-key payloads without target plugin."""
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with direct-key firmware payload."""
+            self._safe_dict_get = AsyncMock(return_value={"os-vnstat": "1"})
+
+    client = _Client()
+    patched: Any = factory_mod._add_plugin_compat(client)
+    assert await patched.is_plugin_installed() is False
+    assert await patched.is_plugin_installed() is False
+    client._safe_dict_get.assert_awaited_once_with("/api/core/firmware/info")
+
+
+@pytest.mark.asyncio
+async def test_add_plugin_compat_retries_invalid_firmware_info_payload() -> None:
+    """Plugin compatibility shim should not cache invalid firmware-info payloads."""
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with invalid then valid firmware-info payloads."""
+            self._safe_dict_get = AsyncMock(
+                side_effect=[
+                    None,
+                    {"package": [{"name": "os-homeassistant-maxit", "installed": "1"}]},
+                ]
+            )
+
+    client = _Client()
+    patched: Any = factory_mod._add_plugin_compat(client)
+    assert await patched.is_plugin_installed() is False
+    assert await patched.is_plugin_installed() is True
+    assert client._safe_dict_get.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_add_plugin_compat_defaults_to_false_without_helpers() -> None:
     """Plugin compatibility shim should return False when no plugin helpers exist."""
 


### PR DESCRIPTION
This pull request improves the plugin detection logic and caching strategy in the OPNsense client compatibility shim, making the detection of the `os-homeassistant-maxit` plugin more robust and efficient. It also introduces comprehensive test coverage for the new caching behavior and edge cases.

**Enhancements to plugin detection and caching:**

* Refactored the internal logic for detecting installed plugins by extracting plugin names from various backend payloads, supporting more payload formats and improving reliability.
* Introduced a caching mechanism for the set of installed plugins, including cache freshness checks based on a configurable TTL, to avoid redundant backend calls and improve performance. [[1]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64R173-R182) [[2]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64L180-R275)
* Added new logic to ensure that only valid plugin payloads are cached, and retries are performed when payloads are invalid or inconclusive.

**Testing improvements:**

* Added tests to verify that plugin detection results are cached correctly for both positive (plugin present) and negative (plugin absent) cases, and that invalid payloads are not cached and are retried.

**Other changes:**

* Added missing import for `datetime` to support the new caching logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Plugin detection now uses a time‑based cache with smarter refresh and retry behavior, reducing backend queries and improving responsiveness while avoiding caching invalid responses.

* **Tests**
  * Added tests covering caching scenarios, payload variations, negative-result handling, and retry behavior to ensure reliable plugin detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->