### PR TITLE
Update update_aiopnsense_manifest.yml

### DIFF
--- a/.github/workflows/update_aiopnsense_manifest.yml
+++ b/.github/workflows/update_aiopnsense_manifest.yml
@@ -239,4 +239,60 @@ jobs:
 
       - name: Log when no update is required
         if: steps.versions.outputs.update_needed != 'true'
-        run: echo "aiopnsense is already at the latest version; no update PR created."
+        run: echo "aiopnsense is already at the latest version; checking for stale update PRs."
+
+      - name: Close stale aiopnsense update PRs
+        if: steps.versions.outputs.update_needed != 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const branch = "chore/update-aiopnsense-manifest";
+            const labelName = "aiopnsense-auto-update";
+
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+
+            const stalePulls = pulls.filter(
+              (pr) =>
+                pr.head.ref === branch &&
+                pr.labels.some((label) => label.name === labelName),
+            );
+
+            if (stalePulls.length === 0) {
+              core.info(
+                `No open ${labelName} PRs found for branch ${branch}.`,
+              );
+            } else {
+              for (const pr of stalePulls) {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: "closed",
+                });
+
+                core.info(`Closed stale aiopnsense update PR #${pr.number}.`);
+              }
+            }
+
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branch}`,
+              });
+              core.info(`Deleted stale branch ${branch}.`);
+            } catch (error) {
+              const status = error.status ?? error.response?.status;
+
+              if (status === 404) {
+                core.info(`Branch ${branch} was already deleted.`);
+                return;
+              }
+
+              throw error;
+            }


### PR DESCRIPTION
This pull request improves the automation for handling aiopnsense update pull requests in the GitHub Actions workflow. Now, when no update is needed, the workflow will automatically close any stale aiopnsense update PRs and delete the associated branch if it exists.

**Enhancements to PR and branch cleanup automation:**

* Added a new step to the `.github/workflows/update_aiopnsense_manifest.yml` workflow that, when no update is required, searches for open pull requests from the `chore/update-aiopnsense-manifest` branch with the `aiopnsense-auto-update` label, closes them if found, and deletes the branch if it exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now detects and logs when checking for stale update pull requests.
  * Automatically closes stale update pull requests that match the designated branch and label.
  * Attempts to remove associated branches after closing stale PRs, treating missing branches as non-fatal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->