### PR TITLE
Fix aiopnsense snake_case issue

### DIFF
--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -113,6 +113,12 @@ def _coerce_query_counts(count_value: Any) -> tuple[int, int]:
 def _callable_accepts_parameter(method: Callable[..., Any], parameter_name: str) -> bool:
     """Report whether a callable accepts the named keyword argument.
 
+    Uses `inspect.signature` first, then falls back to direct `__code__` attribute
+    inspection when signature introspection is unavailable (e.g. for certain
+    Python 3.14+ coroutine patterns).  Returns `False` when neither approach can
+    determine the callable's parameter list, so callers apply a compatibility
+    wrapper rather than risk an unexpected-keyword-argument error at runtime.
+
     Args:
         method: Callable to inspect for keyword compatibility.
         parameter_name: Keyword parameter name to check.
@@ -122,15 +128,59 @@ def _callable_accepts_parameter(method: Callable[..., Any], parameter_name: str)
     """
     try:
         signature = inspect.signature(method)
+
+        if parameter_name in signature.parameters:
+            return (
+                signature.parameters[parameter_name].kind is not inspect.Parameter.POSITIONAL_ONLY
+            )
+        return any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        )
     except TypeError, ValueError:
-        return True
+        pass
 
-    if parameter_name in signature.parameters:
-        return True
+    # Fallback: inspect the underlying code object directly.  This avoids
+    # annotation-evaluation issues that can cause inspect.signature() to raise
+    # in Python 3.14+ with certain coroutine or mixin patterns.
+    try:
+        func: Any = getattr(method, "__func__", method)
+        while hasattr(func, "__wrapped__"):
+            func = func.__wrapped__
+        code = func.__code__
+        nparams: int = code.co_argcount + code.co_kwonlyargcount
+        if parameter_name in code.co_varnames[code.co_posonlyargcount : nparams]:
+            return True
+        return bool(code.co_flags & inspect.CO_VARKEYWORDS)
+    except AttributeError:
+        pass
 
-    return any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD
-        for parameter in signature.parameters.values()
+    # Cannot determine the signature; conservatively assume the parameter is
+    # absent so the caller wraps the method instead of risking a TypeError.
+    return False
+
+
+def _type_error_is_unexpected_parameter(err: TypeError, parameter_name: str) -> bool:
+    """Report whether a TypeError was raised by keyword argument binding.
+
+    Args:
+        err: TypeError raised while attempting a compatibility call.
+        parameter_name: Keyword parameter name that was passed.
+
+    Returns:
+        bool: `True` when the error indicates the callable rejected the keyword.
+    """
+    if err.__traceback__ is None or err.__traceback__.tb_next is not None:
+        return False
+
+    message = str(err)
+    return (
+        ("unexpected keyword argument" in message and parameter_name in message)
+        or (
+            "positional-only arguments passed as keyword arguments" in message
+            and parameter_name in message
+        )
+        or "takes no keyword arguments" in message
     )
 
 
@@ -343,13 +393,17 @@ def _add_core_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol:
     elif not _callable_accepts_parameter(set_use_snake_case, "initial"):
 
         async def _set_use_snake_case_with_initial(initial: bool = False) -> None:
-            """Call a backend naming-mode setter that does not accept `initial`.
+            """Call a backend naming-mode setter with compatibility fallback.
 
             Args:
                 initial: Whether the call occurs during initial setup.
             """
-            _ = initial
-            await set_use_snake_case()
+            try:
+                await set_use_snake_case(initial=initial)
+            except TypeError as err:
+                if not _type_error_is_unexpected_parameter(err, "initial"):
+                    raise
+                await set_use_snake_case()
 
         setattr(client, "set_use_snake_case", _set_use_snake_case_with_initial)
         _LOGGER.debug(

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Mapping, MutableMapping
 from datetime import datetime
 from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version as package_version
+import inspect
 import logging
 from typing import Any
 
@@ -107,6 +108,30 @@ def _coerce_query_counts(count_value: Any) -> tuple[int, int]:
         except TypeError, ValueError:
             return (0, 0)
     return (0, 0)
+
+
+def _callable_accepts_parameter(method: Callable[..., Any], parameter_name: str) -> bool:
+    """Report whether a callable accepts the named keyword argument.
+
+    Args:
+        method: Callable to inspect for keyword compatibility.
+        parameter_name: Keyword parameter name to check.
+
+    Returns:
+        bool: `True` when `method` accepts the parameter or arbitrary keyword arguments.
+    """
+    try:
+        signature = inspect.signature(method)
+    except TypeError, ValueError:
+        return True
+
+    if parameter_name in signature.parameters:
+        return True
+
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
 
 
 def _add_query_count_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol:
@@ -302,7 +327,8 @@ def _add_core_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol:
     Returns:
         OPNsenseClientProtocol: The same client instance with required core compatibility shims.
     """
-    if not hasattr(client, "set_use_snake_case"):
+    set_use_snake_case: Callable[..., Any] | None = getattr(client, "set_use_snake_case", None)
+    if set_use_snake_case is None:
 
         async def _set_use_snake_case(initial: bool = False) -> None:
             """Provide a no-op naming-mode setter for backends without support.
@@ -314,6 +340,21 @@ def _add_core_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol:
 
         setattr(client, "set_use_snake_case", _set_use_snake_case)
         _LOGGER.debug("Applied aiopnsense core compatibility shim for set_use_snake_case()")
+    elif not _callable_accepts_parameter(set_use_snake_case, "initial"):
+
+        async def _set_use_snake_case_with_initial(initial: bool = False) -> None:
+            """Call a backend naming-mode setter that does not accept `initial`.
+
+            Args:
+                initial: Whether the call occurs during initial setup.
+            """
+            _ = initial
+            await set_use_snake_case()
+
+        setattr(client, "set_use_snake_case", _set_use_snake_case_with_initial)
+        _LOGGER.debug(
+            "Applied aiopnsense core compatibility wrapper for set_use_snake_case(initial=...)"
+        )
 
     if not hasattr(client, "reset_query_counts"):
 

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -269,6 +269,26 @@ async def test_add_core_compat_noop_when_core_methods_exist() -> None:
 
 
 @pytest.mark.asyncio
+async def test_add_core_compat_wraps_set_use_snake_case_without_initial() -> None:
+    """Core compatibility shim should normalize legacy naming-mode signatures."""
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize call tracking for the fake client."""
+            self.set_use_snake_case_calls = 0
+
+        async def set_use_snake_case(self) -> None:
+            """Accept naming-mode calls without the `initial` keyword."""
+            self.set_use_snake_case_calls += 1
+
+    client = _Client()
+    patched: Any = factory_mod._add_core_compat(client)
+    await patched.set_use_snake_case(initial=True)
+    await patched.set_use_snake_case()
+    assert client.set_use_snake_case_calls == 2
+
+
+@pytest.mark.asyncio
 async def test_add_core_compat_defaults_when_core_methods_missing() -> None:
     """Core compatibility shim should attach defaults when methods are missing."""
 

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect as _inspect
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
@@ -289,6 +290,76 @@ async def test_add_core_compat_wraps_set_use_snake_case_without_initial() -> Non
 
 
 @pytest.mark.asyncio
+async def test_add_core_compat_wrapper_passes_initial_when_introspection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Core compatibility wrapper should probe with initial before falling back."""
+
+    class _SetUseSnakeCase:
+        def __init__(self) -> None:
+            """Initialize received argument tracking."""
+            self.received_initial: bool | None = None
+
+        async def __call__(self, initial: bool = False) -> None:
+            """Accept initial even though direct introspection is unavailable.
+
+            Args:
+                initial: Initial-setup flag passed by the compatibility wrapper.
+            """
+            self.received_initial = initial
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with callable instance method."""
+            self.set_use_snake_case = _SetUseSnakeCase()
+
+    def _broken_signature(callable_obj: Any, **kwargs: Any) -> Any:
+        raise ValueError("simulated failure")
+
+    monkeypatch.setattr(_inspect, "signature", _broken_signature)
+
+    client = _Client()
+    original_setter = client.set_use_snake_case
+    patched: Any = factory_mod._add_core_compat(client)
+    await patched.set_use_snake_case(initial=True)
+    assert original_setter.received_initial is True
+
+
+@pytest.mark.asyncio
+async def test_add_core_compat_wrapper_reraises_internal_type_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Core compatibility wrapper should not hide TypeError raised inside backend methods."""
+
+    class _SetUseSnakeCase:
+        async def __call__(self, initial: bool = False) -> None:
+            """Raise an internal TypeError after accepting initial.
+
+            Args:
+                initial: Initial-setup flag passed by the compatibility wrapper.
+
+            Raises:
+                TypeError: Always raised to simulate a backend implementation error.
+            """
+            _ = initial
+            raise TypeError("got an unexpected keyword argument 'initial'")
+
+    class _Client:
+        def __init__(self) -> None:
+            """Initialize fake client with callable instance method."""
+            self.set_use_snake_case = _SetUseSnakeCase()
+
+    def _broken_signature(callable_obj: Any, **kwargs: Any) -> Any:
+        raise ValueError("simulated failure")
+
+    monkeypatch.setattr(_inspect, "signature", _broken_signature)
+
+    patched: Any = factory_mod._add_core_compat(_Client())
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await patched.set_use_snake_case(initial=True)
+
+
+@pytest.mark.asyncio
 async def test_add_core_compat_defaults_when_core_methods_missing() -> None:
     """Core compatibility shim should attach defaults when methods are missing."""
 
@@ -300,6 +371,54 @@ async def test_add_core_compat_defaults_when_core_methods_missing() -> None:
     await patched.set_use_snake_case(initial=True)
     await patched.reset_query_counts()
     assert await patched.get_query_counts() == (0, 0)
+
+
+def test_callable_accepts_parameter_via_code_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_callable_accepts_parameter should fall back to __code__ when inspect.signature raises."""
+
+    async def _no_initial(self: Any) -> None:
+        """Fake method without initial."""
+
+    async def _with_initial(self: Any, initial: bool = False) -> None:
+        """Fake method with initial."""
+
+    def _broken_signature(callable_obj: Any, **kwargs: Any) -> Any:
+        raise ValueError("simulated signature failure")
+
+    monkeypatch.setattr(_inspect, "signature", _broken_signature)
+    assert not factory_mod._callable_accepts_parameter(_no_initial, "initial")
+    assert factory_mod._callable_accepts_parameter(_with_initial, "initial")
+
+
+def test_callable_accepts_parameter_rejects_positional_only() -> None:
+    """_callable_accepts_parameter should reject positional-only parameters as keywords."""
+
+    async def _positional_only_initial(initial: bool = False, /) -> None:
+        """Fake method with positional-only initial.
+
+        Args:
+            initial: Positional-only setup flag.
+        """
+
+    assert not factory_mod._callable_accepts_parameter(_positional_only_initial, "initial")
+
+
+def test_callable_accepts_parameter_returns_false_when_all_inspection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_callable_accepts_parameter should return False when all inspection paths fail."""
+
+    # An object that has no __code__ attribute and raises from inspect.signature
+    class _NoCode:
+        def __call__(self) -> None:
+            """Callable without __code__."""
+
+    def _broken_signature(callable_obj: Any, **kwargs: Any) -> Any:
+        raise ValueError("simulated failure")
+
+    monkeypatch.setattr(_inspect, "signature", _broken_signature)
+    result = factory_mod._callable_accepts_parameter(_NoCode(), "initial")
+    assert result is False
 
 
 def test_add_query_count_compat_noop_without_query_methods() -> None:


### PR DESCRIPTION
This pull request enhances the compatibility logic for the `set_use_snake_case` method in the OPNsense client factory, ensuring that clients with different method signatures are handled gracefully. It introduces a utility to detect if a method accepts a specific keyword argument and applies the appropriate compatibility shim. Unit tests are added to verify this behavior.

**Compatibility improvements for client method signatures:**

* Added a new utility function `_callable_accepts_parameter` using the `inspect` module to determine if a callable accepts a specific keyword argument, or arbitrary keyword arguments, improving method signature introspection. [[1]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64R10) [[2]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64R113-R136)
* Updated `_add_core_compat` to use `_callable_accepts_parameter` for checking if `set_use_snake_case` supports the `initial` parameter, and to apply a compatibility wrapper if it does not, ensuring consistent method signatures across client implementations. [[1]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64L305-R331) [[2]](diffhunk://#diff-7c9b674180a19adb849c3d0e6b452ef4bfb5274bea60c398ed093857172f1f64R343-R357)

**Testing enhancements:**

* Added a new async test, `test_add_core_compat_wraps_set_use_snake_case_without_initial`, to verify that the compatibility shim correctly wraps legacy `set_use_snake_case` methods that do not accept the `initial` parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older client implementations by normalizing method behavior so calls with newer parameters work consistently, even if the underlying implementation lacks those parameters.

* **Tests**
  * Added unit tests covering the compatibility wrapper and the parameter-detection behavior to ensure both legacy and modern clients are handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->