### PR TITLE
Add interface enabled state entities

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -139,7 +139,7 @@ class OPNsenseInterfaceEnabledBinarySensor(OPNsenseBinarySensor):
 
         interface_name = key_parts[1]
         interface = dict_get(state, f"interfaces.{interface_name}", {})
-        if not isinstance(interface, Mapping) or "enabled" not in interface:
+        if not isinstance(interface, Mapping) or interface.get("enabled") is None:
             self._available = False
             self.async_write_ha_state()
             return

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -13,12 +13,53 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_SYNC_NOTICES, COORDINATOR, DEFAULT_SYNC_OPTION_VALUE
+from .const import CONF_SYNC_INTERFACES, CONF_SYNC_NOTICES, COORDINATOR, DEFAULT_SYNC_OPTION_VALUE
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
-from .helpers import dict_get
+from .helpers import coerce_bool, dict_get
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+async def _compile_interface_enabled_binary_sensors(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+) -> list:
+    """Compile per-interface enabled-state binary sensors.
+
+    Args:
+        config_entry: Config entry being set up.
+        coordinator: Data update coordinator that caches OPNsense state.
+
+    Returns:
+        list: Interface enabled binary sensor entities.
+    """
+    state: dict[str, Any] = coordinator.data
+    if not isinstance(state, MutableMapping):
+        return []
+
+    interfaces = state.get("interfaces")
+    if not isinstance(interfaces, Mapping):
+        return []
+
+    entities: list = []
+    for interface_name, interface in interfaces.items():
+        if not isinstance(interface_name, str) or not isinstance(interface, Mapping):
+            continue
+
+        entities.append(
+            OPNsenseInterfaceEnabledBinarySensor(
+                config_entry=config_entry,
+                coordinator=coordinator,
+                entity_description=BinarySensorEntityDescription(
+                    key=f"interface.{interface_name}.enabled",
+                    name=f"Interface {interface.get('name', interface_name)} Enabled",
+                    icon="mdi:network",
+                    entity_registry_enabled_default=False,
+                ),
+            )
+        )
+    return entities
 
 
 async def async_setup_entry(
@@ -32,6 +73,8 @@ async def async_setup_entry(
     config: Mapping[str, Any] = config_entry.data
 
     entities: list = []
+    if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
+        entities.extend(await _compile_interface_enabled_binary_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_NOTICES, DEFAULT_SYNC_OPTION_VALUE):
         entities.append(
             OPNsensePendingNoticesPresentBinarySensor(
@@ -74,6 +117,40 @@ class OPNsenseBinarySensor(OPNsenseEntity, BinarySensorEntity):
         )
         self.entity_description: BinarySensorEntityDescription = entity_description
         self._attr_is_on: bool = False
+
+
+class OPNsenseInterfaceEnabledBinarySensor(OPNsenseBinarySensor):
+    """OPNsense binary sensor for interface enabled state."""
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator update."""
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        key_parts = self.entity_description.key.split(".")
+        if len(key_parts) != 3 or key_parts[0] != "interface" or key_parts[2] != "enabled":
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        interface_name = key_parts[1]
+        interface = dict_get(state, f"interfaces.{interface_name}", {})
+        if not isinstance(interface, Mapping) or "enabled" not in interface:
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._available = True
+        self._attr_is_on = coerce_bool(interface.get("enabled"))
+        self._attr_extra_state_attributes = {}
+        for attr in ("interface", "device", "ipv4", "ipv6", "mac"):
+            if attr in interface and (interface[attr] or isinstance(interface[attr], bool)):
+                self._attr_extra_state_attributes[attr] = interface[attr]
+        self.async_write_ha_state()
 
 
 class OPNsensePendingNoticesPresentBinarySensor(OPNsenseBinarySensor):

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1151,8 +1151,13 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
         else:
             properties = ["interface", "device", "ipv4", "ipv6"]
         for attr in properties:
-            if interface.get(attr, None):
+            if attr in interface and (interface[attr] or isinstance(interface[attr], bool)):
                 self._attr_extra_state_attributes[attr] = interface[attr]
+        if interface.get("enabled") is not None and not coerce_bool(interface.get("enabled")):
+            self._attr_native_value = None
+            self._available = False
+            self.async_write_ha_state()
+            return
         self.async_write_ha_state()
 
     @property

--- a/tests/pyopnsense/test_pyopnsense.py
+++ b/tests/pyopnsense/test_pyopnsense.py
@@ -14,6 +14,7 @@ from custom_components.opnsense import (
     switch as switch_mod,
 )
 from custom_components.opnsense.const import CONF_SYNC_FIREWALL_AND_NAT
+from tests.utilities import stub_async_write_ha_state
 
 
 @pytest.mark.asyncio
@@ -260,7 +261,7 @@ async def test_scanner_entity_handle_coordinator_update_missing_state_sets_unava
     )
     # ensure async_write_ha_state won't raise due to missing hass during unit test
     ent.hass = MagicMock()
-    ent.async_write_ha_state = MagicMock()
+    stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()
     assert ent._available is False
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -9,10 +9,16 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.opnsense.binary_sensor import (
+    OPNsenseInterfaceEnabledBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
     async_setup_entry,
 )
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, CONF_SYNC_NOTICES, COORDINATOR
+from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_SYNC_INTERFACES,
+    CONF_SYNC_NOTICES,
+    COORDINATOR,
+)
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 
@@ -84,6 +90,68 @@ async def test_async_setup_entry_creates_only_notices_when_notices_enabled(make_
     # expect one Notices entity created
     assert len(created) == 1
     assert isinstance(created[0], OPNsensePendingNoticesPresentBinarySensor)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_disabled_interface_enabled_sensors(make_config_entry):
+    """Create disabled-by-default enabled-state binary sensors for interfaces."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: True,
+            CONF_SYNC_NOTICES: False,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "interfaces": {
+            "wan": {"name": "WAN", "enabled": False},
+            "lan": {"name": "LAN", "enabled": True},
+        }
+    }
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    created: list = []
+
+    def add_entities(ents):
+        """Add entities.
+
+        Args:
+            ents: Ents provided by pytest or the test case.
+        """
+        created.extend(ents)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+
+    assert len(created) == 2
+    assert all(isinstance(entity, OPNsenseInterfaceEnabledBinarySensor) for entity in created)
+    assert {entity.entity_description.key for entity in created} == {
+        "interface.wan.enabled",
+        "interface.lan.enabled",
+    }
+    assert all(
+        entity.entity_description.entity_registry_enabled_default is False for entity in created
+    )
+
+
+def test_interface_enabled_binary_sensor_state(make_config_entry):
+    """Interface enabled binary sensor should expose the interface enabled state."""
+    entry = make_config_entry()
+    desc = BinarySensorEntityDescription(key="interface.wan.enabled", name="Interface WAN Enabled")
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"interfaces": {"wan": {"name": "WAN", "enabled": False}}}
+    sensor = OPNsenseInterfaceEnabledBinarySensor(
+        config_entry=entry, coordinator=coord, entity_description=desc
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "binary_sensor.wan_enabled"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.is_on is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -11,6 +11,7 @@ import pytest
 from custom_components.opnsense.binary_sensor import (
     OPNsenseInterfaceEnabledBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
+    _compile_interface_enabled_binary_sensors,
     async_setup_entry,
 )
 from custom_components.opnsense.const import (
@@ -21,6 +22,7 @@ from custom_components.opnsense.const import (
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from homeassistant.components.binary_sensor import BinarySensorEntityDescription
+from tests.utilities import stub_async_write_ha_state
 
 
 @pytest.mark.asyncio
@@ -134,6 +136,70 @@ async def test_async_setup_entry_creates_disabled_interface_enabled_sensors(make
     )
 
 
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_interfaces_when_interface_sync_disabled(make_config_entry):
+    """Skip interface enabled binary sensors when interface sync is disabled."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_NOTICES: True,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"interfaces": {"wan": {"name": "WAN", "enabled": True}}}
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    created: list = []
+
+    def add_entities(ents):
+        """Add entities.
+
+        Args:
+            ents: Ents provided by pytest or the test case.
+        """
+        created.extend(ents)
+
+    await async_setup_entry(MagicMock(), entry, add_entities)
+
+    assert len(created) == 1
+    assert isinstance(created[0], OPNsensePendingNoticesPresentBinarySensor)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("coord_data", [None, {"interfaces": []}])
+async def test_compile_interface_enabled_binary_sensors_skips_invalid_state(
+    coord_data, make_config_entry
+):
+    """Skip compiling interface enabled sensors from invalid coordinator state."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id"})
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+
+    assert await _compile_interface_enabled_binary_sensors(entry, coord) == []
+
+
+@pytest.mark.asyncio
+async def test_compile_interface_enabled_binary_sensors_skips_malformed_interfaces(
+    make_config_entry,
+):
+    """Skip malformed interfaces while compiling valid interface enabled sensors."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id"})
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "interfaces": {
+            1: {"name": "bad"},
+            "missing": [],
+            "wan": {"name": "WAN", "enabled": True},
+        }
+    }
+
+    entities = await _compile_interface_enabled_binary_sensors(entry, coord)
+
+    assert len(entities) == 1
+    assert entities[0].entity_description.key == "interface.wan.enabled"
+
+
 def test_interface_enabled_binary_sensor_state(make_config_entry):
     """Interface enabled binary sensor should expose the interface enabled state."""
     entry = make_config_entry()
@@ -146,7 +212,7 @@ def test_interface_enabled_binary_sensor_state(make_config_entry):
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "binary_sensor.wan_enabled"
-    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    stub_async_write_ha_state(sensor)
 
     sensor._handle_coordinator_update()
 
@@ -166,7 +232,7 @@ def test_interface_enabled_binary_sensor_unavailable_when_enabled_unknown(make_c
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "binary_sensor.wan_enabled"
-    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+    stub_async_write_ha_state(sensor)
 
     sensor._handle_coordinator_update()
 
@@ -174,9 +240,78 @@ def test_interface_enabled_binary_sensor_unavailable_when_enabled_unknown(make_c
 
 
 @pytest.mark.parametrize(
+    ("desc_key", "coord_data"),
+    [
+        ("bad.key", {"interfaces": {"wan": {"enabled": True}}}),
+        ("interface.wan.enabled", None),
+        ("interface.wan.enabled", {"interfaces": {"wan": {}}}),
+        ("interface.wan.enabled", {"interfaces": {"wan": []}}),
+    ],
+)
+def test_interface_enabled_binary_sensor_unavailable_for_invalid_payloads(
+    desc_key, coord_data, make_config_entry
+):
+    """Mark interface enabled binary sensor unavailable for invalid payloads."""
+    entry = make_config_entry()
+    desc = BinarySensorEntityDescription(key=desc_key, name="Interface WAN Enabled")
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+    sensor = OPNsenseInterfaceEnabledBinarySensor(
+        config_entry=entry, coordinator=coord, entity_description=desc
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "binary_sensor.wan_enabled"
+    stub_async_write_ha_state(sensor)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_interface_enabled_binary_sensor_extra_attributes(make_config_entry):
+    """Interface enabled binary sensor should expose useful interface attributes."""
+    entry = make_config_entry()
+    desc = BinarySensorEntityDescription(key="interface.wan.enabled", name="Interface WAN Enabled")
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {
+        "interfaces": {
+            "wan": {
+                "enabled": True,
+                "interface": "wan",
+                "device": "igc0",
+                "ipv4": "192.0.2.1",
+                "ipv6": "",
+                "mac": "00:11:22:33:44:55",
+            }
+        }
+    }
+    sensor = OPNsenseInterfaceEnabledBinarySensor(
+        config_entry=entry, coordinator=coord, entity_description=desc
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "binary_sensor.wan_enabled"
+    stub_async_write_ha_state(sensor)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.is_on is True
+    assert sensor.extra_state_attributes == {
+        "interface": "wan",
+        "device": "igc0",
+        "ipv4": "192.0.2.1",
+        "mac": "00:11:22:33:44:55",
+    }
+
+
+@pytest.mark.parametrize(
     "coord_data,expect_write_called,expect_available,expect_is_on,expect_pending",
     [
         (None, True, False, None, None),
+        ({"notices": {}}, True, False, None, None),
+        ({"notices": None}, True, False, None, None),
         (
             {"notices": {"pending_notices_present": True, "pending_notices": [{"id": 1}]}},
             True,
@@ -215,17 +350,10 @@ def test_pending_notices_sensor_update_paths_param(
     )
     s.hass = MagicMock()
     s.entity_id = "binary_sensor.notices"
-
-    write_called = {"val": False}
-
-    def write():
-        """Write."""
-        write_called["val"] = True
-
-    s.async_write_ha_state = write if expect_write_called else lambda: None
+    s.async_write_ha_state = MagicMock()
 
     s._handle_coordinator_update()
-    assert write_called["val"] is expect_write_called
+    assert s.async_write_ha_state.called is expect_write_called
     assert s.available is expect_available
     if expect_is_on is not None:
         assert s.is_on is expect_is_on

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -154,6 +154,25 @@ def test_interface_enabled_binary_sensor_state(make_config_entry):
     assert sensor.is_on is False
 
 
+def test_interface_enabled_binary_sensor_unavailable_when_enabled_unknown(make_config_entry):
+    """Interface enabled binary sensor should be unavailable when enabled state is unknown."""
+    entry = make_config_entry()
+    desc = BinarySensorEntityDescription(key="interface.wan.enabled", name="Interface WAN Enabled")
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"interfaces": {"wan": {"name": "WAN", "enabled": None}}}
+    sensor = OPNsenseInterfaceEnabledBinarySensor(
+        config_entry=entry, coordinator=coord, entity_description=desc
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "binary_sensor.wan_enabled"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
 @pytest.mark.parametrize(
     "coord_data,expect_write_called,expect_available,expect_is_on,expect_pending",
     [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -457,7 +457,7 @@ def test_carp_status_sensor_states_and_attributes(
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "sensor.carp_status"
-    sensor.async_write_ha_state = lambda: None
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
     sensor._handle_coordinator_update()
 
     assert sensor.available is True
@@ -501,7 +501,7 @@ def test_carp_status_sensor_normalizes_state_spacing_and_icon(make_config_entry)
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "sensor.carp_status_normalized"
-    sensor.async_write_ha_state = lambda: None
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
     sensor._handle_coordinator_update()
 
     assert sensor.available is True
@@ -617,7 +617,7 @@ def test_carp_interface_sensor_unavailable_for_malformed_key(make_config_entry) 
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "sensor.carp_malformed_key"
-    sensor.async_write_ha_state = lambda: None
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
     sensor._handle_coordinator_update()
 
     assert sensor.available is False
@@ -647,7 +647,7 @@ def test_carp_interface_sensor_disambiguates_same_subnet_by_interface(make_confi
     )
     sensor.hass = MagicMock()
     sensor.entity_id = "sensor.carp_disambiguated"
-    sensor.async_write_ha_state = lambda: None
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
     sensor._handle_coordinator_update()
 
     assert sensor.available is True
@@ -1101,7 +1101,7 @@ def test_static_cpu_zero_variants(
     sensor = OPNsenseStaticKeySensor(config_entry=entry, coordinator=coord, entity_description=desc)
     sensor.hass = MagicMock()
     sensor.entity_id = "sensor.cpu_total"
-    sensor.async_write_ha_state = lambda: None
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
     if previous is not None:
         sensor._previous_value = previous
 
@@ -1148,6 +1148,92 @@ def test_interface_status_icon_up(make_config_entry):
     s._handle_coordinator_update()
     # when native_value is 'up', icon should not be the down icon
     assert s.icon != "mdi:close-network-outline"
+
+
+def test_interface_status_preserves_false_enabled_attribute(make_config_entry):
+    """Interface status sensor should expose false enabled attributes."""
+    state = {
+        "interfaces": {"wan": {"name": "WAN", "status": "up", "enabled": False, "interface": "wan"}}
+    }
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    entry = make_config_entry()
+
+    desc = MagicMock()
+    desc.key = "interface.wan.status"
+    desc.name = "WAN Status"
+
+    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.wan_status"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+    assert sensor.extra_state_attributes["enabled"] is False
+
+
+def test_interface_sensor_unavailable_when_interface_disabled(make_config_entry):
+    """Interface sensors should be unavailable when the interface is disabled."""
+    state = {
+        "interfaces": {
+            "wan": {
+                "name": "WAN",
+                "status": "up",
+                "enabled": False,
+                "interface": "wan",
+                "inbytes": 2048,
+            }
+        }
+    }
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    entry = make_config_entry()
+
+    desc = MagicMock()
+    desc.key = "interface.wan.inbytes"
+    desc.name = "WAN In Bytes"
+
+    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.wan_inbytes"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+def test_interface_sensor_available_when_enabled_unknown(make_config_entry):
+    """Interface sensors should stay available when enabled state is unknown."""
+    state = {
+        "interfaces": {
+            "wan": {
+                "name": "WAN",
+                "status": "up",
+                "enabled": None,
+                "interface": "wan",
+            }
+        }
+    }
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = state
+    entry = make_config_entry()
+
+    desc = MagicMock()
+    desc.key = "interface.wan.status"
+    desc.name = "WAN Status"
+
+    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.wan_status"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is True
+    assert sensor.native_value == "up"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -46,6 +46,7 @@ from custom_components.opnsense.switch import (
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
+from tests.utilities import stub_async_write_ha_state
 
 
 def make_coord(data):
@@ -232,7 +233,7 @@ async def test_switch_toggle_variants(
     # prefer unique id if present, otherwise fall back to entity_description.key
     unique = getattr(ent, "_attr_unique_id", None)
     ent.entity_id = f"switch.{unique or ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # attach client with AsyncMock methods named per the compile target
     on_mock = AsyncMock(return_value=True)
@@ -586,7 +587,7 @@ async def test_unbound_and_vpn_variations(coordinator, ph_hass, make_config_entr
     unbound.hass = hass
     unbound.coordinator = make_coord(state)
     unbound.entity_id = f"switch.{unbound._attr_unique_id}"
-    unbound.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(unbound)
     unbound._client = MagicMock()
     unbound._client.enable_unbound_blocklist = AsyncMock(return_value=True)
     unbound._client.disable_unbound_blocklist = AsyncMock(return_value=True)
@@ -603,7 +604,7 @@ async def test_unbound_and_vpn_variations(coordinator, ph_hass, make_config_entr
         vpn.hass = hass
         vpn.coordinator = make_coord(state)
         vpn.entity_id = f"switch.{vpn.entity_description.key}"
-        vpn.async_write_ha_state = lambda: None
+        stub_async_write_ha_state(vpn)
         vpn._client = MagicMock()
         vpn._client.toggle_vpn_instance = AsyncMock(return_value=True)
         vpn._handle_coordinator_update()
@@ -703,7 +704,7 @@ async def test_vpn_turn_on_off_calls_client_and_sets_delay(
     ent.hass = ph_hass
     ent.coordinator = make_coord(coord.data)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # client toggles VPN instance
     ent._client = MagicMock()
@@ -747,7 +748,7 @@ async def test_compile_unbound_extended_and_toggle(coordinator, ph_hass, make_co
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id or ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # attach client with AsyncMock methods
     ent._client = MagicMock()
@@ -794,7 +795,7 @@ async def test_vpn_turn_on_off_noops_when_preconditions_fail(
     ent.hass = ph_hass
     ent.coordinator = make_coord(coord.data)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # client that would raise if called -- we assert it's not awaited
     ent._client = MagicMock()
@@ -847,7 +848,7 @@ async def test_vpn_async_turn_off_variations(
     ent.hass = ph_hass
     ent.coordinator = make_coord(coord.data)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # set initial state as on so turn_off proceeds
     ent._attr_is_on = True
@@ -915,7 +916,7 @@ async def test_filter_disabled_and_missing(coordinator, ph_hass, make_config_ent
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()
     assert ent.is_on is False
 
@@ -933,7 +934,7 @@ async def test_unbound_missing_sets_unavailable(coordinator, ph_hass, make_confi
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()
     assert ent.available is False
 
@@ -953,7 +954,7 @@ async def test_unbound_skips_update_when_delay_set(coordinator, ph_hass, make_co
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # set initial known state that should NOT be changed while delay flag is set
     ent._attr_is_on = False
@@ -1059,7 +1060,7 @@ async def test_delay_skips_update_parametrized(
     # entity id setup varies; prefer unique_id when present
     unique = getattr(ent, "_attr_unique_id", None)
     ent.entity_id = f"switch.{unique or getattr(ent, 'entity_description').key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # set initial known state that should NOT be changed while delay flag is set
     ent._attr_is_on = False
@@ -1134,7 +1135,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord(state)
             ent.entity_id = f"switch.{ent._attr_unique_id}"
-            ent.async_write_ha_state = lambda: None
+            stub_async_write_ha_state(ent)
 
             def _fake_get_rule_filter() -> int:
                 """Return a non-mapping value to exercise filter error handling."""
@@ -1153,7 +1154,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord({})
             ent.entity_id = "switch.nat"
-            ent.async_write_ha_state = lambda: None
+            stub_async_write_ha_state(ent)
 
             def _fake_get_rule_nat() -> MutableMapping[str, Any] | None:
                 """Return a non-mapping value to exercise NAT error handling."""
@@ -1172,7 +1173,7 @@ async def test_switch_handle_error_sets_unavailable(
             ent.hass = hass_local
             ent.coordinator = make_coord({})
             ent.entity_id = "switch.svc"
-            ent.async_write_ha_state = lambda: None
+            stub_async_write_ha_state(ent)
 
             def _fake_get_service() -> MutableMapping[str, Any] | None:
                 """Return a non-mapping value to exercise service error handling."""
@@ -1323,7 +1324,7 @@ async def test_vpn_toggle_parametrized(
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     # attach a client and set its toggle_vpn_instance to a simple AsyncMock
     # that returns the desired toggle_return value for the test case.
     ent._client = MagicMock()
@@ -1539,7 +1540,7 @@ async def test_vpn_servers_properties_and_toggle(coordinator, ph_hass, make_conf
     server_ent.hass = hass
     server_ent.coordinator = make_coord(state)
     server_ent.entity_id = f"switch.{server_ent.entity_description.key}"
-    server_ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(server_ent)
     server_ent._client = MagicMock()
     server_ent._client.toggle_vpn_instance = AsyncMock(return_value=True)
 
@@ -1578,7 +1579,7 @@ async def test_nat_handle_missing_rule_returns_none(coordinator, ph_hass, make_c
     ent.hass = hass
     ent.coordinator = make_coord({})
     ent.entity_id = "switch.missing"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     # calling _handle_coordinator_update should not raise
     ent._handle_coordinator_update()
     assert isinstance(ent.available, bool)
@@ -1597,7 +1598,7 @@ async def test_unbound_turn_on_off_failure_logs(coordinator, ph_hass, make_confi
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     # simulate client failure
     ent._client = MagicMock()
     ent._client.enable_unbound_blocklist = AsyncMock(return_value=False)
@@ -1647,7 +1648,7 @@ async def test_client_failure_does_not_set_on(
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     # Ensure service data is populated from coordinator so the turn method
     # exercises the client call path (otherwise _client won't be invoked).
     ent._handle_coordinator_update()
@@ -1693,7 +1694,7 @@ def test_vpn_handle_coordinator_update_state_not_mapping(coordinator, make_confi
     )
     # coordinator.data is None -> unavailable
     coordinator.data = None
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()
     assert ent.available is False
 
@@ -1719,7 +1720,7 @@ async def test_compile_vpn_wireguard_variations(coordinator, ph_hass, make_confi
         vpn.hass = hass
         vpn.coordinator = make_coord(state)
         vpn.entity_id = f"switch.{vpn.entity_description.key}"
-        vpn.async_write_ha_state = lambda: None
+        stub_async_write_ha_state(vpn)
         vpn._client = MagicMock()
         vpn._client.toggle_vpn_instance = AsyncMock(return_value=True)
         vpn._handle_coordinator_update()
@@ -1742,7 +1743,7 @@ def test_vpn_instance_non_mapping_sets_unavailable(coordinator, make_config_entr
         "openvpn": {"clients": {"c1": "not-a-dict"}},
         "wireguard": {"clients": {}, "servers": {}},
     }
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()
     assert ent.available is False
 
@@ -1760,7 +1761,7 @@ async def test_service_async_turn_on_off_failure(coordinator, ph_hass, make_conf
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     # simulate failure to start/stop
     ent._client = MagicMock()
     ent._client.start_service = AsyncMock(return_value=False)
@@ -1785,7 +1786,7 @@ async def test_vpn_toggle_failure_does_not_set_on(coordinator, ph_hass, make_con
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
     ent._client = MagicMock()
     ent._client.toggle_vpn_instance = AsyncMock(return_value=False)
     # attempt to turn on should not set is_on when client returns False
@@ -1906,7 +1907,7 @@ def test_filter_handle_exceptions_sets_unavailable(
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.coordinator = make_coord({})
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # prepare a mapping-like object whose get() raises the desired exception
     class BadGet(dict):
@@ -1948,7 +1949,7 @@ def test_nat_handle_exceptions_sets_unavailable(exc_type, coordinator, make_conf
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.coordinator = make_coord({})
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # create a mapping whose __contains__ raises the exception when checking 'disabled'
     class BadContains(dict):
@@ -1982,7 +1983,7 @@ def test_vpn_handle_exceptions_sets_unavailable(exc_type, coordinator, make_conf
     )
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # instance must be a MutableMapping so the code reaches the try/except block;
     # create a dict subclass that raises when __getitem__ is used for ['enabled']
@@ -2022,7 +2023,7 @@ def test_service_handle_exceptions_sets_unavailable(
     )
     ent.hass = MagicMock(spec=HomeAssistant)
     ent.entity_id = f"switch.{ent.entity_description.key}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # create an object that raises when __getitem__ is used (service[prop])
     class BadIndex(dict):
@@ -2055,7 +2056,7 @@ async def test_unbound_legacy_switch_toggle_failures(coordinator, ph_hass, make_
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # Mock client to return False (failure)
     ent._client = MagicMock()
@@ -2100,7 +2101,7 @@ async def test_unbound_extended_switch_toggle_failures(coordinator, ph_hass, mak
     ent.hass = hass
     ent.coordinator = make_coord(state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
-    ent.async_write_ha_state = lambda: None
+    stub_async_write_ha_state(ent)
 
     # Mock client to return False (failure)
     ent._client = MagicMock()

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -9,6 +9,15 @@ import aiohttp
 import pytest
 
 
+def stub_async_write_ha_state(entity: Any) -> None:
+    """Replace Home Assistant state writes with a no-op for unit-level entity tests.
+
+    Args:
+        entity: Entity instance under test.
+    """
+    object.__setattr__(entity, "async_write_ha_state", lambda: None)
+
+
 def patch_client_factory(monkeypatch: pytest.MonkeyPatch, module: Any, client_ctor: Any) -> None:
     """Patch `create_opnsense_client` with a deterministic async constructor.
 


### PR DESCRIPTION
## Summary
Adds disabled-by-default binary sensors for each interface's administrative enabled state, and makes existing interface sensors unavailable when OPNsense reports that the interface is disabled.

## What Changed
- Added per-interface enabled binary sensors keyed as `interface.<name>.enabled`.
- Preserved explicit false values in interface status attributes so `enabled: false` remains visible.
- Updated interface sensor availability so explicit disabled interfaces mark related interface entities unavailable.
- Added regression tests for disabled interface state, unknown enabled state compatibility, and binary sensor creation.

## Why
OPNsense reports link status separately from administrative enabled state. CARP setups can disable an interface while link status remains up, so exposing and honoring `enabled` gives Home Assistant users a reliable way to monitor administrative interface state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added binary sensors to monitor individual interface enabled/disabled states

* **Improvements**
  * More accurate sensor availability and status handling when interfaces report enabled/disabled
  * Improved population of sensor attributes for clearer interface metadata

* **Tests**
  * Added unit tests covering interface-enabled sensors and related sensor behaviors
  * Test utilities added to stub Home Assistant state writes for safer unit testing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/hass-opnsense/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->