### PR TITLE
Fix aiopnsense update workflow

### DIFF
--- a/.github/scripts/__init__.py
+++ b/.github/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub workflow helper scripts."""

--- a/.github/scripts/build_aiopnsense_release_notes.py
+++ b/.github/scripts/build_aiopnsense_release_notes.py
@@ -1,0 +1,300 @@
+"""Build the aiopnsense dependency update pull request body."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+import json
+import logging
+import os
+from pathlib import Path
+import re
+import sys
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+GITHUB_API_URL = "https://api.github.com"
+LOGGER = logging.getLogger(__name__)
+MENTION_RE = re.compile(r"@(?=[A-Za-z0-9-]+(?:/[A-Za-z0-9-]+)?)")
+MENTION_LINK_RE = re.compile(r"\[@([A-Za-z0-9-]+)\]\(https?://github\.com/[A-Za-z0-9-]+\)")
+CLOSING_KEYWORD_RE = re.compile(
+    r"\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+"
+    r"((?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#\d+)",
+    re.IGNORECASE,
+)
+PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
+
+
+def _version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a tolerant comparison key for release versions.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing common dotted release versions.
+    """
+    parts = re.findall(r"\d+|[A-Za-z]+", version.lstrip("vV"))
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return whether a version string appears to be a prerelease.
+
+    Args:
+        version: Version string to evaluate.
+
+    Returns:
+        True when the version has a common prerelease marker.
+    """
+    return PRERELEASE_RE.search(version) is not None
+
+
+def _stable_version(version: str) -> str:
+    """Return the stable base of a version string.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Stable release portion of the version.
+    """
+    match = PRERELEASE_RE.search(version)
+    return version[: match.start()].rstrip(".-_") if match else version
+
+
+def _sanitize_release_body(body: str) -> str:
+    """Return release text that is safe to embed in a generated PR body.
+
+    Args:
+        body: Release text from GitHub.
+
+    Returns:
+        Sanitized release text.
+    """
+    body = MENTION_LINK_RE.sub(r"\1", body)
+    body = MENTION_RE.sub("@<!-- -->", body)
+    return CLOSING_KEYWORD_RE.sub(
+        lambda match: f"{match.group(1)} {match.group(2).replace('#', r'\#')}",
+        body,
+    )
+
+
+def build_release_notes(
+    *,
+    releases: Sequence[Mapping[str, object]],
+    current_version: str,
+    latest_version: str,
+) -> str:
+    """Build sanitized release notes for the updated version range.
+
+    Args:
+        releases: GitHub releases from the aiopnsense repository.
+        current_version: Currently pinned aiopnsense version.
+        latest_version: Target aiopnsense version.
+
+    Returns:
+        Markdown release notes for matching stable releases.
+    """
+    current = current_version.removeprefix("v").removeprefix("V")
+    latest = latest_version.removeprefix("v").removeprefix("V")
+    current_is_prerelease = _is_prerelease(current)
+    current_stable = _stable_version(current)
+
+    selected: list[Mapping[str, object]] = []
+    for release in releases:
+        tag_name = release.get("tag_name")
+        if not isinstance(tag_name, str):
+            continue
+
+        tag_version = tag_name.removeprefix("v").removeprefix("V")
+        lower_bound = _version_key(tag_version) > _version_key(current_stable)
+        prerelease_repair = current_is_prerelease and _version_key(tag_version) == _version_key(
+            current_stable,
+        )
+        if (
+            not _is_prerelease(tag_version)
+            and (lower_bound or prerelease_repair)
+            and _version_key(tag_version) <= _version_key(latest)
+        ):
+            selected.append(release)
+
+    if not selected:
+        return "No matching GitHub release notes were found for this version range."
+
+    selected.sort(key=lambda release: _version_key(str(release["tag_name"])))
+    notes: list[str] = []
+    for release in selected:
+        tag_name = str(release["tag_name"])
+        title = _sanitize_release_body(str(release.get("name") or tag_name))
+        tag = _sanitize_release_body(tag_name)
+        html_url = str(release.get("html_url") or "")
+        raw_body = str(release.get("body") or "No release body provided.").strip()
+        body = _sanitize_release_body(raw_body)
+        notes.append("\n".join([f"### {title} ({tag})", html_url, "", body]))
+
+    return "\n\n---\n\n".join(notes)
+
+
+def write_pr_body(
+    *,
+    body_path: Path,
+    releases: Sequence[Mapping[str, object]],
+    current_version: str,
+    pyproject_current_version: str,
+    latest_version: str,
+) -> None:
+    """Write the generated aiopnsense update PR body.
+
+    Args:
+        body_path: Path to write the markdown body to.
+        releases: GitHub releases from the aiopnsense repository.
+        current_version: Currently pinned manifest version.
+        pyproject_current_version: Currently pinned pyproject version.
+        latest_version: Target aiopnsense version.
+    """
+    release_notes = build_release_notes(
+        releases=releases,
+        current_version=current_version,
+        latest_version=latest_version,
+    )
+    body_path.write_text(
+        "\n".join(
+            [
+                "Automated update of aiopnsense dependency pins.",
+                "",
+                f"- Previous manifest pinned version: `aiopnsense=={current_version}`",
+                f"- Previous pyproject pinned version: `aiopnsense=={pyproject_current_version}`",
+                f"- Updated pinned version: `aiopnsense=={latest_version}`",
+                "",
+                "## aiopnsense release notes in range",
+                release_notes,
+                "",
+            ],
+        ),
+    )
+
+
+def fetch_releases(*, owner: str, repo: str, token: str | None = None) -> list[dict[str, object]]:
+    """Fetch releases from the GitHub REST API.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        token: Optional GitHub token.
+
+    Returns:
+        List of GitHub release objects.
+    """
+    releases: list[dict[str, object]] = []
+    url: str | None = f"{GITHUB_API_URL}/repos/{owner}/{repo}/releases?per_page=100"
+    while url is not None:
+        request = Request(url, headers=_github_headers(token))  # noqa: S310
+        with urlopen(request, timeout=30) as response:  # noqa: S310
+            payload = json.load(response)
+            if not isinstance(payload, list):
+                raise TypeError(f"Expected a list of releases from {url}")
+            releases.extend(release for release in payload if isinstance(release, dict))
+            url = _next_link(response.headers.get("Link"))
+    return releases
+
+
+def _github_headers(token: str | None) -> dict[str, str]:
+    """Build GitHub API request headers.
+
+    Args:
+        token: Optional GitHub token.
+
+    Returns:
+        Request headers.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "hass-opnsense-update-aiopnsense",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _next_link(link_header: str | None) -> str | None:
+    """Return the next pagination URL from a GitHub Link header.
+
+    Args:
+        link_header: Raw Link header value.
+
+    Returns:
+        Next URL when present.
+    """
+    if not link_header:
+        return None
+    for link in link_header.split(","):
+        url_part, *params = link.split(";")
+        if any(param.strip() == 'rel="next"' for param in params):
+            return url_part.strip()[1:-1]
+    return None
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current-version", required=True)
+    parser.add_argument("--pyproject-current-version", required=True)
+    parser.add_argument("--latest-version", required=True)
+    parser.add_argument("--release-owner", required=True)
+    parser.add_argument("--release-repo", required=True)
+    parser.add_argument("--body-path", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build the update PR body file.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    try:
+        releases = fetch_releases(owner=args.release_owner, repo=args.release_repo, token=token)
+    except HTTPError as err:
+        LOGGER.error(
+            "Failed to fetch releases for %s/%s: %s",
+            args.release_owner,
+            args.release_repo,
+            err,
+        )
+        return 1
+    if not releases:
+        LOGGER.error(
+            "No releases found for %s/%s. Check workflow inputs or repository variables "
+            "(AIOPNSENSE_RELEASE_OWNER/AIOPNSENSE_RELEASE_REPO).",
+            args.release_owner,
+            args.release_repo,
+        )
+        return 1
+
+    write_pr_body(
+        body_path=args.body_path,
+        releases=releases,
+        current_version=args.current_version,
+        pyproject_current_version=args.pyproject_current_version,
+        latest_version=args.latest_version,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/build_aiopnsense_release_notes.py
+++ b/.github/scripts/build_aiopnsense_release_notes.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 import re
 import sys
-from urllib.error import HTTPError
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 GITHUB_API_URL = "https://api.github.com"
@@ -269,7 +269,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     token = os.environ.get("GITHUB_TOKEN")
     try:
         releases = fetch_releases(owner=args.release_owner, repo=args.release_repo, token=token)
-    except HTTPError as err:
+    except URLError as err:
         LOGGER.error(
             "Failed to fetch releases for %s/%s: %s",
             args.release_owner,

--- a/.github/scripts/cleanup_aiopnsense_update_branches.py
+++ b/.github/scripts/cleanup_aiopnsense_update_branches.py
@@ -1,0 +1,390 @@
+"""Clean up stale aiopnsense update pull requests and branches."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+import json
+import logging
+import os
+import sys
+from typing import Protocol
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+GITHUB_API_URL = "https://api.github.com"
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class CleanupResult:
+    """Result of cleaning workflow-owned pull requests and branches.
+
+    Attributes:
+        closed_prs: Pull request numbers closed as stale.
+        deleted_branches: Branch names deleted from the repository.
+    """
+
+    closed_prs: list[int] = field(default_factory=list)
+    deleted_branches: list[str] = field(default_factory=list)
+
+
+class GithubCleanupClient(Protocol):
+    """Protocol for GitHub operations needed by the cleanup routine."""
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """List pull requests by state."""
+
+    def close_pull(self, pull_number: int) -> None:
+        """Close a pull request by number."""
+
+    def delete_ref(self, ref: str) -> None:
+        """Delete a git ref by name."""
+
+
+class GithubClient:
+    """Small GitHub REST client for the workflow cleanup task."""
+
+    def __init__(self, *, repository: str, token: str) -> None:
+        """Initialize the client.
+
+        Args:
+            repository: Repository in ``owner/name`` format.
+            token: GitHub token for API calls.
+        """
+        self.repository = repository
+        self.token = token
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """List pull requests by state.
+
+        Args:
+            state: Pull request state to request.
+
+        Returns:
+            Pull request objects from GitHub.
+        """
+        pulls: list[dict[str, object]] = []
+        url: str | None = (
+            f"{GITHUB_API_URL}/repos/{self.repository}/pulls?state={state}&per_page=100"
+        )
+        while url is not None:
+            payload, link_header = self._request("GET", url)
+            if not isinstance(payload, list):
+                raise TypeError(f"Expected pull request list from {url}")
+            pulls.extend(pull for pull in payload if isinstance(pull, dict))
+            url = _next_link(link_header)
+        return pulls
+
+    def close_pull(self, pull_number: int) -> None:
+        """Close a pull request.
+
+        Args:
+            pull_number: Pull request number to close.
+        """
+        url = f"{GITHUB_API_URL}/repos/{self.repository}/pulls/{pull_number}"
+        self._request("PATCH", url, payload={"state": "closed"})
+
+    def delete_ref(self, ref: str) -> None:
+        """Delete a git ref if it exists.
+
+        Args:
+            ref: Ref path such as ``heads/branch-name``.
+        """
+        url = f"{GITHUB_API_URL}/repos/{self.repository}/git/refs/{ref}"
+        try:
+            self._request("DELETE", url)
+        except HTTPError as err:
+            if err.code == 404 or (err.code == 422 and _is_missing_ref_error(err)):
+                LOGGER.info("Ref %s was already deleted.", ref)
+                return
+            raise
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        payload: Mapping[str, object] | None = None,
+    ) -> tuple[object, str | None]:
+        """Send a GitHub REST request.
+
+        Args:
+            method: HTTP method.
+            url: Request URL.
+            payload: Optional JSON payload.
+
+        Returns:
+            Decoded payload and Link header.
+        """
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = Request(url, data=data, headers=_github_headers(self.token), method=method)  # noqa: S310
+        with urlopen(request, timeout=30) as response:  # noqa: S310
+            if response.status == 204:
+                return {}, response.headers.get("Link")
+            return json.load(response), response.headers.get("Link")
+
+
+def cleanup_update_branches(
+    *,
+    client: GithubCleanupClient,
+    repository: str,
+    branch: str,
+    branch_prefix: str,
+    label_name: str,
+    keep_pr_number: int | None,
+    close_stale_prs: bool,
+    delete_stale_branch: bool,
+    delete_merged_branches: bool,
+) -> CleanupResult:
+    """Clean workflow-owned stale pull requests and branches.
+
+    Args:
+        client: GitHub client with list, close, and delete methods.
+        repository: Repository in ``owner/name`` format.
+        branch: Current workflow update branch.
+        branch_prefix: Prefix for workflow-owned update branches.
+        label_name: Label identifying workflow-created PRs.
+        keep_pr_number: Optional PR number to preserve.
+        close_stale_prs: Whether to close open stale update PRs.
+        delete_stale_branch: Whether to delete the current stale branch.
+        delete_merged_branches: Whether to delete branches from merged update PRs.
+
+    Returns:
+        Summary of cleanup actions.
+    """
+    result = CleanupResult()
+    protected_branches: set[str] = set()
+
+    open_pulls = client.list_pulls(state="open")
+    for pull in open_pulls:
+        if not _is_workflow_pull(
+            pull,
+            repository=repository,
+            branch=branch,
+            branch_prefix=branch_prefix,
+            label_name=label_name,
+        ):
+            continue
+
+        pull_number = _pull_number(pull)
+        head_ref = _head_ref(pull)
+        if keep_pr_number is not None and pull_number == keep_pr_number:
+            protected_branches.add(head_ref)
+            continue
+
+        if close_stale_prs:
+            client.close_pull(pull_number)
+            result.closed_prs.append(pull_number)
+
+    branches_to_delete: set[str] = set()
+    if delete_stale_branch and branch not in protected_branches:
+        branches_to_delete.add(branch)
+
+    if delete_merged_branches:
+        closed_pulls = client.list_pulls(state="closed")
+        for pull in closed_pulls:
+            if pull.get("merged_at") is not None and _is_workflow_pull(
+                pull,
+                repository=repository,
+                branch=branch,
+                branch_prefix=branch_prefix,
+                label_name=label_name,
+            ):
+                branches_to_delete.add(_head_ref(pull))
+
+    branches_to_delete -= protected_branches
+    for branch_name in sorted(branches_to_delete):
+        client.delete_ref(f"heads/{branch_name}")
+        result.deleted_branches.append(branch_name)
+
+    return result
+
+
+def _is_workflow_pull(
+    pull: Mapping[str, object],
+    *,
+    repository: str,
+    branch: str,
+    branch_prefix: str,
+    label_name: str,
+) -> bool:
+    """Return whether a pull request belongs to this workflow.
+
+    Args:
+        pull: Pull request object.
+        repository: Repository in ``owner/name`` format.
+        branch: Current workflow update branch.
+        branch_prefix: Prefix for workflow-owned update branches.
+        label_name: Label identifying workflow-created PRs.
+
+    Returns:
+        True when the PR head branch is owned by this workflow.
+    """
+    labels = pull.get("labels", [])
+    if not isinstance(labels, list) or not any(
+        isinstance(label, dict) and label.get("name") == label_name for label in labels
+    ):
+        return False
+
+    head = pull.get("head", {})
+    if not isinstance(head, dict):
+        return False
+    head_ref = head.get("ref")
+    if not isinstance(head_ref, str):
+        return False
+    if head_ref != branch and not head_ref.startswith(branch_prefix):
+        return False
+
+    head_repo = head.get("repo", {})
+    if not isinstance(head_repo, dict):
+        return False
+    return head_repo.get("full_name") == repository
+
+
+def _head_ref(pull: Mapping[str, object]) -> str:
+    """Return a pull request head ref.
+
+    Args:
+        pull: Pull request object.
+
+    Returns:
+        Pull request head ref.
+    """
+    head = pull["head"]
+    if not isinstance(head, dict) or not isinstance(head.get("ref"), str):
+        raise TypeError("Pull request is missing a head ref")
+    return head["ref"]
+
+
+def _pull_number(pull: Mapping[str, object]) -> int:
+    """Return a pull request number.
+
+    Args:
+        pull: Pull request object.
+
+    Returns:
+        Pull request number.
+    """
+    number = pull["number"]
+    if isinstance(number, int):
+        return number
+    if isinstance(number, str):
+        return int(number)
+    raise TypeError("Pull request is missing a numeric number")
+
+
+def _github_headers(token: str) -> dict[str, str]:
+    """Build GitHub API request headers.
+
+    Args:
+        token: GitHub token.
+
+    Returns:
+        Request headers.
+    """
+    return {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "hass-opnsense-update-aiopnsense-cleanup",
+    }
+
+
+def _is_missing_ref_error(err: HTTPError) -> bool:
+    """Return whether a GitHub 422 error reports a missing ref.
+
+    Args:
+        err: HTTP error from the GitHub API.
+
+    Returns:
+        True when the error body says the reference does not exist.
+    """
+    body = err.read().decode(errors="replace")
+    if not body:
+        return False
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        return "Reference does not exist" in body
+    if not isinstance(payload, dict):
+        return False
+    message = payload.get("message")
+    return isinstance(message, str) and "Reference does not exist" in message
+
+
+def _next_link(link_header: str | None) -> str | None:
+    """Return the next pagination URL from a GitHub Link header.
+
+    Args:
+        link_header: Raw Link header value.
+
+    Returns:
+        Next URL when present.
+    """
+    if not link_header:
+        return None
+    for link in link_header.split(","):
+        url_part, *params = link.split(";")
+        if any(param.strip() == 'rel="next"' for param in params):
+            return url_part.strip()[1:-1]
+    return None
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--branch-prefix", required=True)
+    parser.add_argument("--label-name", required=True)
+    parser.add_argument("--keep-pr-number", type=int)
+    parser.add_argument("--close-stale-prs", action="store_true")
+    parser.add_argument("--delete-stale-branch", action="store_true")
+    parser.add_argument("--delete-merged-branches", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run workflow branch cleanup.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        LOGGER.error("GITHUB_TOKEN is required for cleanup.")
+        return 1
+
+    client = GithubClient(repository=args.repository, token=token)
+    result = cleanup_update_branches(
+        client=client,
+        repository=args.repository,
+        branch=args.branch,
+        branch_prefix=args.branch_prefix,
+        label_name=args.label_name,
+        keep_pr_number=args.keep_pr_number,
+        close_stale_prs=args.close_stale_prs,
+        delete_stale_branch=args.delete_stale_branch,
+        delete_merged_branches=args.delete_merged_branches,
+    )
+    LOGGER.info("Closed stale PRs: %s", result.closed_prs or "none")
+    LOGGER.info("Deleted branches: %s", result.deleted_branches or "none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/cleanup_aiopnsense_update_branches.py
+++ b/.github/scripts/cleanup_aiopnsense_update_branches.py
@@ -156,6 +156,7 @@ def cleanup_update_branches(
     """
     result = CleanupResult()
     protected_branches: set[str] = set()
+    branches_to_delete: set[str] = set()
 
     open_pulls = client.list_pulls(state="open")
     for pull in open_pulls:
@@ -177,8 +178,8 @@ def cleanup_update_branches(
         if close_stale_prs:
             client.close_pull(pull_number)
             result.closed_prs.append(pull_number)
+            branches_to_delete.add(head_ref)
 
-    branches_to_delete: set[str] = set()
     if delete_stale_branch and branch not in protected_branches:
         branches_to_delete.add(branch)
 

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -58,7 +58,25 @@ def _latest_is_newer(current: str, latest: str) -> bool:
     Returns:
         True when latest sorts after current.
     """
-    return not _is_prerelease(latest) and _version_key(latest) > _version_key(current)
+    if _is_prerelease(latest):
+        return False
+    if _is_prerelease(current):
+        return _version_key(latest) >= _stable_version_key(current)
+    return _version_key(latest) > _version_key(current)
+
+
+def _stable_version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a comparison key for the stable part of a version string.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing the stable release version.
+    """
+    match = PRERELEASE_RE.search(version)
+    stable_version = version[: match.start()].rstrip(".-_") if match else version
+    return _version_key(stable_version)
 
 
 def _is_prerelease(version: str) -> bool:

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -1,0 +1,293 @@
+"""Update aiopnsense dependency pins in manifest and pyproject files."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.request import urlopen
+
+PYPI_URL = "https://pypi.org/pypi/aiopnsense/json"
+PIN_PREFIX = "aiopnsense=="
+PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+",\s*$')
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Result of evaluating aiopnsense dependency pins.
+
+    Attributes:
+        current: Current manifest aiopnsense pin version.
+        pyproject_current: Current pyproject aiopnsense pin version.
+        latest: Latest aiopnsense version being evaluated.
+        update_needed: Whether at least one pin should be updated.
+    """
+
+    current: str
+    pyproject_current: str
+    latest: str
+    update_needed: bool
+
+
+def _version_key(version: str) -> tuple[tuple[int, int | str], ...]:
+    """Return a tolerant comparison key for aiopnsense version strings.
+
+    Args:
+        version: Version string to normalize.
+
+    Returns:
+        Tuple suitable for comparing common dotted release versions.
+    """
+    parts = re.findall(r"\d+|[A-Za-z]+", version.lstrip("vV"))
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in parts)
+
+
+def _latest_is_newer(current: str, latest: str) -> bool:
+    """Return whether the latest version is newer than the current version.
+
+    Args:
+        current: Current pinned version.
+        latest: Latest available version.
+
+    Returns:
+        True when latest sorts after current.
+    """
+    return _version_key(latest) > _version_key(current)
+
+
+def fetch_latest_version() -> str:
+    """Fetch the latest aiopnsense version from PyPI.
+
+    Returns:
+        Latest version string.
+
+    Raises:
+        ValueError: If PyPI does not return a usable version.
+    """
+    with urlopen(PYPI_URL, timeout=30) as response:  # noqa: S310
+        payload = json.load(response)
+
+    latest = payload.get("info", {}).get("version")
+    if not isinstance(latest, str) or not latest:
+        raise ValueError("Unable to determine latest aiopnsense version from PyPI response")
+    return latest
+
+
+def _read_manifest_version(manifest_path: Path) -> str:
+    """Read the aiopnsense pin version from a Home Assistant manifest.
+
+    Args:
+        manifest_path: Path to the integration manifest.
+
+    Returns:
+        Current aiopnsense version.
+
+    Raises:
+        ValueError: If there is not exactly one pinned aiopnsense requirement.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    requirements = manifest.get("requirements", [])
+    if not isinstance(requirements, list):
+        raise TypeError(f"Expected requirements list in {manifest_path}")
+
+    pins = [requirement for requirement in requirements if _is_aiopnsense_pin(requirement)]
+    if len(pins) != 1:
+        raise ValueError(
+            f"Expected exactly one aiopnsense requirement in {manifest_path}; found {len(pins)}"
+        )
+    return pins[0].removeprefix(PIN_PREFIX)
+
+
+def _read_pyproject_version(pyproject_path: Path) -> str:
+    """Read the aiopnsense pin version from dependency groups in pyproject.
+
+    Args:
+        pyproject_path: Path to pyproject.toml.
+
+    Returns:
+        Current aiopnsense version.
+
+    Raises:
+        ValueError: If there is not exactly one pinned aiopnsense dependency.
+    """
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    dependency_groups = pyproject.get("dependency-groups", {})
+    if not isinstance(dependency_groups, dict):
+        raise TypeError(f"Expected dependency-groups table in {pyproject_path}")
+
+    pins: list[str] = []
+    for dependencies in dependency_groups.values():
+        if not isinstance(dependencies, list):
+            continue
+        pins.extend(dependency for dependency in dependencies if _is_aiopnsense_pin(dependency))
+
+    if len(pins) != 1:
+        raise ValueError(
+            f"Expected exactly one pinned aiopnsense dependency in {pyproject_path}; "
+            f"found {len(pins)}"
+        )
+    return pins[0].removeprefix(PIN_PREFIX)
+
+
+def _is_aiopnsense_pin(requirement: object) -> bool:
+    """Return whether a dependency entry is an aiopnsense exact pin.
+
+    Args:
+        requirement: Dependency entry read from JSON or TOML.
+
+    Returns:
+        True when the entry is an exact aiopnsense pin.
+    """
+    return isinstance(requirement, str) and requirement.startswith(PIN_PREFIX)
+
+
+def _write_manifest_version(manifest_path: Path, latest_version: str) -> None:
+    """Write the aiopnsense pin version into the manifest.
+
+    Args:
+        manifest_path: Path to the integration manifest.
+        latest_version: Version to pin.
+
+    Raises:
+        ValueError: If there is not exactly one pinned aiopnsense requirement.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    requirements = manifest.get("requirements", [])
+    if not isinstance(requirements, list):
+        raise TypeError(f"Expected requirements list in {manifest_path}")
+
+    updated_count = 0
+    updated_requirements: list[object] = []
+    for requirement in requirements:
+        if _is_aiopnsense_pin(requirement):
+            updated_count += 1
+            updated_requirements.append(f"{PIN_PREFIX}{latest_version}")
+        else:
+            updated_requirements.append(requirement)
+
+    if updated_count != 1:
+        raise ValueError(
+            f"Expected to update exactly one aiopnsense requirement in {manifest_path}; "
+            f"updated {updated_count}"
+        )
+
+    manifest["requirements"] = updated_requirements
+    manifest_path.write_text(f"{json.dumps(manifest, indent=2)}\n")
+
+
+def _write_pyproject_version(pyproject_path: Path, latest_version: str) -> None:
+    """Write the aiopnsense pin version into pyproject while preserving layout.
+
+    Args:
+        pyproject_path: Path to pyproject.toml.
+        latest_version: Version to pin.
+
+    Raises:
+        ValueError: If there is not exactly one pinned aiopnsense dependency line.
+    """
+    text = pyproject_path.read_text()
+    updated, count = PYPROJECT_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}",', text)
+    if count != 1:
+        raise ValueError(
+            f"Expected to update exactly one aiopnsense pin in {pyproject_path}; updated {count}"
+        )
+    pyproject_path.write_text(updated)
+
+
+def update_pins(
+    *,
+    manifest_path: Path,
+    pyproject_path: Path,
+    latest_version: str,
+    write: bool = True,
+) -> UpdateResult:
+    """Evaluate and optionally update aiopnsense dependency pins.
+
+    Args:
+        manifest_path: Path to manifest.json.
+        pyproject_path: Path to pyproject.toml.
+        latest_version: Latest aiopnsense version to use.
+        write: Whether to rewrite dependency files when an update is needed.
+
+    Returns:
+        Evaluation result for workflow outputs and tests.
+    """
+    current = _read_manifest_version(manifest_path)
+    pyproject_current = _read_pyproject_version(pyproject_path)
+    update_needed = _latest_is_newer(current, latest_version) or (
+        current == latest_version and pyproject_current != latest_version
+    )
+
+    if write and update_needed:
+        _write_manifest_version(manifest_path, latest_version)
+        _write_pyproject_version(pyproject_path, latest_version)
+
+    return UpdateResult(
+        current=current,
+        pyproject_current=pyproject_current,
+        latest=latest_version,
+        update_needed=update_needed,
+    )
+
+
+def _write_github_outputs(result: UpdateResult, output_path: Path) -> None:
+    """Append update result values to the GitHub Actions output file.
+
+    Args:
+        result: Update result to write.
+        output_path: Path from the GITHUB_OUTPUT environment variable.
+    """
+    with output_path.open("a") as output_file:
+        output_file.write(f"current={result.current}\n")
+        output_file.write(f"pyproject_current={result.pyproject_current}\n")
+        output_file.write(f"latest={result.latest}\n")
+        output_file.write(f"update_needed={str(result.update_needed).lower()}\n")
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv: Command-line arguments excluding the executable name.
+
+    Returns:
+        Parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest-path", type=Path, required=True)
+    parser.add_argument("--pyproject-path", type=Path, required=True)
+    parser.add_argument("--latest-version")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the aiopnsense dependency pin updater.
+
+    Args:
+        argv: Optional command-line arguments excluding the executable name.
+
+    Returns:
+        Process exit code.
+    """
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    latest_version = args.latest_version or fetch_latest_version()
+    result = update_pins(
+        manifest_path=args.manifest_path,
+        pyproject_path=args.pyproject_path,
+        latest_version=latest_version,
+        write=args.write,
+    )
+    if args.github_output is not None:
+        _write_github_outputs(result, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -123,11 +123,31 @@ def _select_latest_stable_version(payload: Mapping[str, object]) -> str:
         raise TypeError("Expected releases mapping in PyPI response")
 
     stable_versions = [
-        version for version in releases if isinstance(version, str) and not _is_prerelease(version)
+        version
+        for version, files in releases.items()
+        if (
+            isinstance(version, str)
+            and not _is_prerelease(version)
+            and _release_has_usable_file(files)
+        )
     ]
     if not stable_versions:
         raise ValueError("Unable to determine latest stable aiopnsense version from PyPI response")
     return max(stable_versions, key=_version_key)
+
+
+def _release_has_usable_file(files: object) -> bool:
+    """Return whether a PyPI release has at least one non-yanked file.
+
+    Args:
+        files: Release file list from a PyPI JSON response.
+
+    Returns:
+        True when at least one file can be installed.
+    """
+    if not isinstance(files, list):
+        return False
+    return any(isinstance(file, dict) and file.get("yanked") is not True for file in files)
 
 
 def _read_manifest_version(manifest_path: Path) -> str:

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -25,7 +25,7 @@ class UpdateResult:
     Attributes:
         current: Current manifest aiopnsense pin version.
         pyproject_current: Current pyproject aiopnsense pin version.
-        latest: Latest aiopnsense version being evaluated.
+        latest: aiopnsense version selected as the update target.
         update_needed: Whether at least one pin should be updated.
     """
 
@@ -224,7 +224,7 @@ def update_pins(
     Args:
         manifest_path: Path to manifest.json.
         pyproject_path: Path to pyproject.toml.
-        latest_version: Latest aiopnsense version to use.
+        latest_version: Latest aiopnsense version available for evaluation.
         write: Whether to rewrite dependency files when an update is needed.
 
     Returns:
@@ -243,7 +243,7 @@ def update_pins(
     return UpdateResult(
         current=current,
         pyproject_current=pyproject_current,
-        latest=latest_version,
+        latest=target_version,
         update_needed=update_needed,
     )
 

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 import json
 from pathlib import Path
@@ -74,10 +74,10 @@ def _is_prerelease(version: str) -> bool:
 
 
 def fetch_latest_version() -> str:
-    """Fetch the latest aiopnsense version from PyPI.
+    """Fetch the latest stable aiopnsense version from PyPI.
 
     Returns:
-        Latest version string.
+        Latest stable version string.
 
     Raises:
         ValueError: If PyPI does not return a usable version.
@@ -85,10 +85,31 @@ def fetch_latest_version() -> str:
     with urlopen(PYPI_URL, timeout=30) as response:  # noqa: S310
         payload = json.load(response)
 
-    latest = payload.get("info", {}).get("version")
-    if not isinstance(latest, str) or not latest:
-        raise ValueError("Unable to determine latest aiopnsense version from PyPI response")
-    return latest
+    return _select_latest_stable_version(payload)
+
+
+def _select_latest_stable_version(payload: Mapping[str, object]) -> str:
+    """Select the newest stable version from a PyPI JSON payload.
+
+    Args:
+        payload: PyPI JSON response payload.
+
+    Returns:
+        Newest non-prerelease version from the release list.
+
+    Raises:
+        ValueError: If PyPI does not return any stable versions.
+    """
+    releases = payload.get("releases", {})
+    if not isinstance(releases, dict):
+        raise TypeError("Expected releases mapping in PyPI response")
+
+    stable_versions = [
+        version for version in releases if isinstance(version, str) and not _is_prerelease(version)
+    ]
+    if not stable_versions:
+        raise ValueError("Unable to determine latest stable aiopnsense version from PyPI response")
+    return max(stable_versions, key=_version_key)
 
 
 def _read_manifest_version(manifest_path: Path) -> str:

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -15,6 +15,7 @@ from urllib.request import urlopen
 PYPI_URL = "https://pypi.org/pypi/aiopnsense/json"
 PIN_PREFIX = "aiopnsense=="
 PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+",\s*$')
+PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
 
 
 @dataclass(frozen=True)
@@ -57,7 +58,19 @@ def _latest_is_newer(current: str, latest: str) -> bool:
     Returns:
         True when latest sorts after current.
     """
-    return _version_key(latest) > _version_key(current)
+    return not _is_prerelease(latest) and _version_key(latest) > _version_key(current)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Return whether a version string appears to be a prerelease.
+
+    Args:
+        version: Version string to evaluate.
+
+    Returns:
+        True when the version has a common prerelease marker.
+    """
+    return PRERELEASE_RE.search(version) is not None
 
 
 def fetch_latest_version() -> str:
@@ -219,13 +232,13 @@ def update_pins(
     """
     current = _read_manifest_version(manifest_path)
     pyproject_current = _read_pyproject_version(pyproject_path)
-    update_needed = _latest_is_newer(current, latest_version) or (
-        current == latest_version and pyproject_current != latest_version
-    )
+    latest_is_newer = _latest_is_newer(current, latest_version)
+    target_version = latest_version if latest_is_newer else current
+    update_needed = latest_is_newer or pyproject_current != target_version
 
     if write and update_needed:
-        _write_manifest_version(manifest_path, latest_version)
-        _write_pyproject_version(pyproject_path, latest_version)
+        _write_manifest_version(manifest_path, target_version)
+        _write_pyproject_version(pyproject_path, target_version)
 
     return UpdateResult(
         current=current,

--- a/.github/scripts/update_aiopnsense_pins.py
+++ b/.github/scripts/update_aiopnsense_pins.py
@@ -14,7 +14,7 @@ from urllib.request import urlopen
 
 PYPI_URL = "https://pypi.org/pypi/aiopnsense/json"
 PIN_PREFIX = "aiopnsense=="
-PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+",\s*$')
+PYPROJECT_PIN_RE = re.compile(r'(?m)^(\s*)"aiopnsense==[^"]+"(,?)\s*$')
 PRERELEASE_RE = re.compile(r"(?i)(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)")
 
 
@@ -263,7 +263,7 @@ def _write_pyproject_version(pyproject_path: Path, latest_version: str) -> None:
         ValueError: If there is not exactly one pinned aiopnsense dependency line.
     """
     text = pyproject_path.read_text()
-    updated, count = PYPROJECT_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}",', text)
+    updated, count = PYPROJECT_PIN_RE.subn(rf'\1"{PIN_PREFIX}{latest_version}"\2', text)
     if count != 1:
         raise ValueError(
             f"Expected to update exactly one aiopnsense pin in {pyproject_path}; updated {count}"

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+
       - name: Determine current and latest aiopnsense versions
         id: versions
         run: |
@@ -95,6 +100,13 @@ jobs:
               );
             }
 
+            function stableVersion(version) {
+              return version.replace(
+                /[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*.*$/i,
+                "",
+              );
+            }
+
             function sanitizeReleaseBody(body) {
               return body
                 .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
@@ -123,9 +135,10 @@ jobs:
             const selected = releases
               .filter((release) => {
                 const tagVersion = release.tag_name.replace(/^v/i, "");
+                const currentStable = stableVersion(current);
                 return (
                   !isPrerelease(tagVersion) &&
-                  compareVersions(tagVersion, current) > 0 &&
+                  compareVersions(tagVersion, currentStable) >= 0 &&
                   compareVersions(tagVersion, latest) <= 0
                 );
               })

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -48,13 +48,15 @@ jobs:
 
       - name: Update aiopnsense dependency pins
         if: steps.versions.outputs.update_needed == 'true'
+        env:
+          LATEST_VERSION: ${{ steps.versions.outputs.latest }}
         run: |
           set -euo pipefail
 
           python .github/scripts/update_aiopnsense_pins.py \
             --manifest-path custom_components/opnsense/manifest.json \
             --pyproject-path pyproject.toml \
-            --latest-version "${{ steps.versions.outputs.latest }}" \
+            --latest-version "$LATEST_VERSION" \
             --write
 
       - name: Build aiopnsense release notes

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -135,10 +135,12 @@ jobs:
             const selected = releases
               .filter((release) => {
                 const tagVersion = release.tag_name.replace(/^v/i, "");
+                const currentIsPrerelease = isPrerelease(current);
                 const currentStable = stableVersion(current);
+                const lowerBound = compareVersions(tagVersion, currentStable);
                 return (
                   !isPrerelease(tagVersion) &&
-                  compareVersions(tagVersion, currentStable) >= 0 &&
+                  (lowerBound > 0 || (currentIsPrerelease && lowerBound === 0)) &&
                   compareVersions(tagVersion, latest) <= 0
                 );
               })

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -61,121 +61,23 @@ jobs:
 
       - name: Build aiopnsense release notes
         if: steps.versions.outputs.update_needed == 'true'
-        id: release_notes
-        uses: actions/github-script@v9
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           CURRENT_VERSION: ${{ steps.versions.outputs.current }}
+          PYPROJECT_CURRENT_VERSION: ${{ steps.versions.outputs.pyproject_current }}
           LATEST_VERSION: ${{ steps.versions.outputs.latest }}
           REPO_OWNER: ${{ github.event.inputs.aiopnsense_release_owner || vars.AIOPNSENSE_RELEASE_OWNER || 'Snuffy2' }}
           REPO_NAME: ${{ github.event.inputs.aiopnsense_release_repo || vars.AIOPNSENSE_RELEASE_REPO || 'aiopnsense' }}
-        with:
-          script: |
-            const current = process.env.CURRENT_VERSION.replace(/^v/i, "");
-            const latest = process.env.LATEST_VERSION.replace(/^v/i, "");
-            const releaseOwner = process.env.REPO_OWNER;
-            const releaseRepo = process.env.REPO_NAME;
+        run: |
+          set -euo pipefail
 
-            function parseVersion(version) {
-              return version
-                .replace(/^v/i, "")
-                .split(/[^0-9]+/)
-                .filter(Boolean)
-                .map((part) => Number(part));
-            }
-
-            function compareVersions(a, b) {
-              const pa = parseVersion(a);
-              const pb = parseVersion(b);
-              const max = Math.max(pa.length, pb.length);
-              for (let i = 0; i < max; i += 1) {
-                const va = pa[i] ?? 0;
-                const vb = pb[i] ?? 0;
-                if (va > vb) return 1;
-                if (va < vb) return -1;
-              }
-              return 0;
-            }
-
-            function isPrerelease(version) {
-              return /(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)/i.test(
-                version,
-              );
-            }
-
-            function stableVersion(version) {
-              return version.replace(
-                /[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*.*$/i,
-                "",
-              );
-            }
-
-            function sanitizeReleaseBody(body) {
-              return body
-                .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
-                .replace(/@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)/g, "@<!-- -->")
-                .replace(
-                  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+)/gi,
-                  (_match, keyword, reference) =>
-                    `${keyword} ${reference.replace("#", "\\#")}`,
-                );
-            }
-
-            const releases = await github.paginate(github.rest.repos.listReleases, {
-              owner: releaseOwner,
-              repo: releaseRepo,
-              per_page: 100,
-            });
-            if (releases.length === 0) {
-              core.setFailed(
-                `No releases found for ${releaseOwner}/${releaseRepo}. ` +
-                  "Check workflow inputs or repository variables " +
-                  "(AIOPNSENSE_RELEASE_OWNER/AIOPNSENSE_RELEASE_REPO).",
-              );
-              return;
-            }
-
-            const selected = releases
-              .filter((release) => {
-                const tagVersion = release.tag_name.replace(/^v/i, "");
-                const currentIsPrerelease = isPrerelease(current);
-                const currentStable = stableVersion(current);
-                const lowerBound = compareVersions(tagVersion, currentStable);
-                return (
-                  !isPrerelease(tagVersion) &&
-                  (lowerBound > 0 || (currentIsPrerelease && lowerBound === 0)) &&
-                  compareVersions(tagVersion, latest) <= 0
-                );
-              })
-              .sort((a, b) =>
-                compareVersions(
-                  a.tag_name.replace(/^v/i, ""),
-                  b.tag_name.replace(/^v/i, ""),
-                ),
-              );
-
-            let notes = "";
-            if (selected.length === 0) {
-              notes =
-                "No matching GitHub release notes were found for this version range.";
-            } else {
-              notes = selected
-                .map((release) => {
-                  const title = sanitizeReleaseBody(release.name || release.tag_name);
-                  const tag = sanitizeReleaseBody(release.tag_name);
-                  const body = sanitizeReleaseBody(
-                    (release.body || "No release body provided.").trim(),
-                  );
-                  return [
-                    `### ${title} (${tag})`,
-                    release.html_url,
-                    "",
-                    body,
-                  ].join("\n");
-                })
-                .join("\n\n---\n\n");
-            }
-
-            core.setOutput("notes", notes);
+          python .github/scripts/build_aiopnsense_release_notes.py \
+            --current-version "$CURRENT_VERSION" \
+            --pyproject-current-version "$PYPROJECT_CURRENT_VERSION" \
+            --latest-version "$LATEST_VERSION" \
+            --release-owner "$REPO_OWNER" \
+            --release-repo "$REPO_NAME" \
+            --body-path aiopnsense-update-pr-body.md
 
       - name: Create or update aiopnsense update PR
         if: steps.versions.outputs.update_needed == 'true'
@@ -188,55 +90,27 @@ jobs:
           title: 'Bump aiopnsense to ${{ steps.versions.outputs.latest }}'
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: aiopnsense-auto-update
-          body: |
-            Automated update of aiopnsense dependency pins.
-
-            - Previous manifest pinned version: `aiopnsense==${{ steps.versions.outputs.current }}`
-            - Previous pyproject pinned version: `aiopnsense==${{ steps.versions.outputs.pyproject_current }}`
-            - Updated pinned version: `aiopnsense==${{ steps.versions.outputs.latest }}`
-
-            ## aiopnsense release notes in range
-            ${{ steps.release_notes.outputs.notes }}
+          body-path: aiopnsense-update-pr-body.md
           add-paths: |
             custom_components/opnsense/manifest.json
             pyproject.toml
 
       - name: Close extra auto-generated PRs
         if: steps.versions.outputs.update_needed == 'true' && steps.cpr.outputs.pull-request-number != ''
-        uses: actions/github-script@v9
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           KEEP_PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        with:
-          script: |
-            const keep = Number(process.env.KEEP_PR_NUMBER);
-            const branch = "chore/update-aiopnsense-manifest";
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
-            });
+        run: |
+          set -euo pipefail
 
-            for (const pr of pulls) {
-              if (pr.number === keep) {
-                continue;
-              }
-              const hasAutoLabel = pr.labels.some(
-                (label) => label.name === "aiopnsense-auto-update",
-              );
-              if (!hasAutoLabel) {
-                continue;
-              }
-              if (pr.head.ref !== branch) {
-                continue;
-              }
-              await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: pr.number,
-                state: "closed",
-              });
-            }
+          python .github/scripts/cleanup_aiopnsense_update_branches.py \
+            --repository "${{ github.repository }}" \
+            --branch chore/update-aiopnsense-manifest \
+            --branch-prefix chore/update-aiopnsense \
+            --label-name aiopnsense-auto-update \
+            --keep-pr-number "$KEEP_PR_NUMBER" \
+            --close-stale-prs \
+            --delete-merged-branches
 
       - name: Log when no update is required
         if: steps.versions.outputs.update_needed != 'true'
@@ -244,61 +118,16 @@ jobs:
 
       - name: Close stale aiopnsense update PRs
         if: steps.versions.outputs.update_needed != 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const branch = "chore/update-aiopnsense-manifest";
-            const labelName = "aiopnsense-auto-update";
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
 
-            const pulls = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
-            });
-
-            const stalePulls = pulls.filter(
-              (pr) =>
-                pr.head.ref === branch &&
-                pr.labels.some((label) => label.name === labelName),
-            );
-
-            if (stalePulls.length === 0) {
-              core.info(
-                `No open ${labelName} PRs found for branch ${branch}.`,
-              );
-            } else {
-              for (const pr of stalePulls) {
-                await github.rest.pulls.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: pr.number,
-                  state: "closed",
-                });
-
-                core.info(`Closed stale aiopnsense update PR #${pr.number}.`);
-              }
-            }
-
-            try {
-              await github.rest.git.deleteRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `heads/${branch}`,
-              });
-              core.info(`Deleted stale branch ${branch}.`);
-            } catch (error) {
-              const status = error.status ?? error.response?.status;
-
-              const message = error.response?.data?.message ?? error.message ?? "";
-
-              if (
-                status === 404 ||
-                (status === 422 && message.includes("Reference does not exist"))
-              ) {
-                core.info(`Branch ${branch} was already deleted.`);
-                return;
-              }
-
-              throw error;
-            }
+          python .github/scripts/cleanup_aiopnsense_update_branches.py \
+            --repository "${{ github.repository }}" \
+            --branch chore/update-aiopnsense-manifest \
+            --branch-prefix chore/update-aiopnsense \
+            --label-name aiopnsense-auto-update \
+            --close-stale-prs \
+            --delete-stale-branch \
+            --delete-merged-branches

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -1,4 +1,4 @@
-name: Update aiopnsense in manifest
+name: Update aiopnsense dependency pins
 
 on:
   schedule:
@@ -36,54 +36,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          manifest_path="custom_components/opnsense/manifest.json"
-          current_requirement_count="$(
-            jq -r '[.requirements[] | select(startswith("aiopnsense"))] | length' "$manifest_path"
-          )"
-          current_requirement="$(
-            jq -r '[.requirements[] | select(startswith("aiopnsense"))] | .[0] // empty' "$manifest_path"
-          )"
-          if [ "$current_requirement_count" -ne 1 ]; then
-            echo "Expected exactly one aiopnsense requirement in $manifest_path; found $current_requirement_count (current_requirement='$current_requirement')" >&2
-            exit 1
-          fi
-          current_version="$(printf '%s' "$current_requirement" | sed -E 's/^[^0-9]*//')"
-          latest_version="$(curl -fsSL https://pypi.org/pypi/aiopnsense/json | jq -r '.info.version // empty')"
-          if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
-            echo "Unable to determine latest aiopnsense version from PyPI response" >&2
-            exit 1
-          fi
+          python .github/scripts/update_aiopnsense_pins.py \
+            --manifest-path custom_components/opnsense/manifest.json \
+            --pyproject-path pyproject.toml \
+            --github-output "$GITHUB_OUTPUT"
 
-          update_needed="false"
-          if [ "$(printf '%s\n%s\n' "$current_version" "$latest_version" | sort -V | tail -n1)" = "$latest_version" ] && [ "$current_version" != "$latest_version" ]; then
-            update_needed="true"
-          fi
-
-          {
-            echo "current=$current_version"
-            echo "latest=$latest_version"
-            echo "update_needed=$update_needed"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Update manifest requirement
+      - name: Update aiopnsense dependency pins
         if: steps.versions.outputs.update_needed == 'true'
         run: |
           set -euo pipefail
 
-          manifest_path="custom_components/opnsense/manifest.json"
-          latest_version="${{ steps.versions.outputs.latest }}"
-          tmp_file="$(mktemp)"
-
-          jq --arg latest "$latest_version" '
-            .requirements |= map(
-              if startswith("aiopnsense")
-              then "aiopnsense==" + $latest
-              else .
-              end
-            )
-          ' "$manifest_path" > "$tmp_file"
-
-          mv "$tmp_file" "$manifest_path"
+          python .github/scripts/update_aiopnsense_pins.py \
+            --manifest-path custom_components/opnsense/manifest.json \
+            --pyproject-path pyproject.toml \
+            --latest-version "${{ steps.versions.outputs.latest }}" \
+            --write
 
       - name: Build aiopnsense release notes
         if: steps.versions.outputs.update_needed == 'true'
@@ -191,15 +158,17 @@ jobs:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: aiopnsense-auto-update
           body: |
-            Automated update of `custom_components/opnsense/manifest.json`.
+            Automated update of aiopnsense dependency pins.
 
-            - Previous pinned version: `aiopnsense==${{ steps.versions.outputs.current }}`
+            - Previous manifest pinned version: `aiopnsense==${{ steps.versions.outputs.current }}`
+            - Previous pyproject pinned version: `aiopnsense==${{ steps.versions.outputs.pyproject_current }}`
             - Updated pinned version: `aiopnsense==${{ steps.versions.outputs.latest }}`
 
             ## aiopnsense release notes in range
             ${{ steps.release_notes.outputs.notes }}
           add-paths: |
             custom_components/opnsense/manifest.json
+            pyproject.toml
 
       - name: Close extra auto-generated PRs
         if: steps.versions.outputs.update_needed == 'true' && steps.cpr.outputs.pull-request-number != ''
@@ -290,7 +259,12 @@ jobs:
             } catch (error) {
               const status = error.status ?? error.response?.status;
 
-              if (status === 404) {
+              const message = error.response?.data?.message ?? error.message ?? "";
+
+              if (
+                status === 404 ||
+                (status === 422 && message.includes("Reference does not exist"))
+              ) {
                 core.info(`Branch ${branch} was already deleted.`);
                 return;
               }

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -98,7 +98,12 @@ jobs:
             function sanitizeReleaseBody(body) {
               return body
                 .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
-                .replace(/(^|\s)@([A-Za-z0-9-]+)/g, "$1$2");
+                .replace(/(^|\s)@([A-Za-z0-9-]+)/g, "$1$2")
+                .replace(
+                  /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+)/gi,
+                  (_match, keyword, reference) =>
+                    `${keyword} ${reference.replace("#", "\\#")}`,
+                );
             }
 
             const releases = await github.paginate(github.rest.repos.listReleases, {

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -89,6 +89,12 @@ jobs:
               return 0;
             }
 
+            function isPrerelease(version) {
+              return /(?:[.\-_]?(?:a|alpha|b|beta|c|pre|preview|rc|dev)\d*)/i.test(
+                version,
+              );
+            }
+
             function sanitizeReleaseBody(body) {
               return body
                 .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
@@ -113,6 +119,7 @@ jobs:
               .filter((release) => {
                 const tagVersion = release.tag_name.replace(/^v/i, "");
                 return (
+                  !isPrerelease(tagVersion) &&
                   compareVersions(tagVersion, current) > 0 &&
                   compareVersions(tagVersion, latest) <= 0
                 );

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -110,7 +110,7 @@ jobs:
             function sanitizeReleaseBody(body) {
               return body
                 .replace(/\[@([A-Za-z0-9-]+)\]\(https?:\/\/github\.com\/[A-Za-z0-9-]+\)/g, "$1")
-                .replace(/(^|\s)@([A-Za-z0-9-]+)/g, "$1$2")
+                .replace(/@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)/g, "@<!-- -->")
                 .replace(
                   /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+)/gi,
                   (_match, keyword, reference) =>
@@ -158,11 +158,13 @@ jobs:
             } else {
               notes = selected
                 .map((release) => {
+                  const title = sanitizeReleaseBody(release.name || release.tag_name);
+                  const tag = sanitizeReleaseBody(release.tag_name);
                   const body = sanitizeReleaseBody(
                     (release.body || "No release body provided.").trim(),
                   );
                   return [
-                    `### ${release.name || release.tag_name} (${release.tag_name})`,
+                    `### ${title} (${tag})`,
                     release.html_url,
                     "",
                     body,

--- a/.github/workflows/update_aiopnsense.yml
+++ b/.github/workflows/update_aiopnsense.yml
@@ -100,11 +100,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           KEEP_PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           python .github/scripts/cleanup_aiopnsense_update_branches.py \
-            --repository "${{ github.repository }}" \
+            --repository "$REPOSITORY" \
             --branch chore/update-aiopnsense-manifest \
             --branch-prefix chore/update-aiopnsense \
             --label-name aiopnsense-auto-update \
@@ -120,11 +121,12 @@ jobs:
         if: steps.versions.outputs.update_needed != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
 
           python .github/scripts/cleanup_aiopnsense_update_branches.py \
-            --repository "${{ github.repository }}" \
+            --repository "$REPOSITORY" \
             --branch chore/update-aiopnsense-manifest \
             --branch-prefix chore/update-aiopnsense \
             --label-name aiopnsense-auto-update \

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -12,6 +12,37 @@ WORKFLOW_PATH = Path(".github/workflows/update_aiopnsense.yml")
 SCRIPT_PATH = Path(".github/scripts/update_aiopnsense_pins.py")
 
 
+def _write_pin_files(
+    tmp_path: Path,
+    *,
+    manifest_version: str,
+    pyproject_version: str | None = None,
+    pyproject_text: str | None = None,
+) -> tuple[Path, Path]:
+    """Write temporary manifest and pyproject files with aiopnsense pins."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "requirements": [
+                    "xmltodict==0.14.2",
+                    f"aiopnsense=={manifest_version}",
+                ],
+            },
+        ),
+    )
+
+    if pyproject_text is None:
+        pyproject_text = f"""[dependency-groups]
+ha = [
+    "aiopnsense=={pyproject_version or manifest_version}",
+]
+"""
+    pyproject_path.write_text(pyproject_text)
+    return manifest_path, pyproject_path
+
+
 @pytest.fixture
 def updater_script() -> ModuleType:
     """Load the aiopnsense pin updater script as a test module."""
@@ -24,103 +55,103 @@ def updater_script() -> ModuleType:
     return module
 
 
-def test_workflow_updates_manifest_and_pyproject_pins() -> None:
-    """Workflow should include both aiopnsense dependency pin files in update PRs."""
-    workflow = WORKFLOW_PATH.read_text()
-
-    assert "actions/setup-python@v6" in workflow
-    assert "python-version: '3.14'" in workflow
-    assert "Automated update of aiopnsense dependency pins." in workflow
-    assert "custom_components/opnsense/manifest.json" in workflow
-    assert "pyproject.toml" in workflow
-    assert "pyproject_current" in workflow
-    assert str(SCRIPT_PATH) in workflow
-
-
-def test_workflow_treats_missing_stale_branch_as_success() -> None:
-    """Workflow should not fail when GitHub reports an absent branch as a 422."""
-    workflow = WORKFLOW_PATH.read_text()
-
-    assert "status === 422" in workflow
-    assert 'message.includes("Reference does not exist")' in workflow
-    assert "Branch ${branch} was already deleted." in workflow
-
-
-def test_workflow_filters_prerelease_release_notes() -> None:
-    """Workflow should not include prerelease release notes for stable updates."""
-    workflow = WORKFLOW_PATH.read_text()
-
-    assert "function isPrerelease(version)" in workflow
-    assert "function stableVersion(version)" in workflow
-    assert "const currentIsPrerelease = isPrerelease(current);" in workflow
-    assert "const currentStable = stableVersion(current);" in workflow
-    assert "const lowerBound = compareVersions(tagVersion, currentStable);" in workflow
-    assert "!isPrerelease(tagVersion)" in workflow
-    assert "(lowerBound > 0 || (currentIsPrerelease && lowerBound === 0))" in workflow
-
-
-def test_workflow_neutralizes_release_note_closing_keywords() -> None:
-    """Workflow should prevent copied release notes from closing local issues."""
-    workflow = WORKFLOW_PATH.read_text()
-
-    assert "const title = sanitizeReleaseBody(release.name || release.tag_name);" in workflow
-    assert "const tag = sanitizeReleaseBody(release.tag_name);" in workflow
-    assert "`### ${title} (${tag})`" in workflow
-    assert r"@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)" in workflow
-    assert '"@<!-- -->"' in workflow
-    assert "reference.replace" in workflow
-    assert r'"\\#"' in workflow
-    assert "close[sd]?|fix(?:e[sd])?|resolve[sd]?" in workflow
-
-
-def test_updater_script_updates_manifest_and_pyproject(
-    tmp_path: Path, updater_script: ModuleType
-) -> None:
-    """Updater script should rewrite exactly one pin in each dependency file."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(
-        json.dumps(
-            {
-                "requirements": [
-                    "xmltodict==0.14.2",
-                    "aiopnsense==1.0.8",
-                ],
-            },
+@pytest.mark.parametrize(
+    ("needle", "reason"),
+    [
+        ("actions/setup-python@v6", "pins a Python runtime"),
+        ("python-version: '3.14'", "uses a tomllib-capable Python"),
+        ("Automated update of aiopnsense dependency pins.", "describes generated PRs"),
+        ("custom_components/opnsense/manifest.json", "updates the integration manifest"),
+        ("pyproject.toml", "updates the local dependency pin"),
+        ("pyproject_current", "reports pyproject drift in PR metadata"),
+        (str(SCRIPT_PATH), "runs the checked-in updater helper"),
+        ("status === 422", "handles GitHub missing-reference responses"),
+        ('message.includes("Reference does not exist")', "detects stale deleted branches"),
+        ("Branch ${branch} was already deleted.", "logs stale branch cleanup"),
+        ("function isPrerelease(version)", "detects prerelease release tags"),
+        ("function stableVersion(version)", "normalizes prerelease current pins"),
+        ("const currentIsPrerelease = isPrerelease(current);", "tracks prerelease repairs"),
+        ("const currentStable = stableVersion(current);", "compares against stable base"),
+        ("const lowerBound = compareVersions(tagVersion, currentStable);", "bounds notes"),
+        ("!isPrerelease(tagVersion)", "filters prerelease release notes"),
+        (
+            "(lowerBound > 0 || (currentIsPrerelease && lowerBound === 0))",
+            "excludes current stable except prerelease repairs",
         ),
-    )
-    pyproject_path.write_text(
-        """[dependency-groups]
-ha = [
-    "aiopnsense==1.0.8",
-    "homeassistant",
-]
-""",
+        (
+            "const title = sanitizeReleaseBody(release.name || release.tag_name);",
+            "sanitizes release-note headings",
+        ),
+        ("const tag = sanitizeReleaseBody(release.tag_name);", "sanitizes tag headings"),
+        ("`### ${title} (${tag})`", "uses sanitized heading values"),
+        (r"@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)", "neutralizes mentions"),
+        ('"@<!-- -->"', "breaks GitHub mention syntax"),
+        ("reference.replace", "escapes issue references"),
+        (r'"\\#"', "breaks GitHub closing keywords"),
+        ("close[sd]?|fix(?:e[sd])?|resolve[sd]?", "matches closing keywords"),
+    ],
+)
+def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
+    """Workflow should include the expected aiopnsense updater logic."""
+    del reason
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert needle in workflow
+
+
+@pytest.mark.parametrize(
+    (
+        "manifest_version",
+        "pyproject_version",
+        "latest_version",
+        "expected_update_needed",
+        "expected_target",
+    ),
+    [
+        ("1.0.8", "1.0.8", "1.0.9", True, "1.0.9"),
+        ("1.0.0", "1.0.0", "1.0.1rc1", False, "1.0.0"),
+        ("1.0.1rc1", "1.0.1rc1", "1.0.1", True, "1.0.1"),
+        ("1.0.10", "1.0.9", "1.0.9", True, "1.0.10"),
+    ],
+)
+def test_updater_script_pin_update_scenarios(
+    tmp_path: Path,
+    updater_script: ModuleType,
+    manifest_version: str,
+    pyproject_version: str,
+    latest_version: str,
+    expected_update_needed: bool,
+    expected_target: str,
+) -> None:
+    """Updater script should handle stable, prerelease, and drift pin scenarios."""
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version=manifest_version,
+        pyproject_version=pyproject_version,
     )
 
     result = updater_script.update_pins(
         manifest_path=manifest_path,
         pyproject_path=pyproject_path,
-        latest_version="1.0.9",
+        latest_version=latest_version,
     )
 
-    assert result.current == "1.0.8"
-    assert result.pyproject_current == "1.0.8"
-    assert result.latest == "1.0.9"
-    assert result.update_needed is True
-    assert "aiopnsense==1.0.9" in manifest_path.read_text()
-    assert '    "aiopnsense==1.0.9",' in pyproject_path.read_text()
+    assert result.current == manifest_version
+    assert result.pyproject_current == pyproject_version
+    assert result.latest == expected_target
+    assert result.update_needed is expected_update_needed
+    assert f"aiopnsense=={expected_target}" in manifest_path.read_text()
+    assert f'    "aiopnsense=={expected_target}",' in pyproject_path.read_text()
 
 
 def test_updater_script_updates_pyproject_pin_without_trailing_comma(
     tmp_path: Path, updater_script: ModuleType
 ) -> None:
     """Updater script should preserve valid TOML dependency-list formatting."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.8"]}))
-    pyproject_path.write_text(
-        """[dependency-groups]
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version="1.0.8",
+        pyproject_text="""[dependency-groups]
 ha = [
     "homeassistant",
     "aiopnsense==1.0.8"
@@ -138,121 +169,43 @@ ha = [
     assert '    "aiopnsense==1.0.9"\n' in pyproject_path.read_text()
 
 
-def test_updater_script_ignores_prerelease_updates(
-    tmp_path: Path, updater_script: ModuleType
-) -> None:
-    """Updater script should not treat prereleases as newer stable pins."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.0"]}))
-    pyproject_path.write_text(
-        """[dependency-groups]
-ha = [
-    "aiopnsense==1.0.0",
-]
-""",
-    )
-
-    result = updater_script.update_pins(
-        manifest_path=manifest_path,
-        pyproject_path=pyproject_path,
-        latest_version="1.0.1rc1",
-    )
-
-    assert result.update_needed is False
-    assert result.latest == "1.0.0"
-    assert "aiopnsense==1.0.0" in manifest_path.read_text()
-    assert '    "aiopnsense==1.0.0",' in pyproject_path.read_text()
-
-
-def test_updater_script_updates_prerelease_pin_to_matching_stable(
-    tmp_path: Path, updater_script: ModuleType
-) -> None:
-    """Updater script should replace current prerelease pins with stable releases."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.1rc1"]}))
-    pyproject_path.write_text(
-        """[dependency-groups]
-ha = [
-    "aiopnsense==1.0.1rc1",
-]
-""",
-    )
-
-    result = updater_script.update_pins(
-        manifest_path=manifest_path,
-        pyproject_path=pyproject_path,
-        latest_version="1.0.1",
-    )
-
-    assert result.update_needed is True
-    assert result.latest == "1.0.1"
-    assert "aiopnsense==1.0.1" in manifest_path.read_text()
-    assert '    "aiopnsense==1.0.1",' in pyproject_path.read_text()
-
-
+@pytest.mark.parametrize(
+    ("payload", "expected_latest"),
+    [
+        (
+            {
+                "info": {"version": "1.1.0rc1"},
+                "releases": {
+                    "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
+                    "1.0.9": [{"filename": "aiopnsense-1.0.9.tar.gz"}],
+                    "1.1.0rc1": [{"filename": "aiopnsense-1.1.0rc1.tar.gz"}],
+                },
+            },
+            "1.0.9",
+        ),
+        (
+            {
+                "releases": {
+                    "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
+                    "1.0.9": [],
+                    "1.0.10": [{"filename": "aiopnsense-1.0.10.tar.gz", "yanked": True}],
+                },
+            },
+            "1.0.8",
+        ),
+    ],
+)
 def test_updater_script_selects_latest_stable_from_pypi_payload(
     updater_script: ModuleType,
+    payload: dict[str, object],
+    expected_latest: str,
 ) -> None:
-    """Updater script should ignore prereleases when reading PyPI releases."""
+    """Updater script should select the latest installable stable PyPI release."""
     latest = updater_script._select_latest_stable_version(
-        {
-            "info": {"version": "1.1.0rc1"},
-            "releases": {
-                "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
-                "1.0.9": [{"filename": "aiopnsense-1.0.9.tar.gz"}],
-                "1.1.0rc1": [{"filename": "aiopnsense-1.1.0rc1.tar.gz"}],
-            },
-        },
+        payload,
     )
 
-    assert latest == "1.0.9"
-
-
-def test_updater_script_ignores_stable_releases_without_usable_files(
-    updater_script: ModuleType,
-) -> None:
-    """Updater script should ignore PyPI releases with no installable files."""
-    latest = updater_script._select_latest_stable_version(
-        {
-            "releases": {
-                "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
-                "1.0.9": [],
-                "1.0.10": [{"filename": "aiopnsense-1.0.10.tar.gz", "yanked": True}],
-            },
-        },
-    )
-
-    assert latest == "1.0.8"
-
-
-def test_updater_script_repairs_pyproject_drift_when_manifest_is_newer(
-    tmp_path: Path,
-    updater_script: ModuleType,
-) -> None:
-    """Updater script should align pyproject to a newer manifest pin."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.10"]}))
-    pyproject_path.write_text(
-        """[dependency-groups]
-ha = [
-    "aiopnsense==1.0.9",
-]
-""",
-    )
-
-    result = updater_script.update_pins(
-        manifest_path=manifest_path,
-        pyproject_path=pyproject_path,
-        latest_version="1.0.9",
-    )
-
-    assert result.update_needed is True
-    assert result.latest == "1.0.10"
-    assert "aiopnsense==1.0.10" in manifest_path.read_text()
-    assert '    "aiopnsense==1.0.10",' in pyproject_path.read_text()
+    assert latest == expected_latest
 
 
 def test_updater_script_rejects_duplicate_pyproject_pins(
@@ -260,11 +213,10 @@ def test_updater_script_rejects_duplicate_pyproject_pins(
     updater_script: ModuleType,
 ) -> None:
     """Updater script should fail clearly when pyproject has ambiguous pins."""
-    manifest_path = tmp_path / "manifest.json"
-    pyproject_path = tmp_path / "pyproject.toml"
-    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.8"]}))
-    pyproject_path.write_text(
-        """[dependency-groups]
+    manifest_path, pyproject_path = _write_pin_files(
+        tmp_path,
+        manifest_version="1.0.8",
+        pyproject_text="""[dependency-groups]
 ha = [
     "aiopnsense==1.0.8",
     "aiopnsense==1.0.9",

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -52,9 +52,11 @@ def test_workflow_filters_prerelease_release_notes() -> None:
 
     assert "function isPrerelease(version)" in workflow
     assert "function stableVersion(version)" in workflow
+    assert "const currentIsPrerelease = isPrerelease(current);" in workflow
     assert "const currentStable = stableVersion(current);" in workflow
+    assert "const lowerBound = compareVersions(tagVersion, currentStable);" in workflow
     assert "!isPrerelease(tagVersion)" in workflow
-    assert "compareVersions(tagVersion, currentStable) >= 0" in workflow
+    assert "(lowerBound > 0 || (currentIsPrerelease && lowerBound === 0))" in workflow
 
 
 def test_workflow_neutralizes_release_note_closing_keywords() -> None:

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -107,6 +107,32 @@ ha = [
     assert '    "aiopnsense==1.0.9",' in pyproject_path.read_text()
 
 
+def test_updater_script_updates_pyproject_pin_without_trailing_comma(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater script should preserve valid TOML dependency-list formatting."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.8"]}))
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "homeassistant",
+    "aiopnsense==1.0.8"
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="1.0.9",
+    )
+
+    assert result.update_needed is True
+    assert '    "aiopnsense==1.0.9"\n' in pyproject_path.read_text()
+
+
 def test_updater_script_ignores_prerelease_updates(
     tmp_path: Path, updater_script: ModuleType
 ) -> None:

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -105,6 +105,7 @@ ha = [
     )
 
     assert result.update_needed is False
+    assert result.latest == "1.0.0"
     assert "aiopnsense==1.0.0" in manifest_path.read_text()
     assert '    "aiopnsense==1.0.0",' in pyproject_path.read_text()
 
@@ -132,6 +133,7 @@ ha = [
     )
 
     assert result.update_needed is True
+    assert result.latest == "1.0.10"
     assert "aiopnsense==1.0.10" in manifest_path.read_text()
     assert '    "aiopnsense==1.0.10",' in pyproject_path.read_text()
 

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -356,6 +356,7 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
     client = FakeCleanupClient(
         open_pulls=[
             _workflow_pull(number=10),
+            _workflow_pull(number=9, ref="chore/update-aiopnsense-old"),
             _workflow_pull(number=11, ref="feature/manual"),
         ],
         closed_pulls=[
@@ -376,10 +377,16 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
         delete_merged_branches=True,
     )
 
-    assert client.closed_prs == [10]
-    assert client.deleted_refs == ["heads/chore/update-aiopnsense-manifest"]
-    assert result.closed_prs == [10]
-    assert result.deleted_branches == ["chore/update-aiopnsense-manifest"]
+    assert client.closed_prs == [10, 9]
+    assert client.deleted_refs == [
+        "heads/chore/update-aiopnsense-manifest",
+        "heads/chore/update-aiopnsense-old",
+    ]
+    assert result.closed_prs == [10, 9]
+    assert result.deleted_branches == [
+        "chore/update-aiopnsense-manifest",
+        "chore/update-aiopnsense-old",
+    ]
 
 
 def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -63,6 +63,11 @@ def test_workflow_neutralizes_release_note_closing_keywords() -> None:
     """Workflow should prevent copied release notes from closing local issues."""
     workflow = WORKFLOW_PATH.read_text()
 
+    assert "const title = sanitizeReleaseBody(release.name || release.tag_name);" in workflow
+    assert "const tag = sanitizeReleaseBody(release.tag_name);" in workflow
+    assert "`### ${title} (${tag})`" in workflow
+    assert r"@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)" in workflow
+    assert '"@<!-- -->"' in workflow
     assert "reference.replace" in workflow
     assert r'"\\#"' in workflow
     assert "close[sd]?|fix(?:e[sd])?|resolve[sd]?" in workflow

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -110,6 +110,24 @@ ha = [
     assert '    "aiopnsense==1.0.0",' in pyproject_path.read_text()
 
 
+def test_updater_script_selects_latest_stable_from_pypi_payload(
+    updater_script: ModuleType,
+) -> None:
+    """Updater script should ignore prereleases when reading PyPI releases."""
+    latest = updater_script._select_latest_stable_version(
+        {
+            "info": {"version": "1.1.0rc1"},
+            "releases": {
+                "1.0.8": [],
+                "1.0.9": [],
+                "1.1.0rc1": [],
+            },
+        },
+    )
+
+    assert latest == "1.0.9"
+
+
 def test_updater_script_repairs_pyproject_drift_when_manifest_is_newer(
     tmp_path: Path,
     updater_script: ModuleType,

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -52,6 +52,15 @@ def test_workflow_filters_prerelease_release_notes() -> None:
     assert "!isPrerelease(tagVersion)" in workflow
 
 
+def test_workflow_neutralizes_release_note_closing_keywords() -> None:
+    """Workflow should prevent copied release notes from closing local issues."""
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert "reference.replace" in workflow
+    assert r'"\\#"' in workflow
+    assert "close[sd]?|fix(?:e[sd])?|resolve[sd]?" in workflow
+
+
 def test_updater_script_updates_manifest_and_pyproject(
     tmp_path: Path, updater_script: ModuleType
 ) -> None:
@@ -153,14 +162,31 @@ def test_updater_script_selects_latest_stable_from_pypi_payload(
         {
             "info": {"version": "1.1.0rc1"},
             "releases": {
-                "1.0.8": [],
-                "1.0.9": [],
-                "1.1.0rc1": [],
+                "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
+                "1.0.9": [{"filename": "aiopnsense-1.0.9.tar.gz"}],
+                "1.1.0rc1": [{"filename": "aiopnsense-1.1.0rc1.tar.gz"}],
             },
         },
     )
 
     assert latest == "1.0.9"
+
+
+def test_updater_script_ignores_stable_releases_without_usable_files(
+    updater_script: ModuleType,
+) -> None:
+    """Updater script should ignore PyPI releases with no installable files."""
+    latest = updater_script._select_latest_stable_version(
+        {
+            "releases": {
+                "1.0.8": [{"filename": "aiopnsense-1.0.8.tar.gz"}],
+                "1.0.9": [],
+                "1.0.10": [{"filename": "aiopnsense-1.0.10.tar.gz", "yanked": True}],
+            },
+        },
+    )
+
+    assert latest == "1.0.8"
 
 
 def test_updater_script_repairs_pyproject_drift_when_manifest_is_newer(

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -10,6 +10,8 @@ import pytest
 
 WORKFLOW_PATH = Path(".github/workflows/update_aiopnsense.yml")
 SCRIPT_PATH = Path(".github/scripts/update_aiopnsense_pins.py")
+RELEASE_NOTES_SCRIPT_PATH = Path(".github/scripts/build_aiopnsense_release_notes.py")
+CLEANUP_SCRIPT_PATH = Path(".github/scripts/cleanup_aiopnsense_update_branches.py")
 
 
 def _write_pin_files(
@@ -46,11 +48,28 @@ ha = [
 @pytest.fixture
 def updater_script() -> ModuleType:
     """Load the aiopnsense pin updater script as a test module."""
-    spec = util.spec_from_file_location("update_aiopnsense_pins", SCRIPT_PATH)
+    return _load_script("update_aiopnsense_pins", SCRIPT_PATH)
+
+
+@pytest.fixture
+def release_notes_script() -> ModuleType:
+    """Load the aiopnsense release-note builder script as a test module."""
+    return _load_script("build_aiopnsense_release_notes", RELEASE_NOTES_SCRIPT_PATH)
+
+
+@pytest.fixture
+def cleanup_script() -> ModuleType:
+    """Load the aiopnsense cleanup script as a test module."""
+    return _load_script("cleanup_aiopnsense_update_branches", CLEANUP_SCRIPT_PATH)
+
+
+def _load_script(module_name: str, script_path: Path) -> ModuleType:
+    """Load a checked-in workflow helper script as a test module."""
+    spec = util.spec_from_file_location(module_name, script_path)
     assert spec is not None
     assert spec.loader is not None
     module = util.module_from_spec(spec)
-    sys.modules["update_aiopnsense_pins"] = module
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
 
@@ -65,38 +84,22 @@ def updater_script() -> ModuleType:
         ("pyproject.toml", "updates the local dependency pin"),
         ("pyproject_current", "reports pyproject drift in PR metadata"),
         (str(SCRIPT_PATH), "runs the checked-in updater helper"),
+        (str(RELEASE_NOTES_SCRIPT_PATH), "runs the checked-in release-note helper"),
+        (str(CLEANUP_SCRIPT_PATH), "runs the checked-in cleanup helper"),
+        ("--body-path aiopnsense-update-pr-body.md", "uses a PR body file"),
+        ("--delete-merged-branches", "cleans merged workflow-owned branches"),
         ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
         ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
-        ("status === 422", "handles GitHub missing-reference responses"),
-        ('message.includes("Reference does not exist")', "detects stale deleted branches"),
-        ("Branch ${branch} was already deleted.", "logs stale branch cleanup"),
-        ("function isPrerelease(version)", "detects prerelease release tags"),
-        ("function stableVersion(version)", "normalizes prerelease current pins"),
-        ("const currentIsPrerelease = isPrerelease(current);", "tracks prerelease repairs"),
-        ("const currentStable = stableVersion(current);", "compares against stable base"),
-        ("const lowerBound = compareVersions(tagVersion, currentStable);", "bounds notes"),
-        ("!isPrerelease(tagVersion)", "filters prerelease release notes"),
-        (
-            "(lowerBound > 0 || (currentIsPrerelease && lowerBound === 0))",
-            "excludes current stable except prerelease repairs",
-        ),
-        (
-            "const title = sanitizeReleaseBody(release.name || release.tag_name);",
-            "sanitizes release-note headings",
-        ),
-        ("const tag = sanitizeReleaseBody(release.tag_name);", "sanitizes tag headings"),
-        ("`### ${title} (${tag})`", "uses sanitized heading values"),
-        (r"@(?=[A-Za-z0-9-]+(?:\/[A-Za-z0-9-]+)?)", "neutralizes mentions"),
-        ('"@<!-- -->"', "breaks GitHub mention syntax"),
-        ("reference.replace", "escapes issue references"),
-        (r'"\\#"', "breaks GitHub closing keywords"),
-        ("close[sd]?|fix(?:e[sd])?|resolve[sd]?", "matches closing keywords"),
     ],
 )
 def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
     """Workflow should include the expected aiopnsense updater logic."""
     del reason
-    workflow = WORKFLOW_PATH.read_text()
+    workflow = (
+        f"{WORKFLOW_PATH.read_text()}\n"
+        f"{RELEASE_NOTES_SCRIPT_PATH.read_text()}\n"
+        f"{CLEANUP_SCRIPT_PATH.read_text()}"
+    )
 
     assert needle in workflow
 
@@ -232,3 +235,192 @@ ha = [
             pyproject_path=pyproject_path,
             latest_version="1.0.10",
         )
+
+
+def test_release_note_script_builds_sanitized_pr_body(
+    tmp_path: Path,
+    release_notes_script: ModuleType,
+) -> None:
+    """Release-note script should build a mention-safe PR body file."""
+    releases = [
+        {
+            "tag_name": "1.0.8",
+            "name": "Ignored current",
+            "body": "old",
+            "html_url": "https://example.test/1.0.8",
+        },
+        {
+            "tag_name": "1.0.9",
+            "name": "Fixes @someone",
+            "body": "fixes #123 and thanks [@helper](https://github.com/helper)",
+            "html_url": "https://example.test/1.0.9",
+        },
+        {
+            "tag_name": "1.1.0rc1",
+            "name": "Ignored prerelease",
+            "body": "future",
+            "html_url": "https://example.test/1.1.0rc1",
+        },
+    ]
+    body_path = tmp_path / "body.md"
+
+    release_notes_script.write_pr_body(
+        body_path=body_path,
+        releases=releases,
+        current_version="1.0.8",
+        pyproject_current_version="1.0.8",
+        latest_version="1.0.9",
+    )
+
+    body = body_path.read_text()
+    assert "Automated update of aiopnsense dependency pins." in body
+    assert "Updated pinned version: `aiopnsense==1.0.9`" in body
+    assert "### Fixes @<!-- -->someone (1.0.9)" in body
+    assert "fixes \\#123 and thanks helper" in body
+    assert "Ignored current" not in body
+    assert "Ignored prerelease" not in body
+
+
+def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
+    cleanup_script: ModuleType,
+) -> None:
+    """Cleanup script should close stale PRs and remove workflow-created branches."""
+
+    class FakeGithubClient:
+        """Fake GitHub client that records branch cleanup operations."""
+
+        def __init__(self) -> None:
+            """Initialize fake pull request and ref state."""
+            self.closed_prs: list[int] = []
+            self.deleted_refs: list[str] = []
+            self.open_pulls: list[dict[str, object]] = [
+                {
+                    "number": 10,
+                    "head": {
+                        "ref": "chore/update-aiopnsense-manifest",
+                        "repo": {"full_name": "o/r"},
+                    },
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+                {
+                    "number": 11,
+                    "head": {"ref": "feature/manual", "repo": {"full_name": "o/r"}},
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+            ]
+            self.closed_pulls: list[dict[str, object]] = [
+                {
+                    "number": 8,
+                    "merged_at": "2026-05-28T00:00:00Z",
+                    "head": {
+                        "ref": "chore/update-aiopnsense-manifest",
+                        "repo": {"full_name": "o/r"},
+                    },
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+                {
+                    "number": 7,
+                    "merged_at": None,
+                    "head": {"ref": "chore/update-aiopnsense-old", "repo": {"full_name": "o/r"}},
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+            ]
+
+        def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+            """Return fake pull requests by state."""
+            return self.open_pulls if state == "open" else self.closed_pulls
+
+        def close_pull(self, pull_number: int) -> None:
+            """Record a closed pull request."""
+            self.closed_prs.append(pull_number)
+
+        def delete_ref(self, ref: str) -> None:
+            """Record a deleted git ref."""
+            self.deleted_refs.append(ref)
+
+    client = FakeGithubClient()
+
+    result = cleanup_script.cleanup_update_branches(
+        client=client,
+        repository="o/r",
+        branch="chore/update-aiopnsense-manifest",
+        branch_prefix="chore/update-aiopnsense",
+        label_name="aiopnsense-auto-update",
+        keep_pr_number=None,
+        close_stale_prs=True,
+        delete_stale_branch=True,
+        delete_merged_branches=True,
+    )
+
+    assert client.closed_prs == [10]
+    assert client.deleted_refs == ["heads/chore/update-aiopnsense-manifest"]
+    assert result.closed_prs == [10]
+    assert result.deleted_branches == ["chore/update-aiopnsense-manifest"]
+
+
+def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:
+    """Cleanup script should not delete the branch for the kept update PR."""
+
+    class FakeGithubClient:
+        """Fake GitHub client that includes a current PR and old merged PR."""
+
+        def __init__(self) -> None:
+            """Initialize fake pull request and ref state."""
+            self.deleted_refs: list[str] = []
+            self.open_pulls: list[dict[str, object]] = [
+                {
+                    "number": 12,
+                    "head": {
+                        "ref": "chore/update-aiopnsense-manifest",
+                        "repo": {"full_name": "o/r"},
+                    },
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+            ]
+            self.closed_pulls: list[dict[str, object]] = [
+                {
+                    "number": 8,
+                    "merged_at": "2026-05-28T00:00:00Z",
+                    "head": {
+                        "ref": "chore/update-aiopnsense-manifest",
+                        "repo": {"full_name": "o/r"},
+                    },
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+                {
+                    "number": 6,
+                    "merged_at": "2026-05-20T00:00:00Z",
+                    "head": {"ref": "chore/update-aiopnsense-old", "repo": {"full_name": "o/r"}},
+                    "labels": [{"name": "aiopnsense-auto-update"}],
+                },
+            ]
+
+        def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+            """Return fake pull requests by state."""
+            return self.open_pulls if state == "open" else self.closed_pulls
+
+        def close_pull(self, pull_number: int) -> None:
+            """Fail if the kept pull request would be closed."""
+            raise AssertionError(f"Unexpected close for PR {pull_number}")
+
+        def delete_ref(self, ref: str) -> None:
+            """Record a deleted git ref."""
+            self.deleted_refs.append(ref)
+
+    client = FakeGithubClient()
+
+    result = cleanup_script.cleanup_update_branches(
+        client=client,
+        repository="o/r",
+        branch="chore/update-aiopnsense-manifest",
+        branch_prefix="chore/update-aiopnsense",
+        label_name="aiopnsense-auto-update",
+        keep_pr_number=12,
+        close_stale_prs=True,
+        delete_stale_branch=False,
+        delete_merged_branches=True,
+    )
+
+    assert client.deleted_refs == ["heads/chore/update-aiopnsense-old"]
+    assert result.closed_prs == []
+    assert result.deleted_branches == ["chore/update-aiopnsense-old"]

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -83,6 +83,59 @@ ha = [
     assert '    "aiopnsense==1.0.9",' in pyproject_path.read_text()
 
 
+def test_updater_script_ignores_prerelease_updates(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater script should not treat prereleases as newer stable pins."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.0"]}))
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "aiopnsense==1.0.0",
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="1.0.1rc1",
+    )
+
+    assert result.update_needed is False
+    assert "aiopnsense==1.0.0" in manifest_path.read_text()
+    assert '    "aiopnsense==1.0.0",' in pyproject_path.read_text()
+
+
+def test_updater_script_repairs_pyproject_drift_when_manifest_is_newer(
+    tmp_path: Path,
+    updater_script: ModuleType,
+) -> None:
+    """Updater script should align pyproject to a newer manifest pin."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.10"]}))
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "aiopnsense==1.0.9",
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="1.0.9",
+    )
+
+    assert result.update_needed is True
+    assert "aiopnsense==1.0.10" in manifest_path.read_text()
+    assert '    "aiopnsense==1.0.10",' in pyproject_path.read_text()
+
+
 def test_updater_script_rejects_duplicate_pyproject_pins(
     tmp_path: Path,
     updater_script: ModuleType,

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -154,6 +154,8 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
         ("--delete-merged-branches", "cleans merged workflow-owned branches"),
         ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
         ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
+        ("REPOSITORY: ${{ github.repository }}", "exports repository before shell use"),
+        ('--repository "$REPOSITORY"', "avoids inline repository template expansion"),
     ],
 )
 def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
@@ -161,6 +163,11 @@ def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> No
     del reason
 
     assert needle in _read_update_workflow_surface()
+
+
+def test_workflow_avoids_inline_repository_template_expansion() -> None:
+    """Workflow should not expand the repository context inside shell scripts."""
+    assert '--repository "${{ github.repository }}"' not in WORKFLOW_PATH.read_text()
 
 
 def _read_update_workflow_surface() -> str:
@@ -347,6 +354,39 @@ def test_release_note_script_builds_sanitized_pr_body(
     assert "fixes \\#123 and thanks helper" in body
     assert "Ignored current" not in body
     assert "Ignored prerelease" not in body
+
+
+def test_release_note_script_handles_url_errors(
+    tmp_path: Path,
+    release_notes_script: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Release-note script should report network failures without a traceback."""
+
+    def raise_url_error(**_: object) -> list[dict[str, object]]:
+        """Raise a urlopen-style network failure."""
+        raise release_notes_script.URLError("DNS failure")
+
+    monkeypatch.setattr(release_notes_script, "fetch_releases", raise_url_error)
+
+    result = release_notes_script.main(
+        [
+            "--current-version",
+            "1.0.8",
+            "--pyproject-current-version",
+            "1.0.8",
+            "--latest-version",
+            "1.0.9",
+            "--release-owner",
+            "Snuffy2",
+            "--release-repo",
+            "aiopnsense",
+            "--body-path",
+            str(tmp_path / "body.md"),
+        ],
+    )
+
+    assert result == 1
 
 
 def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -14,6 +14,70 @@ RELEASE_NOTES_SCRIPT_PATH = Path(".github/scripts/build_aiopnsense_release_notes
 CLEANUP_SCRIPT_PATH = Path(".github/scripts/cleanup_aiopnsense_update_branches.py")
 
 
+class FakeCleanupClient:
+    """Fake GitHub cleanup client that records mutating calls."""
+
+    def __init__(
+        self,
+        *,
+        open_pulls: list[dict[str, object]],
+        closed_pulls: list[dict[str, object]],
+        fail_on_close: bool = False,
+    ) -> None:
+        """Initialize fake pull request state.
+
+        Args:
+            open_pulls: Pull requests to return for open PR lookups.
+            closed_pulls: Pull requests to return for closed PR lookups.
+            fail_on_close: Whether closing a PR should fail the test.
+        """
+        self.open_pulls = open_pulls
+        self.closed_pulls = closed_pulls
+        self.fail_on_close = fail_on_close
+        self.closed_prs: list[int] = []
+        self.deleted_refs: list[str] = []
+
+    def list_pulls(self, *, state: str) -> list[dict[str, object]]:
+        """Return fake pull requests by state."""
+        return self.open_pulls if state == "open" else self.closed_pulls
+
+    def close_pull(self, pull_number: int) -> None:
+        """Record or reject a closed pull request."""
+        if self.fail_on_close:
+            raise AssertionError(f"Unexpected close for PR {pull_number}")
+        self.closed_prs.append(pull_number)
+
+    def delete_ref(self, ref: str) -> None:
+        """Record a deleted git ref."""
+        self.deleted_refs.append(ref)
+
+
+def _workflow_pull(
+    *,
+    number: int,
+    ref: str = "chore/update-aiopnsense-manifest",
+    label: str = "aiopnsense-auto-update",
+    merged_at: str | None = None,
+) -> dict[str, object]:
+    """Return a fake workflow pull request object.
+
+    Args:
+        number: Pull request number.
+        ref: Pull request head ref.
+        label: Pull request label name.
+        merged_at: Optional merge timestamp for closed PRs.
+
+    Returns:
+        Fake pull request object shaped like the GitHub REST API response.
+    """
+    return {
+        "number": number,
+        "merged_at": merged_at,
+        "head": {"ref": ref, "repo": {"full_name": "o/r"}},
+        "labels": [{"name": label}],
+    }
+
+
 def _write_pin_files(
     tmp_path: Path,
     *,
@@ -95,13 +159,17 @@ def _load_script(module_name: str, script_path: Path) -> ModuleType:
 def test_workflow_contains_expected_update_logic(needle: str, reason: str) -> None:
     """Workflow should include the expected aiopnsense updater logic."""
     del reason
-    workflow = (
+
+    assert needle in _read_update_workflow_surface()
+
+
+def _read_update_workflow_surface() -> str:
+    """Read workflow and helper surfaces checked by workflow assertions."""
+    return (
         f"{WORKFLOW_PATH.read_text()}\n"
         f"{RELEASE_NOTES_SCRIPT_PATH.read_text()}\n"
         f"{CLEANUP_SCRIPT_PATH.read_text()}"
     )
-
-    assert needle in workflow
 
 
 @pytest.mark.parametrize(
@@ -285,60 +353,16 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
     cleanup_script: ModuleType,
 ) -> None:
     """Cleanup script should close stale PRs and remove workflow-created branches."""
-
-    class FakeGithubClient:
-        """Fake GitHub client that records branch cleanup operations."""
-
-        def __init__(self) -> None:
-            """Initialize fake pull request and ref state."""
-            self.closed_prs: list[int] = []
-            self.deleted_refs: list[str] = []
-            self.open_pulls: list[dict[str, object]] = [
-                {
-                    "number": 10,
-                    "head": {
-                        "ref": "chore/update-aiopnsense-manifest",
-                        "repo": {"full_name": "o/r"},
-                    },
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-                {
-                    "number": 11,
-                    "head": {"ref": "feature/manual", "repo": {"full_name": "o/r"}},
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-            ]
-            self.closed_pulls: list[dict[str, object]] = [
-                {
-                    "number": 8,
-                    "merged_at": "2026-05-28T00:00:00Z",
-                    "head": {
-                        "ref": "chore/update-aiopnsense-manifest",
-                        "repo": {"full_name": "o/r"},
-                    },
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-                {
-                    "number": 7,
-                    "merged_at": None,
-                    "head": {"ref": "chore/update-aiopnsense-old", "repo": {"full_name": "o/r"}},
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-            ]
-
-        def list_pulls(self, *, state: str) -> list[dict[str, object]]:
-            """Return fake pull requests by state."""
-            return self.open_pulls if state == "open" else self.closed_pulls
-
-        def close_pull(self, pull_number: int) -> None:
-            """Record a closed pull request."""
-            self.closed_prs.append(pull_number)
-
-        def delete_ref(self, ref: str) -> None:
-            """Record a deleted git ref."""
-            self.deleted_refs.append(ref)
-
-    client = FakeGithubClient()
+    client = FakeCleanupClient(
+        open_pulls=[
+            _workflow_pull(number=10),
+            _workflow_pull(number=11, ref="feature/manual"),
+        ],
+        closed_pulls=[
+            _workflow_pull(number=8, merged_at="2026-05-28T00:00:00Z"),
+            _workflow_pull(number=7, ref="chore/update-aiopnsense-old"),
+        ],
+    )
 
     result = cleanup_script.cleanup_update_branches(
         client=client,
@@ -360,54 +384,18 @@ def test_cleanup_script_closes_stale_prs_and_deletes_workflow_branches(
 
 def test_cleanup_script_keeps_active_update_branch(cleanup_script: ModuleType) -> None:
     """Cleanup script should not delete the branch for the kept update PR."""
-
-    class FakeGithubClient:
-        """Fake GitHub client that includes a current PR and old merged PR."""
-
-        def __init__(self) -> None:
-            """Initialize fake pull request and ref state."""
-            self.deleted_refs: list[str] = []
-            self.open_pulls: list[dict[str, object]] = [
-                {
-                    "number": 12,
-                    "head": {
-                        "ref": "chore/update-aiopnsense-manifest",
-                        "repo": {"full_name": "o/r"},
-                    },
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-            ]
-            self.closed_pulls: list[dict[str, object]] = [
-                {
-                    "number": 8,
-                    "merged_at": "2026-05-28T00:00:00Z",
-                    "head": {
-                        "ref": "chore/update-aiopnsense-manifest",
-                        "repo": {"full_name": "o/r"},
-                    },
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-                {
-                    "number": 6,
-                    "merged_at": "2026-05-20T00:00:00Z",
-                    "head": {"ref": "chore/update-aiopnsense-old", "repo": {"full_name": "o/r"}},
-                    "labels": [{"name": "aiopnsense-auto-update"}],
-                },
-            ]
-
-        def list_pulls(self, *, state: str) -> list[dict[str, object]]:
-            """Return fake pull requests by state."""
-            return self.open_pulls if state == "open" else self.closed_pulls
-
-        def close_pull(self, pull_number: int) -> None:
-            """Fail if the kept pull request would be closed."""
-            raise AssertionError(f"Unexpected close for PR {pull_number}")
-
-        def delete_ref(self, ref: str) -> None:
-            """Record a deleted git ref."""
-            self.deleted_refs.append(ref)
-
-    client = FakeGithubClient()
+    client = FakeCleanupClient(
+        open_pulls=[_workflow_pull(number=12)],
+        closed_pulls=[
+            _workflow_pull(number=8, merged_at="2026-05-28T00:00:00Z"),
+            _workflow_pull(
+                number=6,
+                ref="chore/update-aiopnsense-old",
+                merged_at="2026-05-20T00:00:00Z",
+            ),
+        ],
+        fail_on_close=True,
+    )
 
     result = cleanup_script.cleanup_update_branches(
         client=client,

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -44,6 +44,14 @@ def test_workflow_treats_missing_stale_branch_as_success() -> None:
     assert "Branch ${branch} was already deleted." in workflow
 
 
+def test_workflow_filters_prerelease_release_notes() -> None:
+    """Workflow should not include prerelease release notes for stable updates."""
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert "function isPrerelease(version)" in workflow
+    assert "!isPrerelease(tagVersion)" in workflow
+
+
 def test_updater_script_updates_manifest_and_pyproject(
     tmp_path: Path, updater_script: ModuleType
 ) -> None:
@@ -108,6 +116,33 @@ ha = [
     assert result.latest == "1.0.0"
     assert "aiopnsense==1.0.0" in manifest_path.read_text()
     assert '    "aiopnsense==1.0.0",' in pyproject_path.read_text()
+
+
+def test_updater_script_updates_prerelease_pin_to_matching_stable(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater script should replace current prerelease pins with stable releases."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.1rc1"]}))
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "aiopnsense==1.0.1rc1",
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="1.0.1",
+    )
+
+    assert result.update_needed is True
+    assert result.latest == "1.0.1"
+    assert "aiopnsense==1.0.1" in manifest_path.read_text()
+    assert '    "aiopnsense==1.0.1",' in pyproject_path.read_text()
 
 
 def test_updater_script_selects_latest_stable_from_pypi_payload(

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -28,6 +28,8 @@ def test_workflow_updates_manifest_and_pyproject_pins() -> None:
     """Workflow should include both aiopnsense dependency pin files in update PRs."""
     workflow = WORKFLOW_PATH.read_text()
 
+    assert "actions/setup-python@v6" in workflow
+    assert "python-version: '3.14'" in workflow
     assert "Automated update of aiopnsense dependency pins." in workflow
     assert "custom_components/opnsense/manifest.json" in workflow
     assert "pyproject.toml" in workflow
@@ -49,7 +51,10 @@ def test_workflow_filters_prerelease_release_notes() -> None:
     workflow = WORKFLOW_PATH.read_text()
 
     assert "function isPrerelease(version)" in workflow
+    assert "function stableVersion(version)" in workflow
+    assert "const currentStable = stableVersion(current);" in workflow
     assert "!isPrerelease(tagVersion)" in workflow
+    assert "compareVersions(tagVersion, currentStable) >= 0" in workflow
 
 
 def test_workflow_neutralizes_release_note_closing_keywords() -> None:

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -65,6 +65,8 @@ def updater_script() -> ModuleType:
         ("pyproject.toml", "updates the local dependency pin"),
         ("pyproject_current", "reports pyproject drift in PR metadata"),
         (str(SCRIPT_PATH), "runs the checked-in updater helper"),
+        ("LATEST_VERSION: ${{ steps.versions.outputs.latest }}", "exports latest pin"),
+        ('--latest-version "$LATEST_VERSION"', "avoids shell template injection"),
         ("status === 422", "handles GitHub missing-reference responses"),
         ('message.includes("Reference does not exist")', "detects stale deleted branches"),
         ("Branch ${branch} was already deleted.", "logs stale branch cleanup"),

--- a/tests/test_update_aiopnsense_workflow.py
+++ b/tests/test_update_aiopnsense_workflow.py
@@ -1,0 +1,108 @@
+"""Tests for the aiopnsense dependency update workflow."""
+
+from importlib import util
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+WORKFLOW_PATH = Path(".github/workflows/update_aiopnsense.yml")
+SCRIPT_PATH = Path(".github/scripts/update_aiopnsense_pins.py")
+
+
+@pytest.fixture
+def updater_script() -> ModuleType:
+    """Load the aiopnsense pin updater script as a test module."""
+    spec = util.spec_from_file_location("update_aiopnsense_pins", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = util.module_from_spec(spec)
+    sys.modules["update_aiopnsense_pins"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_workflow_updates_manifest_and_pyproject_pins() -> None:
+    """Workflow should include both aiopnsense dependency pin files in update PRs."""
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert "Automated update of aiopnsense dependency pins." in workflow
+    assert "custom_components/opnsense/manifest.json" in workflow
+    assert "pyproject.toml" in workflow
+    assert "pyproject_current" in workflow
+    assert str(SCRIPT_PATH) in workflow
+
+
+def test_workflow_treats_missing_stale_branch_as_success() -> None:
+    """Workflow should not fail when GitHub reports an absent branch as a 422."""
+    workflow = WORKFLOW_PATH.read_text()
+
+    assert "status === 422" in workflow
+    assert 'message.includes("Reference does not exist")' in workflow
+    assert "Branch ${branch} was already deleted." in workflow
+
+
+def test_updater_script_updates_manifest_and_pyproject(
+    tmp_path: Path, updater_script: ModuleType
+) -> None:
+    """Updater script should rewrite exactly one pin in each dependency file."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "requirements": [
+                    "xmltodict==0.14.2",
+                    "aiopnsense==1.0.8",
+                ],
+            },
+        ),
+    )
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "aiopnsense==1.0.8",
+    "homeassistant",
+]
+""",
+    )
+
+    result = updater_script.update_pins(
+        manifest_path=manifest_path,
+        pyproject_path=pyproject_path,
+        latest_version="1.0.9",
+    )
+
+    assert result.current == "1.0.8"
+    assert result.pyproject_current == "1.0.8"
+    assert result.latest == "1.0.9"
+    assert result.update_needed is True
+    assert "aiopnsense==1.0.9" in manifest_path.read_text()
+    assert '    "aiopnsense==1.0.9",' in pyproject_path.read_text()
+
+
+def test_updater_script_rejects_duplicate_pyproject_pins(
+    tmp_path: Path,
+    updater_script: ModuleType,
+) -> None:
+    """Updater script should fail clearly when pyproject has ambiguous pins."""
+    manifest_path = tmp_path / "manifest.json"
+    pyproject_path = tmp_path / "pyproject.toml"
+    manifest_path.write_text(json.dumps({"requirements": ["aiopnsense==1.0.8"]}))
+    pyproject_path.write_text(
+        """[dependency-groups]
+ha = [
+    "aiopnsense==1.0.8",
+    "aiopnsense==1.0.9",
+]
+""",
+    )
+
+    with pytest.raises(ValueError, match="Expected exactly one pinned aiopnsense dependency"):
+        updater_script.update_pins(
+            manifest_path=manifest_path,
+            pyproject_path=pyproject_path,
+            latest_version="1.0.10",
+        )


### PR DESCRIPTION
## Summary

Adds a replacement GitHub Actions workflow for keeping the `aiopnsense` dependency pin current across both the Home Assistant integration manifest and `pyproject.toml`.

The workflow now uses a tested Python helper to detect the latest PyPI release, update both dependency files consistently, create or update a single labeled PR with release notes, and clean up stale auto-update PRs when no update is required.

## What Changed

- Added `.github/scripts/update_aiopnsense_pins.py` to read, compare, and update the `aiopnsense==...` pin in `custom_components/opnsense/manifest.json` and `pyproject.toml`.
- Replaced the old manifest-only workflow with `.github/workflows/update_aiopnsense.yml`.
- Included aiopnsense release-note collection for versions between the current and latest pins.
- Configured the workflow to create/update a single `chore/update-aiopnsense-manifest` PR labeled `aiopnsense-auto-update`.
- Added stale PR and stale branch cleanup when no dependency update is needed.
- Added regression coverage for the workflow contents and updater script behavior.

## Why

The existing automation only handled the manifest pin, which could leave the repository's local/test dependency pin out of sync with the integration manifest. Moving the pin update logic into a small tested helper keeps the workflow simpler and makes the consistency checks easier to validate locally.

## Validation

- `./.venv/bin/pytest`
- `./.venv/bin/prek run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated scheduled workflow now detects aiopnsense version drift, creates/update PRs, and can apply pinned updates.
  * Generates sanitized release-note content for update PRs.

* **Chores**
  * Improved branch/PR cleanup for auto-generated update workflows with safer deletion logic.
  * Added module docstring for workflow helper scripts.

* **Tests**
  * Added comprehensive end-to-end and unit tests covering update, release-note generation, and cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Snuffy2/hass-opnsense/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->