### PR TITLE
Add CARP maintenance mode switch

### DIFF
--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -138,13 +138,19 @@ class OPNsenseInterfaceEnabledBinarySensor(OPNsenseBinarySensor):
 
         interface_name = key_parts[1]
         interface = dict_get(state, f"interfaces.{interface_name}", {})
-        if not isinstance(interface, Mapping) or interface.get("enabled") is None:
+        if not isinstance(interface, Mapping):
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        enabled = coerce_bool(interface.get("enabled"))
+        if enabled is None:
             self._available = False
             self.async_write_ha_state()
             return
 
         self._available = True
-        self._attr_is_on = coerce_bool(interface.get("enabled"))
+        self._attr_is_on = enabled
         self._attr_extra_state_attributes = {}
         for attr in ("interface", "device", "ipv4", "ipv6", "mac"):
             if attr in interface and (interface[attr] or isinstance(interface[attr], bool)):

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -39,19 +39,24 @@ def is_private_ip(url: str) -> bool:
         return ip_obj.is_private
 
 
-def coerce_bool(value: Any) -> bool:
+def coerce_bool(value: Any) -> bool | None:
     """Normalize values that may represent booleans.
 
     Args:
         value: Arbitrary state value returned by backend APIs.
 
     Returns:
-        bool: Parsed boolean interpretation for common numeric/string variants.
+        bool | None: Parsed boolean interpretation for common numeric/string variants.
+            Returns ``None`` when the value is missing or not bool-like.
     """
     if isinstance(value, bool):
         return value
     if isinstance(value, int | float):
         return value != 0
     if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return False
+        normalized_value = value.strip().lower()
+        if normalized_value in {"1", "true", "yes", "on"}:
+            return True
+        if normalized_value in {"0", "false", "no", "off"}:
+            return False
+    return None

--- a/custom_components/opnsense/manifest.json
+++ b/custom_components/opnsense/manifest.json
@@ -13,7 +13,7 @@
   "requirements": [
     "python-dateutil",
     "awesomeversion",
-    "aiopnsense==1.0.11"
+    "aiopnsense==1.0.10"
   ],
   "version": "v0.7.0"
 }

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -842,6 +842,8 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode on."""
+        if self.delay_update:
+            return
         if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
             return
         await self._async_refresh_carp_state()
@@ -858,6 +860,8 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode off."""
+        if self.delay_update:
+            return
         if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
             return
         await self._async_refresh_carp_state()

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -821,26 +821,6 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
             return None
         return status_summary
 
-    @staticmethod
-    def _is_trustworthy_maintenance_mode(maintenance_mode: Any) -> bool:
-        """Check if the maintenance mode value can be trusted as a boolean state."""
-        if maintenance_mode is None:
-            return False
-        if isinstance(maintenance_mode, bool | int | float):
-            return True
-        if not isinstance(maintenance_mode, str):
-            return False
-        return maintenance_mode.strip().lower() in {
-            "0",
-            "1",
-            "true",
-            "false",
-            "yes",
-            "no",
-            "on",
-            "off",
-        }
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update for the CARP maintenance switch."""
@@ -854,16 +834,16 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
             return
 
         state = status_summary.get("state")
-        maintenance_mode = status_summary.get("maintenance_mode")
-        if (
-            isinstance(state, str) and state.lower() in {"unknown", "unavailable"}
-        ) or not self._is_trustworthy_maintenance_mode(maintenance_mode):
+        maintenance_mode = coerce_bool(status_summary.get("maintenance_mode"))
+        if (isinstance(state, str) and state.lower() in {"unknown", "unavailable"}) or (
+            maintenance_mode is None
+        ):
             self._available = False
             self._attr_is_on = False
             self.async_write_ha_state()
             return
 
-        self._attr_is_on = coerce_bool(maintenance_mode)
+        self._attr_is_on = maintenance_mode
         self._available = True
         self._attr_extra_state_attributes = {
             "state": status_summary.get("state"),

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -834,13 +834,18 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
         }
         self.async_write_ha_state()
 
+    async def _async_refresh_carp_state(self) -> None:
+        """Refresh CARP state before deciding whether the toggle endpoint is needed."""
+        self.delay_update = False
+        await self.coordinator.async_request_refresh()
+        self._handle_coordinator_update()
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode on."""
-        if (
-            self.is_on
-            or self._client is None
-            or not hasattr(self._client, "toggle_carp_maintenance_mode")
-        ):
+        if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
+            return
+        await self._async_refresh_carp_state()
+        if self.is_on:
             return
         result = await self._client.toggle_carp_maintenance_mode()
         if result:
@@ -853,11 +858,10 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode off."""
-        if (
-            not self.is_on
-            or self._client is None
-            or not hasattr(self._client, "toggle_carp_maintenance_mode")
-        ):
+        if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
+            return
+        await self._async_refresh_carp_state()
+        if not self.is_on:
             return
         result = await self._client.toggle_carp_maintenance_mode()
         if result:

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -675,8 +675,8 @@ async def async_setup_entry(
                 ValueError,
             ) as e:
                 _LOGGER.error(
-                    "Error comparing firmware version %s when determining creating CARP "
-                    "maintenance switch. %s: %s",
+                    "Error comparing firmware version %s when determining whether to create "
+                    "CARP maintenance switch. %s: %s",
                     firmware,
                     type(e).__name__,
                     e,

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -15,6 +15,7 @@ from .const import (
     ATTR_NAT_OUTBOUND,
     ATTR_NAT_PORT_FORWARD,
     ATTR_UNBOUND_BLOCKLIST,
+    CONF_SYNC_CARP,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_SYNC_SERVICES,
     CONF_SYNC_UNBOUND,
@@ -24,7 +25,7 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
-from .helpers import dict_get
+from .helpers import coerce_bool, dict_get
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -260,6 +261,41 @@ async def _compile_vpn_switches(
                 )
                 entities.append(entity)
     return entities
+
+
+async def _compile_carp_maintenance_switch(
+    config_entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    state: MutableMapping[str, Any],
+) -> list:
+    """Compile the CARP persistent maintenance mode switch.
+
+    Args:
+        config_entry: The Home Assistant config entry.
+        coordinator: The data update coordinator.
+        state: The current state data from OPNsense.
+
+    Returns:
+        list: A list containing one OPNsenseCarpMaintenanceSwitch entity when
+            CARP summary data is available.
+    """
+    status_summary = dict_get(state, "carp.status_summary")
+    if not isinstance(status_summary, MutableMapping):
+        return []
+
+    return [
+        OPNsenseCarpMaintenanceSwitch(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=SwitchEntityDescription(
+                key="carp.maintenance_mode",
+                name="CARP Persistent Maintenance Mode",
+                icon="mdi:server-network",
+                device_class=SwitchDeviceClass.SWITCH,
+                entity_registry_enabled_default=False,
+            ),
+        )
+    ]
 
 
 async def _compile_static_unbound_switch_legacy(
@@ -623,6 +659,28 @@ async def async_setup_entry(
         entities.extend(await _compile_service_switches(config_entry, coordinator, state))
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
+    if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
+        firmware = state.get("host_firmware_version")
+        if firmware:
+            try:
+                if awesomeversion.AwesomeVersion(firmware) >= awesomeversion.AwesomeVersion(
+                    "26.1.1"
+                ):
+                    entities.extend(
+                        await _compile_carp_maintenance_switch(config_entry, coordinator, state)
+                    )
+            except (
+                awesomeversion.exceptions.AwesomeVersionCompareException,
+                TypeError,
+                ValueError,
+            ) as e:
+                _LOGGER.error(
+                    "Error comparing firmware version %s when determining creating CARP "
+                    "maintenance switch. %s: %s",
+                    firmware,
+                    type(e).__name__,
+                    e,
+                )
     if config.get(CONF_SYNC_UNBOUND, DEFAULT_SYNC_OPTION_VALUE):
         firmware = state.get("host_firmware_version")
         if firmware:
@@ -730,6 +788,92 @@ class OPNsenseSwitch(OPNsenseEntity, SwitchEntity):
         self._delay_update_remove = async_call_later(
             hass=self.hass, delay=self._delay_seconds, action=_clear
         )
+
+
+class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
+    """Class for the CARP persistent maintenance mode switch."""
+
+    def _opnsense_get_status_summary(self) -> MutableMapping[str, Any] | None:
+        """Get the CARP status summary from the coordinator.
+
+        Returns:
+            MutableMapping[str, Any] | None: The CARP status summary if available.
+        """
+        state: dict[str, Any] = self.coordinator.data
+        if not isinstance(state, MutableMapping):
+            return None
+        status_summary = dict_get(state, "carp.status_summary")
+        if not isinstance(status_summary, MutableMapping):
+            return None
+        return status_summary
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator update for the CARP maintenance switch."""
+        if self.delay_update:
+            _LOGGER.debug("Skipping coordinator update for CARP switch %s due to delay", self.name)
+            return
+        status_summary = self._opnsense_get_status_summary()
+        if status_summary is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
+
+        self._attr_is_on = coerce_bool(status_summary.get("maintenance_mode"))
+        self._available = True
+        self._attr_extra_state_attributes = {
+            "state": status_summary.get("state"),
+            "enabled": status_summary.get("enabled"),
+            "demotion": status_summary.get("demotion"),
+            "status_message": status_summary.get("status_message"),
+            "vip_count": status_summary.get("vip_count"),
+            "master_count": status_summary.get("master_count"),
+            "backup_count": status_summary.get("backup_count"),
+            "other_count": status_summary.get("other_count"),
+            "interfaces": status_summary.get("interfaces"),
+        }
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn CARP persistent maintenance mode on."""
+        if (
+            self.is_on
+            or self._client is None
+            or not hasattr(self._client, "toggle_carp_maintenance_mode")
+        ):
+            return
+        result = await self._client.toggle_carp_maintenance_mode()
+        if result:
+            _LOGGER.info("Turned on CARP persistent maintenance mode")
+            self._attr_is_on = True
+            self.async_write_ha_state()
+            self.delay_update = True
+        else:
+            _LOGGER.error("Failed to turn on CARP persistent maintenance mode")
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn CARP persistent maintenance mode off."""
+        if (
+            not self.is_on
+            or self._client is None
+            or not hasattr(self._client, "toggle_carp_maintenance_mode")
+        ):
+            return
+        result = await self._client.toggle_carp_maintenance_mode()
+        if result:
+            _LOGGER.info("Turned off CARP persistent maintenance mode")
+            self._attr_is_on = False
+            self.async_write_ha_state()
+            self.delay_update = True
+        else:
+            _LOGGER.error("Failed to turn off CARP persistent maintenance mode")
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon for the entity."""
+        if self.available and self.is_on:
+            return "mdi:server-network-off"
+        return super().icon
 
 
 class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -793,6 +793,20 @@ class OPNsenseSwitch(OPNsenseEntity, SwitchEntity):
 class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
     """Class for the CARP persistent maintenance mode switch."""
 
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: OPNsenseDataUpdateCoordinator,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize CARP maintenance switch state."""
+        super().__init__(
+            config_entry=config_entry,
+            coordinator=coordinator,
+            entity_description=entity_description,
+        )
+        self._toggle_in_flight: bool = False
+
     def _opnsense_get_status_summary(self) -> MutableMapping[str, Any] | None:
         """Get the CARP status summary from the coordinator.
 
@@ -807,6 +821,26 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
             return None
         return status_summary
 
+    @staticmethod
+    def _is_trustworthy_maintenance_mode(maintenance_mode: Any) -> bool:
+        """Check if the maintenance mode value can be trusted as a boolean state."""
+        if maintenance_mode is None:
+            return False
+        if isinstance(maintenance_mode, bool | int | float):
+            return True
+        if not isinstance(maintenance_mode, str):
+            return False
+        return maintenance_mode.strip().lower() in {
+            "0",
+            "1",
+            "true",
+            "false",
+            "yes",
+            "no",
+            "on",
+            "off",
+        }
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update for the CARP maintenance switch."""
@@ -819,7 +853,17 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
             self.async_write_ha_state()
             return
 
-        self._attr_is_on = coerce_bool(status_summary.get("maintenance_mode"))
+        state = status_summary.get("state")
+        maintenance_mode = status_summary.get("maintenance_mode")
+        if (
+            isinstance(state, str) and state.lower() in {"unknown", "unavailable"}
+        ) or not self._is_trustworthy_maintenance_mode(maintenance_mode):
+            self._available = False
+            self._attr_is_on = False
+            self.async_write_ha_state()
+            return
+
+        self._attr_is_on = coerce_bool(maintenance_mode)
         self._available = True
         self._attr_extra_state_attributes = {
             "state": status_summary.get("state"),
@@ -842,39 +886,51 @@ class OPNsenseCarpMaintenanceSwitch(OPNsenseSwitch):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode on."""
+        if self._toggle_in_flight:
+            return
         if self.delay_update:
             return
         if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
             return
-        await self._async_refresh_carp_state()
-        if self.is_on:
-            return
-        result = await self._client.toggle_carp_maintenance_mode()
-        if result:
-            _LOGGER.info("Turned on CARP persistent maintenance mode")
-            self._attr_is_on = True
-            self.async_write_ha_state()
-            self.delay_update = True
-        else:
-            _LOGGER.error("Failed to turn on CARP persistent maintenance mode")
+        self._toggle_in_flight = True
+        try:
+            await self._async_refresh_carp_state()
+            if not self.available or self.is_on:
+                return
+            result = await self._client.toggle_carp_maintenance_mode()
+            if result:
+                _LOGGER.info("Turned on CARP persistent maintenance mode")
+                self._attr_is_on = True
+                self.async_write_ha_state()
+                self.delay_update = True
+            else:
+                _LOGGER.error("Failed to turn on CARP persistent maintenance mode")
+        finally:
+            self._toggle_in_flight = False
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn CARP persistent maintenance mode off."""
+        if self._toggle_in_flight:
+            return
         if self.delay_update:
             return
         if self._client is None or not hasattr(self._client, "toggle_carp_maintenance_mode"):
             return
-        await self._async_refresh_carp_state()
-        if not self.is_on:
-            return
-        result = await self._client.toggle_carp_maintenance_mode()
-        if result:
-            _LOGGER.info("Turned off CARP persistent maintenance mode")
-            self._attr_is_on = False
-            self.async_write_ha_state()
-            self.delay_update = True
-        else:
-            _LOGGER.error("Failed to turn off CARP persistent maintenance mode")
+        self._toggle_in_flight = True
+        try:
+            await self._async_refresh_carp_state()
+            if not self.available or not self.is_on:
+                return
+            result = await self._client.toggle_carp_maintenance_mode()
+            if result:
+                _LOGGER.info("Turned off CARP persistent maintenance mode")
+                self._attr_is_on = False
+                self.async_write_ha_state()
+                self.delay_update = True
+            else:
+                _LOGGER.error("Failed to turn off CARP persistent maintenance mode")
+        finally:
+            self._toggle_in_flight = False
 
     @property
     def icon(self) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ version = { attr = "custom_components.opnsense.const.VERSION" }
 
 [dependency-groups]
 ha = [
-    "aiopnsense==1.0.11",
+    "aiopnsense==1.0.10",
     "homeassistant",
 ]
 lint = [

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,45 @@
+"""Unit tests for shared OPNsense integration helpers."""
+
+from typing import Any
+
+import pytest
+
+from custom_components.opnsense.helpers import coerce_bool
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(True, True, id="true"),
+        pytest.param(False, False, id="false"),
+        pytest.param(1, True, id="int-one"),
+        pytest.param(0, False, id="int-zero"),
+        pytest.param(2.5, True, id="float-non-zero"),
+        pytest.param(0.0, False, id="float-zero"),
+        pytest.param("1", True, id="string-one"),
+        pytest.param("0", False, id="string-zero"),
+        pytest.param("true", True, id="string-true"),
+        pytest.param("false", False, id="string-false"),
+        pytest.param("yes", True, id="string-yes"),
+        pytest.param("no", False, id="string-no"),
+        pytest.param("on", True, id="string-on"),
+        pytest.param("off", False, id="string-off"),
+    ],
+)
+def test_coerce_bool_parses_bool_like_values(value: Any, expected: bool) -> None:
+    """Verify bool-like values are converted to booleans."""
+    assert coerce_bool(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("", id="empty-string"),
+        pytest.param("maybe", id="unknown-string"),
+        pytest.param(None, id="none"),
+        pytest.param(object(), id="object"),
+    ],
+)
+def test_coerce_bool_returns_none_for_unknown_values(value: Any) -> None:
+    """Verify unknown values are not coerced into a boolean."""
+    assert coerce_bool(value) is None

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -58,6 +58,7 @@ def make_coord(data: Any) -> Any:
     """Create a MagicMock that behaves like an OPNsenseDataUpdateCoordinator for tests."""
     m = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     m.data = data
+    m.async_request_refresh = AsyncMock()
     return m
 
 
@@ -197,6 +198,90 @@ async def test_carp_maintenance_switch_state_and_toggle(
     entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
     assert entity.is_on is False
     assert entity.delay_update is True
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_turn_on_refreshes_before_toggle(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance turn on should not toggle if refreshed state is already on."""
+    state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
+    coordinator = make_coord(state)
+
+    async def refresh_state() -> None:
+        """Set refreshed CARP maintenance state."""
+        state["carp"]["status_summary"]["maintenance_mode"] = True
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_state)
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseCarpMaintenanceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(
+            key="carp.maintenance_mode",
+            name="CARP Persistent Maintenance Mode",
+        ),
+    )
+    entity.hass = ph_hass
+    entity.entity_id = "switch.carp_maintenance_mode"
+    stub_async_write_ha_state(entity)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
+    entity._handle_coordinator_update()
+
+    await entity.async_turn_on()
+
+    coordinator.async_request_refresh.assert_awaited_once()
+    entity._client.toggle_carp_maintenance_mode.assert_not_awaited()
+    assert entity.is_on is True
+    assert entity.delay_update is False
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_turn_off_refreshes_before_toggle(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance turn off should not toggle if refreshed state is already off."""
+    state = {"carp": {"status_summary": {"maintenance_mode": True, "enabled": True}}}
+    coordinator = make_coord(state)
+
+    async def refresh_state() -> None:
+        """Set refreshed CARP maintenance state."""
+        state["carp"]["status_summary"]["maintenance_mode"] = False
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_state)
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseCarpMaintenanceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(
+            key="carp.maintenance_mode",
+            name="CARP Persistent Maintenance Mode",
+        ),
+    )
+    entity.hass = ph_hass
+    entity.entity_id = "switch.carp_maintenance_mode"
+    stub_async_write_ha_state(entity)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
+    entity._handle_coordinator_update()
+
+    await entity.async_turn_off()
+
+    coordinator.async_request_refresh.assert_awaited_once()
+    entity._client.toggle_carp_maintenance_mode.assert_not_awaited()
+    assert entity.is_on is False
+    assert entity.delay_update is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -366,6 +366,63 @@ async def test_carp_maintenance_switch_ignores_service_calls_during_delay(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("method_name", "initial_state"), [("async_turn_on", False), ("async_turn_off", True)]
+)
+async def test_carp_maintenance_switch_serializes_overlapping_requests(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    method_name: str,
+    initial_state: bool,
+) -> None:
+    """CARP maintenance toggles should only execute one backend call at a time."""
+    state = {"carp": {"status_summary": {"maintenance_mode": initial_state, "enabled": True}}}
+    coordinator = make_coord(state)
+    refresh_gate = asyncio.Event()
+    refresh_started = asyncio.Event()
+    toggle_gate = asyncio.Event()
+    toggle_started = asyncio.Event()
+    refresh_calls = 0
+
+    async def refresh_side_effect() -> None:
+        """Pause refresh so both toggle paths overlap."""
+        nonlocal refresh_calls
+        refresh_calls += 1
+        refresh_started.set()
+        if refresh_calls <= 2:
+            await refresh_gate.wait()
+
+    toggle_calls = 0
+
+    async def toggle_side_effect() -> bool:
+        """Pause toggles so both requests can overlap before completion."""
+        nonlocal toggle_calls
+        toggle_calls += 1
+        toggle_started.set()
+        if toggle_calls <= 2:
+            await toggle_gate.wait()
+        return True
+
+    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_side_effect)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(side_effect=toggle_side_effect)
+
+    first_task = asyncio.create_task(getattr(entity, method_name)())
+    second_task = asyncio.create_task(getattr(entity, method_name)())
+
+    await refresh_started.wait()
+    refresh_gate.set()
+    await toggle_started.wait()
+    toggle_gate.set()
+    await first_task
+    await second_task
+
+    coordinator.async_request_refresh.assert_awaited_once()
+    entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("method_name", "maintenance_mode"),
     [
         pytest.param("async_turn_on", False, id="turn-on-no-client"),
@@ -471,6 +528,43 @@ async def test_carp_maintenance_switch_unavailable_without_mapping_state(
     entity._handle_coordinator_update()
 
     assert entity.available is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("maintenance_state", "maintenance_mode"),
+    [
+        pytest.param("unknown", False, id="unknown-state"),
+        pytest.param("unavailable", False, id="unavailable-state"),
+        pytest.param("ok", None, id="missing-maintenance-mode"),
+        pytest.param("ok", "maybe", id="untrusted-maintenance-mode"),
+        pytest.param("ok", object(), id="unsupported-maintenance-mode"),
+    ],
+)
+async def test_carp_maintenance_switch_unavailable_for_untrusted_summary(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    maintenance_state: str,
+    maintenance_mode: Any,
+) -> None:
+    """CARP maintenance switch should be unavailable when summary state is unreliable."""
+    coordinator = make_coord(
+        {
+            "carp": {
+                "status_summary": {
+                    "maintenance_mode": maintenance_mode,
+                    "state": maintenance_state,
+                    "enabled": True,
+                }
+            }
+        }
+    )
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+
+    entity._handle_coordinator_update()
+
+    assert entity.available is False
+    assert entity.is_on is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -21,6 +21,7 @@ from custom_components.opnsense.const import (
     ATTR_NAT_OUTBOUND,
     ATTR_NAT_PORT_FORWARD,
     CONF_DEVICE_UNIQUE_ID,
+    CONF_SYNC_CARP,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_SYNC_SERVICES,
     CONF_SYNC_UNBOUND,
@@ -29,12 +30,14 @@ from custom_components.opnsense.const import (
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.switch import (
+    OPNsenseCarpMaintenanceSwitch,
     OPNsenseFilterSwitchLegacy,
     OPNsenseFirewallRuleSwitch,
     OPNsenseNATRuleSwitch,
     OPNsenseNatSwitchLegacy,
     OPNsenseServiceSwitch,
     OPNsenseVPNSwitch,
+    _compile_carp_maintenance_switch,
     _compile_filter_switches_legacy,
     _compile_firewall_rules_switches,
     _compile_nat_destination_rules_switches,
@@ -56,6 +59,171 @@ def make_coord(data: Any) -> Any:
     m = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     m.data = data
     return m
+
+
+@pytest.mark.asyncio
+async def test_compile_carp_maintenance_switch(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should compile when CARP summary data exists."""
+    state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    entities = await _compile_carp_maintenance_switch(config_entry, coordinator, state)
+
+    assert len(entities) == 1
+    assert isinstance(entities[0], OPNsenseCarpMaintenanceSwitch)
+    assert entities[0].entity_description.key == "carp.maintenance_mode"
+    assert entities[0].entity_description.entity_registry_enabled_default is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_data", "expected_count"),
+    [
+        pytest.param(
+            {},
+            1,
+            id="default-carp-sync-enabled",
+        ),
+        pytest.param(
+            {CONF_SYNC_CARP: True},
+            1,
+            id="carp-sync-enabled",
+        ),
+        pytest.param(
+            {CONF_SYNC_CARP: False},
+            0,
+            id="carp-sync-disabled",
+        ),
+    ],
+)
+async def test_async_setup_entry_carp_maintenance_switch_sync_gate(
+    coordinator: MagicMock,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    config_data: dict[str, Any],
+    expected_count: int,
+) -> None:
+    """CARP maintenance switch should follow the CARP sync flag."""
+    calls: dict[str, list[Any]] = {}
+
+    def fake_add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        calls["entities"] = list(entities)
+
+    coordinator.data = {
+        "carp": {"status_summary": {"maintenance_mode": False, "enabled": True}},
+        "host_firmware_version": "26.1.1",
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_UNBOUND: False,
+            **config_data,
+        },
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    await switch_mod.async_setup_entry(
+        ph_hass, config_entry, cast("AddEntitiesCallback", fake_add_entities)
+    )
+
+    carp_switches = [
+        entity
+        for entity in calls.get("entities", [])
+        if isinstance(entity, OPNsenseCarpMaintenanceSwitch)
+    ]
+    assert len(carp_switches) == expected_count
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_state_and_toggle(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should mirror summary state and toggle maintenance mode."""
+    state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
+    coordinator = make_coord(state)
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseCarpMaintenanceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(
+            key="carp.maintenance_mode",
+            name="CARP Persistent Maintenance Mode",
+        ),
+    )
+    entity.hass = ph_hass
+    entity.entity_id = "switch.carp_maintenance_mode"
+    stub_async_write_ha_state(entity)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
+
+    entity._handle_coordinator_update()
+    assert entity.available is True
+    assert entity.is_on is False
+
+    await entity.async_turn_on()
+
+    entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
+    assert entity.is_on is True
+    assert entity.delay_update is True
+
+    entity.delay_update = False
+    state["carp"]["status_summary"]["maintenance_mode"] = True
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
+
+    await entity.async_turn_off()
+
+    entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
+    assert entity.is_on is False
+    assert entity.delay_update is True
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_unavailable_without_summary(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should become unavailable without summary data."""
+    coordinator = make_coord({"carp": {}})
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseCarpMaintenanceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(
+            key="carp.maintenance_mode",
+            name="CARP Persistent Maintenance Mode",
+        ),
+    )
+    entity.entity_id = "switch.carp_maintenance_mode"
+    stub_async_write_ha_state(entity)
+
+    entity._handle_coordinator_update()
+
+    assert entity.available is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -327,6 +327,45 @@ async def test_carp_maintenance_switch_refreshes_before_toggle(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("first_method_name", "second_method_name", "initial_state", "optimistic_state"),
+    [
+        pytest.param("async_turn_on", "async_turn_on", False, True, id="turn-on-then-turn-on"),
+        pytest.param("async_turn_on", "async_turn_off", False, True, id="turn-on-then-turn-off"),
+        pytest.param("async_turn_off", "async_turn_off", True, False, id="turn-off-then-turn-off"),
+        pytest.param("async_turn_off", "async_turn_on", True, False, id="turn-off-then-turn-on"),
+    ],
+)
+async def test_carp_maintenance_switch_ignores_service_calls_during_delay(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    first_method_name: str,
+    second_method_name: str,
+    initial_state: bool,
+    optimistic_state: bool,
+) -> None:
+    """CARP maintenance should not toggle again while optimistic state is pending."""
+    state = {"carp": {"status_summary": {"maintenance_mode": initial_state, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
+    entity._handle_coordinator_update()
+
+    await getattr(entity, first_method_name)()
+    assert entity.is_on is optimistic_state
+    assert entity.delay_update is True
+
+    coordinator.async_request_refresh.reset_mock()
+    await getattr(entity, second_method_name)()
+
+    coordinator.async_request_refresh.assert_not_awaited()
+    entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
+    assert entity.is_on is optimistic_state
+    assert entity.delay_update is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("method_name", "maintenance_mode"),
     [
         pytest.param("async_turn_on", False, id="turn-on-no-client"),

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -62,17 +62,27 @@ def make_coord(data: Any) -> Any:
     return m
 
 
+def make_carp_config_entry(
+    make_config_entry: Callable[..., MockConfigEntry],
+    coordinator: Any,
+    data: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Create a config entry with CARP test coordinator runtime data."""
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1", **(data or {})},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    return config_entry
+
+
 def make_carp_maintenance_switch(
     ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],
     coordinator: Any,
 ) -> OPNsenseCarpMaintenanceSwitch:
     """Create a CARP maintenance switch entity for tests."""
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    config_entry = make_carp_config_entry(make_config_entry, coordinator)
     entity = OPNsenseCarpMaintenanceSwitch(
         config_entry=config_entry,
         coordinator=coordinator,
@@ -87,6 +97,52 @@ def make_carp_maintenance_switch(
     return entity
 
 
+async def collect_setup_carp_switches(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    coordinator: Any,
+    *,
+    config_data: dict[str, Any] | None = None,
+    firmware: Any = "26.1.1",
+) -> list[OPNsenseCarpMaintenanceSwitch]:
+    """Run switch setup and return CARP maintenance switches."""
+    calls: dict[str, list[Any]] = {}
+
+    def fake_add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        calls["entities"] = list(entities)
+
+    coordinator.data = {
+        "carp": {"status_summary": {"maintenance_mode": False, "enabled": True}},
+        "host_firmware_version": firmware,
+    }
+    config_entry = make_carp_config_entry(
+        make_config_entry,
+        coordinator,
+        {
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_UNBOUND: False,
+            **(config_data or {}),
+        },
+    )
+
+    await switch_mod.async_setup_entry(
+        ph_hass, config_entry, cast("AddEntitiesCallback", fake_add_entities)
+    )
+    return [
+        entity
+        for entity in calls.get("entities", [])
+        if isinstance(entity, OPNsenseCarpMaintenanceSwitch)
+    ]
+
+
 @pytest.mark.asyncio
 async def test_compile_carp_maintenance_switch(
     coordinator: MagicMock,
@@ -94,11 +150,7 @@ async def test_compile_carp_maintenance_switch(
 ) -> None:
     """CARP maintenance switch should compile when CARP summary data exists."""
     state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    config_entry = make_carp_config_entry(make_config_entry, coordinator)
 
     entities = await _compile_carp_maintenance_switch(config_entry, coordinator, state)
 
@@ -114,11 +166,7 @@ async def test_compile_carp_maintenance_switch_skips_missing_summary(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """CARP maintenance switch should not compile without CARP summary data."""
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    config_entry = make_carp_config_entry(make_config_entry, coordinator)
 
     entities = await _compile_carp_maintenance_switch(config_entry, coordinator, {"carp": {}})
 
@@ -154,43 +202,12 @@ async def test_async_setup_entry_carp_maintenance_switch_sync_gate(
     expected_count: int,
 ) -> None:
     """CARP maintenance switch should follow the CARP sync flag."""
-    calls: dict[str, list[Any]] = {}
-
-    def fake_add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
-        """Capture switch entities emitted by setup.
-
-        Args:
-            entities: Switch entities emitted by setup.
-            _update_before_add: Whether HA should refresh entities before adding them.
-        """
-        calls["entities"] = list(entities)
-
-    coordinator.data = {
-        "carp": {"status_summary": {"maintenance_mode": False, "enabled": True}},
-        "host_firmware_version": "26.1.1",
-    }
-    config_entry = make_config_entry(
-        data={
-            CONF_DEVICE_UNIQUE_ID: "dev1",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_UNBOUND: False,
-            **config_data,
-        },
-        title="OPNsenseTest",
+    carp_switches = await collect_setup_carp_switches(
+        ph_hass,
+        make_config_entry,
+        coordinator,
+        config_data=config_data,
     )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    await switch_mod.async_setup_entry(
-        ph_hass, config_entry, cast("AddEntitiesCallback", fake_add_entities)
-    )
-
-    carp_switches = [
-        entity
-        for entity in calls.get("entities", [])
-        if isinstance(entity, OPNsenseCarpMaintenanceSwitch)
-    ]
     assert len(carp_switches) == expected_count
 
 
@@ -210,42 +227,12 @@ async def test_async_setup_entry_carp_maintenance_switch_firmware_gate(
     expected_count: int,
 ) -> None:
     """CARP maintenance switch should only compile for supported firmware."""
-    calls: dict[str, list[Any]] = {}
-
-    def fake_add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
-        """Capture switch entities emitted by setup.
-
-        Args:
-            entities: Switch entities emitted by setup.
-            _update_before_add: Whether HA should refresh entities before adding them.
-        """
-        calls["entities"] = list(entities)
-
-    coordinator.data = {
-        "carp": {"status_summary": {"maintenance_mode": False, "enabled": True}},
-        "host_firmware_version": firmware,
-    }
-    config_entry = make_config_entry(
-        data={
-            CONF_DEVICE_UNIQUE_ID: "dev1",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_UNBOUND: False,
-        },
-        title="OPNsenseTest",
+    carp_switches = await collect_setup_carp_switches(
+        ph_hass,
+        make_config_entry,
+        coordinator,
+        firmware=firmware,
     )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    await switch_mod.async_setup_entry(
-        ph_hass, config_entry, cast("AddEntitiesCallback", fake_add_entities)
-    )
-
-    carp_switches = [
-        entity
-        for entity in calls.get("entities", [])
-        if isinstance(entity, OPNsenseCarpMaintenanceSwitch)
-    ]
     assert len(carp_switches) == expected_count
 
 
@@ -257,22 +244,7 @@ async def test_carp_maintenance_switch_state_and_toggle(
     """CARP maintenance switch should mirror summary state and toggle maintenance mode."""
     state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
     coordinator = make_coord(state)
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseCarpMaintenanceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(
-            key="carp.maintenance_mode",
-            name="CARP Persistent Maintenance Mode",
-        ),
-    )
-    entity.hass = ph_hass
-    entity.entity_id = "switch.carp_maintenance_mode"
-    stub_async_write_ha_state(entity)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
     entity._client = MagicMock()
     entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
 
@@ -317,86 +289,39 @@ async def test_carp_maintenance_switch_ignores_updates_during_delay(
 
 
 @pytest.mark.asyncio
-async def test_carp_maintenance_switch_turn_on_refreshes_before_toggle(
+@pytest.mark.parametrize(
+    ("method_name", "initial_state", "refreshed_state"),
+    [
+        pytest.param("async_turn_on", False, True, id="turn-on-already-on-after-refresh"),
+        pytest.param("async_turn_off", True, False, id="turn-off-already-off-after-refresh"),
+    ],
+)
+async def test_carp_maintenance_switch_refreshes_before_toggle(
     ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],
+    method_name: str,
+    initial_state: bool,
+    refreshed_state: bool,
 ) -> None:
-    """CARP maintenance turn on should not toggle if refreshed state is already on."""
-    state = {"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}
+    """CARP maintenance should not toggle when refreshed state already matches."""
+    state = {"carp": {"status_summary": {"maintenance_mode": initial_state, "enabled": True}}}
     coordinator = make_coord(state)
 
     async def refresh_state() -> None:
         """Set refreshed CARP maintenance state."""
-        state["carp"]["status_summary"]["maintenance_mode"] = True
+        state["carp"]["status_summary"]["maintenance_mode"] = refreshed_state
 
     coordinator.async_request_refresh = AsyncMock(side_effect=refresh_state)
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseCarpMaintenanceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(
-            key="carp.maintenance_mode",
-            name="CARP Persistent Maintenance Mode",
-        ),
-    )
-    entity.hass = ph_hass
-    entity.entity_id = "switch.carp_maintenance_mode"
-    stub_async_write_ha_state(entity)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
     entity._client = MagicMock()
     entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
     entity._handle_coordinator_update()
 
-    await entity.async_turn_on()
+    await getattr(entity, method_name)()
 
     coordinator.async_request_refresh.assert_awaited_once()
     entity._client.toggle_carp_maintenance_mode.assert_not_awaited()
-    assert entity.is_on is True
-    assert entity.delay_update is False
-
-
-@pytest.mark.asyncio
-async def test_carp_maintenance_switch_turn_off_refreshes_before_toggle(
-    ph_hass: HomeAssistant,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """CARP maintenance turn off should not toggle if refreshed state is already off."""
-    state = {"carp": {"status_summary": {"maintenance_mode": True, "enabled": True}}}
-    coordinator = make_coord(state)
-
-    async def refresh_state() -> None:
-        """Set refreshed CARP maintenance state."""
-        state["carp"]["status_summary"]["maintenance_mode"] = False
-
-    coordinator.async_request_refresh = AsyncMock(side_effect=refresh_state)
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseCarpMaintenanceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(
-            key="carp.maintenance_mode",
-            name="CARP Persistent Maintenance Mode",
-        ),
-    )
-    entity.hass = ph_hass
-    entity.entity_id = "switch.carp_maintenance_mode"
-    stub_async_write_ha_state(entity)
-    entity._client = MagicMock()
-    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=True)
-    entity._handle_coordinator_update()
-
-    await entity.async_turn_off()
-
-    coordinator.async_request_refresh.assert_awaited_once()
-    entity._client.toggle_carp_maintenance_mode.assert_not_awaited()
-    assert entity.is_on is False
+    assert entity.is_on is refreshed_state
     assert entity.delay_update is False
 
 
@@ -483,25 +408,12 @@ async def test_carp_maintenance_switch_failed_toggle_keeps_state(
 
 @pytest.mark.asyncio
 async def test_carp_maintenance_switch_unavailable_without_summary(
+    ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """CARP maintenance switch should become unavailable without summary data."""
     coordinator = make_coord({"carp": {}})
-    config_entry = make_config_entry(
-        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
-        title="OPNsenseTest",
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseCarpMaintenanceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(
-            key="carp.maintenance_mode",
-            name="CARP Persistent Maintenance Mode",
-        ),
-    )
-    entity.entity_id = "switch.carp_maintenance_mode"
-    stub_async_write_ha_state(entity)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
 
     entity._handle_coordinator_update()
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -62,6 +62,31 @@ def make_coord(data: Any) -> Any:
     return m
 
 
+def make_carp_maintenance_switch(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    coordinator: Any,
+) -> OPNsenseCarpMaintenanceSwitch:
+    """Create a CARP maintenance switch entity for tests."""
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    entity = OPNsenseCarpMaintenanceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(
+            key="carp.maintenance_mode",
+            name="CARP Persistent Maintenance Mode",
+        ),
+    )
+    entity.hass = ph_hass
+    entity.entity_id = "switch.carp_maintenance_mode"
+    stub_async_write_ha_state(entity)
+    return entity
+
+
 @pytest.mark.asyncio
 async def test_compile_carp_maintenance_switch(
     coordinator: MagicMock,
@@ -81,6 +106,23 @@ async def test_compile_carp_maintenance_switch(
     assert isinstance(entities[0], OPNsenseCarpMaintenanceSwitch)
     assert entities[0].entity_description.key == "carp.maintenance_mode"
     assert entities[0].entity_description.entity_registry_enabled_default is False
+
+
+@pytest.mark.asyncio
+async def test_compile_carp_maintenance_switch_skips_missing_summary(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should not compile without CARP summary data."""
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    entities = await _compile_carp_maintenance_switch(config_entry, coordinator, {"carp": {}})
+
+    assert entities == []
 
 
 @pytest.mark.asyncio
@@ -153,6 +195,61 @@ async def test_async_setup_entry_carp_maintenance_switch_sync_gate(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("firmware", "expected_count"),
+    [
+        pytest.param("26.1", 0, id="firmware-too-old"),
+        pytest.param(object(), 0, id="invalid-firmware"),
+    ],
+)
+async def test_async_setup_entry_carp_maintenance_switch_firmware_gate(
+    coordinator: MagicMock,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    firmware: Any,
+    expected_count: int,
+) -> None:
+    """CARP maintenance switch should only compile for supported firmware."""
+    calls: dict[str, list[Any]] = {}
+
+    def fake_add_entities(entities: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup.
+
+        Args:
+            entities: Switch entities emitted by setup.
+            _update_before_add: Whether HA should refresh entities before adding them.
+        """
+        calls["entities"] = list(entities)
+
+    coordinator.data = {
+        "carp": {"status_summary": {"maintenance_mode": False, "enabled": True}},
+        "host_firmware_version": firmware,
+    }
+    config_entry = make_config_entry(
+        data={
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_UNBOUND: False,
+        },
+        title="OPNsenseTest",
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    await switch_mod.async_setup_entry(
+        ph_hass, config_entry, cast("AddEntitiesCallback", fake_add_entities)
+    )
+
+    carp_switches = [
+        entity
+        for entity in calls.get("entities", [])
+        if isinstance(entity, OPNsenseCarpMaintenanceSwitch)
+    ]
+    assert len(carp_switches) == expected_count
+
+
+@pytest.mark.asyncio
 async def test_carp_maintenance_switch_state_and_toggle(
     ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],
@@ -198,6 +295,25 @@ async def test_carp_maintenance_switch_state_and_toggle(
     entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
     assert entity.is_on is False
     assert entity.delay_update is True
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_ignores_updates_during_delay(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should keep optimistic state during update delay."""
+    state = {"carp": {"status_summary": {"maintenance_mode": True, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._handle_coordinator_update()
+    assert entity.is_on is True
+
+    entity.delay_update = True
+    state["carp"]["status_summary"]["maintenance_mode"] = False
+    entity._handle_coordinator_update()
+
+    assert entity.is_on is True
 
 
 @pytest.mark.asyncio
@@ -285,6 +401,87 @@ async def test_carp_maintenance_switch_turn_off_refreshes_before_toggle(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "maintenance_mode"),
+    [
+        pytest.param("async_turn_on", False, id="turn-on-no-client"),
+        pytest.param("async_turn_off", True, id="turn-off-no-client"),
+    ],
+)
+async def test_carp_maintenance_switch_turn_returns_without_client(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    method_name: str,
+    maintenance_mode: bool,
+) -> None:
+    """CARP maintenance switch should not refresh or toggle without a client."""
+    state = {"carp": {"status_summary": {"maintenance_mode": maintenance_mode, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._handle_coordinator_update()
+
+    await getattr(entity, method_name)()
+
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "maintenance_mode"),
+    [
+        pytest.param("async_turn_on", False, id="turn-on-missing-method"),
+        pytest.param("async_turn_off", True, id="turn-off-missing-method"),
+    ],
+)
+async def test_carp_maintenance_switch_turn_returns_without_toggle_method(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    method_name: str,
+    maintenance_mode: bool,
+) -> None:
+    """CARP maintenance switch should not refresh or toggle without toggle support."""
+    state = {"carp": {"status_summary": {"maintenance_mode": maintenance_mode, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._client = cast("Any", object())
+    entity._handle_coordinator_update()
+
+    await getattr(entity, method_name)()
+
+    coordinator.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "maintenance_mode", "expected_state"),
+    [
+        pytest.param("async_turn_on", False, False, id="turn-on-fails"),
+        pytest.param("async_turn_off", True, True, id="turn-off-fails"),
+    ],
+)
+async def test_carp_maintenance_switch_failed_toggle_keeps_state(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    method_name: str,
+    maintenance_mode: bool,
+    expected_state: bool,
+) -> None:
+    """CARP maintenance switch should keep current state when toggle fails."""
+    state = {"carp": {"status_summary": {"maintenance_mode": maintenance_mode, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+    entity._client = MagicMock()
+    entity._client.toggle_carp_maintenance_mode = AsyncMock(return_value=False)
+    entity._handle_coordinator_update()
+
+    await getattr(entity, method_name)()
+
+    entity._client.toggle_carp_maintenance_mode.assert_awaited_once()
+    assert entity.is_on is expected_state
+    assert entity.delay_update is False
+
+
+@pytest.mark.asyncio
 async def test_carp_maintenance_switch_unavailable_without_summary(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
@@ -309,6 +506,38 @@ async def test_carp_maintenance_switch_unavailable_without_summary(
     entity._handle_coordinator_update()
 
     assert entity.available is False
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_unavailable_without_mapping_state(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should become unavailable without mapping state."""
+    coordinator = make_coord([])
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+
+    entity._handle_coordinator_update()
+
+    assert entity.available is False
+
+
+@pytest.mark.asyncio
+async def test_carp_maintenance_switch_icon(
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP maintenance switch should use an alert icon while maintenance is on."""
+    state = {"carp": {"status_summary": {"maintenance_mode": True, "enabled": True}}}
+    coordinator = make_coord(state)
+    entity = make_carp_maintenance_switch(ph_hass, make_config_entry, coordinator)
+
+    entity._handle_coordinator_update()
+    assert entity.icon == "mdi:server-network-off"
+
+    state["carp"]["status_summary"]["maintenance_mode"] = False
+    entity._handle_coordinator_update()
+    assert entity.icon is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CARP persistent maintenance mode toggle switch for OPNsense 26.1.1 and later.

* **Bug Fixes**
  * Improved interface availability detection logic.
  * Enhanced boolean value parsing to properly handle unrecognized or missing values.

* **Chores**
  * Downgraded dependency version for compatibility improvements.

* **Tests**
  * Added comprehensive test coverage for boolean value coercion and CARP switch functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->