### PR TITLE
Align aiopnsense log level with hass-opnsense

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -63,6 +63,15 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+def _align_aiopnsense_log_level() -> None:
+    """Mirror the integration log level to aiopnsense when it is not explicit."""
+    aiopnsense_logger = logging.getLogger("aiopnsense")
+    if _LOGGER.level == logging.NOTSET or aiopnsense_logger.level != logging.NOTSET:
+        return
+
+    aiopnsense_logger.setLevel(_LOGGER.level)
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle config-entry option updates and schedule integration reload.
 
@@ -123,6 +132,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     Returns:
         bool: Always `True` after service setup succeeds.
     """
+    _align_aiopnsense_log_level()
     await async_setup_services(hass)
     return True
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -942,9 +942,9 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             entity_description=entity_description,
         )
         self._rule_id: str = self._opnsense_get_rule_id()
-        _LOGGER.debug(
-            "[OPNsenseFirewallRuleSwitch init] Name: %s, rule_id: %s", self.name, self._rule_id
-        )
+        # _LOGGER.debug(
+        #     "[OPNsenseFirewallRuleSwitch init] Name: %s, rule_id: %s", self.name, self._rule_id
+        # )
 
     def _opnsense_get_rule_id(self) -> str:
         """Get the rule ID from the entity description.
@@ -1004,14 +1004,14 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
         for name, attr in properties.items():
             self._attr_extra_state_attributes[name] = rule.get(attr, None)
         self.async_write_ha_state()
-        _LOGGER.debug(
-            "[OPNsenseFirewallRuleSwitch handle_coordinator_update] Name: %s, available: %s, is_on:"
-            " %s, extra_state_attributes: %s",
-            self.name,
-            self.available,
-            self.is_on,
-            self.extra_state_attributes,
-        )
+        # _LOGGER.debug(
+        #     "[OPNsenseFirewallRuleSwitch handle_coordinator_update] "
+        #     "Name: %s, available: %s, is_on: %s, extra_state_attributes: %s",
+        #     self.name,
+        #     self.available,
+        #     self.is_on,
+        #     self.extra_state_attributes,
+        # )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
@@ -1117,7 +1117,7 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             _LOGGER.debug("Skipping coordinator update for NAT switch %s due to delay", self.name)
             return
         rule = self._opnsense_get_rule()
-        _LOGGER.debug("[OPNsenseNATRuleSwitch handle_coordinator_update] fetched rule: %s", rule)
+        # _LOGGER.debug("[OPNsenseNATRuleSwitch handle_coordinator_update] fetched rule: %s", rule)
         if not rule:
             self._available = False
             self.async_write_ha_state()
@@ -1183,14 +1183,15 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             self._attr_extra_state_attributes[name] = rule.get(attr, None)
 
         self.async_write_ha_state()
-        _LOGGER.debug(
-            "[OPNsenseNATRuleSwitch handle_coordinator_update] Name: %s, available: %s, is_on: %s, "
-            "extra_state_attributes: %s",
-            self.name,
-            self.available,
-            self.is_on,
-            self.extra_state_attributes,
-        )
+        # _LOGGER.debug(
+        #     "[OPNsenseNATRuleSwitch handle_coordinator_update] "
+        #     "Name: %s, available: %s, is_on: %s, "
+        #     "extra_state_attributes: %s",
+        #     self.name,
+        #     self.available,
+        #     self.is_on,
+        #     self.extra_state_attributes,
+        # )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -104,14 +104,14 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         self._attr_latest_version = product_latest.replace("_", ".") if product_latest else None
 
         product_class = self._get_product_class(product_series)
-        _LOGGER.debug(
-            "[Update handle_coordinator_update] product_version: %s, product_latest: %s, "
-            "product_series: %s, product_class: %s",
-            product_version,
-            product_latest,
-            product_series,
-            product_class,
-        )
+        # _LOGGER.debug(
+        #     "[Update handle_coordinator_update] product_version: %s, product_latest: %s, "
+        #     "product_series: %s, product_class: %s",
+        #     product_version,
+        #     product_latest,
+        #     product_series,
+        #     product_class,
+        # )
 
         if product_series and product_latest and product_class:
             self._attr_release_url = f"https://github.com/opnsense/changelog/blob/master/{product_class}/{product_series}/{product_latest.split('+')[0].split('_')[0]}"
@@ -120,7 +120,10 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
                 self.config_entry.data.get("url", None) + "/ui/core/firmware#changelog"
             )
 
-        _LOGGER.debug("[Update handle_coordinator_update] release_url: %s", self._attr_release_url)
+        # _LOGGER.debug(
+        #     "[Update handle_coordinator_update] release_url: %s",
+        #     self._attr_release_url
+        # )
         self._release_notes = self._get_release_notes(state, product_latest, product_version)
         self._attr_release_summary = dict_get(state, "firmware_update_info.status_msg")
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ and removal/unload behaviors for the hass-opnsense integration.
 
 from collections.abc import Callable
 import importlib
+import logging
 from typing import Any, Never, Self
 from unittest.mock import ANY, AsyncMock, MagicMock, call
 
@@ -74,6 +75,65 @@ def _patch_hass_async_create_clientsession(monkeypatch: pytest.MonkeyPatch) -> N
         lambda *a, **k: object(),
         raising=False,
     )
+
+
+def test_align_aiopnsense_log_level_mirrors_opnsense_when_unset() -> None:
+    """Aiopnsense should inherit the integration debug level when not configured."""
+    opnsense_logger = logging.getLogger("custom_components.opnsense")
+    aiopnsense_logger = logging.getLogger("aiopnsense")
+    aiopnsense_helper_logger = logging.getLogger("aiopnsense.helpers")
+    original_opnsense_level = opnsense_logger.level
+    original_aiopnsense_level = aiopnsense_logger.level
+
+    try:
+        opnsense_logger.setLevel(logging.DEBUG)
+        aiopnsense_logger.setLevel(logging.NOTSET)
+
+        init_mod._align_aiopnsense_log_level()
+
+        assert aiopnsense_logger.level == logging.DEBUG
+        assert aiopnsense_helper_logger.getEffectiveLevel() == logging.DEBUG
+    finally:
+        opnsense_logger.setLevel(original_opnsense_level)
+        aiopnsense_logger.setLevel(original_aiopnsense_level)
+
+
+def test_align_aiopnsense_log_level_keeps_explicit_aiopnsense_level() -> None:
+    """aiopnsense-specific logger configuration should remain authoritative."""
+    opnsense_logger = logging.getLogger("custom_components.opnsense")
+    aiopnsense_logger = logging.getLogger("aiopnsense")
+    original_opnsense_level = opnsense_logger.level
+    original_aiopnsense_level = aiopnsense_logger.level
+
+    try:
+        opnsense_logger.setLevel(logging.DEBUG)
+        aiopnsense_logger.setLevel(logging.WARNING)
+
+        init_mod._align_aiopnsense_log_level()
+
+        assert aiopnsense_logger.level == logging.WARNING
+    finally:
+        opnsense_logger.setLevel(original_opnsense_level)
+        aiopnsense_logger.setLevel(original_aiopnsense_level)
+
+
+def test_align_aiopnsense_log_level_leaves_both_loggers_unset() -> None:
+    """Unset loggers should continue to inherit the root logger level."""
+    opnsense_logger = logging.getLogger("custom_components.opnsense")
+    aiopnsense_logger = logging.getLogger("aiopnsense")
+    original_opnsense_level = opnsense_logger.level
+    original_aiopnsense_level = aiopnsense_logger.level
+
+    try:
+        opnsense_logger.setLevel(logging.NOTSET)
+        aiopnsense_logger.setLevel(logging.NOTSET)
+
+        init_mod._align_aiopnsense_log_level()
+
+        assert aiopnsense_logger.level == logging.NOTSET
+    finally:
+        opnsense_logger.setLevel(original_opnsense_level)
+        aiopnsense_logger.setLevel(original_aiopnsense_level)
 
 
 @pytest.mark.asyncio
@@ -365,21 +425,25 @@ async def test_async_setup_calls_services_and_handles_exceptions(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any, should_raise: Any
 ) -> None:
     """async_setup should call async_setup_services; exceptions should propagate."""
+    mock_align = MagicMock()
     if should_raise:
         mock_services = AsyncMock(side_effect=RuntimeError("fail"))
     else:
         mock_services = AsyncMock(return_value=None)
 
+    monkeypatch.setattr(init_mod, "_align_aiopnsense_log_level", mock_align)
     monkeypatch.setattr(init_mod, "async_setup_services", mock_services)
 
     if should_raise:
         with pytest.raises(RuntimeError):
             await init_mod.async_setup(ph_hass, {})
         mock_services.assert_awaited_once()
+        mock_align.assert_called_once_with()
     else:
         res = await init_mod.async_setup(ph_hass, {})
         assert res is True
         mock_services.assert_awaited_once()
+        mock_align.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -84,10 +84,12 @@ def test_align_aiopnsense_log_level_mirrors_opnsense_when_unset() -> None:
     aiopnsense_helper_logger = logging.getLogger("aiopnsense.helpers")
     original_opnsense_level = opnsense_logger.level
     original_aiopnsense_level = aiopnsense_logger.level
+    original_aiopnsense_helper_level = aiopnsense_helper_logger.level
 
     try:
         opnsense_logger.setLevel(logging.DEBUG)
         aiopnsense_logger.setLevel(logging.NOTSET)
+        aiopnsense_helper_logger.setLevel(logging.NOTSET)
 
         init_mod._align_aiopnsense_log_level()
 
@@ -96,6 +98,7 @@ def test_align_aiopnsense_log_level_mirrors_opnsense_when_unset() -> None:
     finally:
         opnsense_logger.setLevel(original_opnsense_level)
         aiopnsense_logger.setLevel(original_aiopnsense_level)
+        aiopnsense_helper_logger.setLevel(original_aiopnsense_helper_level)
 
 
 def test_align_aiopnsense_log_level_keeps_explicit_aiopnsense_level() -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1648,6 +1648,82 @@ async def test_delay_skips_update_parametrized(
 
 
 @pytest.mark.asyncio
+async def test_nat_rule_switch_delay_skips_update(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """NAT rule switch should return early when delayed updates are active."""
+    state = {
+        "firewall": {
+            "nat": {
+                "source_nat": {
+                    "nat1": {
+                        "uuid": "nat1",
+                        "description": "Source NAT Rule",
+                        "%interface": "wan",
+                        "enabled": "1",
+                    }
+                }
+            }
+        }
+    }
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1", "url": "http://example"},
+        options={CONF_SYNC_FIREWALL_AND_NAT: True},
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = state
+
+    ents = await _compile_nat_source_rules_switches(config_entry, coordinator, state)
+    assert len(ents) == 1
+
+    ent = ents[0]
+    ent.hass = ph_hass
+    ent.coordinator = make_coord(state)
+    ent.entity_id = f"switch.{ent.entity_description.key}"
+    stub_async_write_ha_state(ent)
+    ent._attr_is_on = False
+    ent._available = True
+    ent._delay_update = True
+
+    ent._handle_coordinator_update()
+
+    assert ent.is_on is False
+    assert ent.available is True
+
+
+@pytest.mark.asyncio
+async def test_nat_rule_switch_missing_rule_marks_unavailable(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """NAT rule switch should become unavailable when its backing rule disappears."""
+    state: dict[str, Any] = {"firewall": {"nat": {"source_nat": {}}}}
+    desc = SwitchEntityDescription(key="firewall.nat.source_nat.missing", name="Missing")
+    config_entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1", "url": "http://example"},
+        options={CONF_SYNC_FIREWALL_AND_NAT: True},
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseNATRuleSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    ent.hass = ph_hass
+    ent.coordinator = make_coord(state)
+    ent.entity_id = "switch.missing_nat_rule"
+    stub_async_write_ha_state(ent)
+    ent._available = True
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
+@pytest.mark.asyncio
 async def test_compile_helpers_bad_input(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:


### PR DESCRIPTION
## Summary
Cleans up overly chatty OPNsense logging and makes `aiopnsense` follow the integration log level when users only configure `custom_components.opnsense`.

## What Changed
- Commented out verbose debug statements in firewall, NAT, and firmware update entities that were adding low-signal log noise.
- Added `_align_aiopnsense_log_level()` during integration setup so `aiopnsense` inherits the explicit `custom_components.opnsense` level when `aiopnsense` itself is unset.
- Preserved explicit `aiopnsense` logger configuration by leaving it untouched when users set a level directly.
- Added regression coverage for mirrored log levels, explicit `aiopnsense` overrides, and the fully inherited `NOTSET` case.
- Updated `async_setup` tests to verify the logging alignment hook runs during integration setup.

## Why
The branch reduces noisy debug output without removing targeted debugging when users opt in. It also fixes the mismatch where enabling `custom_components.opnsense: debug` did not surface `aiopnsense` debug records unless users knew to configure a second logger namespace manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved logging configuration to automatically synchronize the integration's logger level with the aiopnsense library logger, ensuring consistent debug message verbosity when enabled.

* **Chores**
  * Removed unnecessary debug logging statements from firewall rule switches and firmware update handlers.
  * Added unit tests to verify logging level synchronization behavior during integration setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->