### PR TITLE
Refine device tracker entity behavior

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -408,11 +408,32 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
 
     @property  # type: ignore[misc] # overriding final from ScannerEntity
     def device_info(self) -> DeviceInfo | None:
-        """Return the device info.
+        """Return device registry metadata for the tracker.
+
+        Home Assistant's ``ScannerEntity`` can automatically attach a scanner
+        entity to an existing device when the device registry already has a
+        matching network MAC connection. That auto-link path only runs when
+        the scanner entity does not provide its own device info.
+
+        When a matching device exists, return ``None`` so the base scanner
+        implementation links this tracker to that device. When no matching
+        device exists, return the historical hass-opnsense device info so Home
+        Assistant still creates the manually associated tracker device.
 
         Returns:
-            Device registry metadata for the tracked MAC address.
+            ``None`` for an existing MAC-matched device, otherwise fallback
+            device registry metadata for the tracked MAC address.
         """
+        # Returning None here opts into ScannerEntity's existing-device linking
+        # path. Returning DeviceInfo below preserves the previous fallback
+        # behavior for trackers whose MAC is not already in the device registry.
+        if (
+            self.mac_address is not None
+            and getattr(self, "hass", None) is not None
+            and self.find_device_entry() is not None
+        ):
+            return None
+
         return DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self.mac_address or "")},
             default_manufacturer=self._mac_vendor or "",

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -333,7 +333,11 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         Returns:
             ``True`` when the entity should be enabled by default.
         """
-        return self._attr_entity_registry_enabled_default
+        return self._attr_entity_registry_enabled_default or (
+            self.mac_address is not None
+            and getattr(self, "hass", None) is not None
+            and self.find_device_entry() is not None
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -351,11 +351,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         Returns:
             ``True`` when the entity should be enabled by default.
         """
-        return self._attr_entity_registry_enabled_default or (
-            self.mac_address is not None
-            and getattr(self, "hass", None) is not None
-            and self._has_matching_enabled_mac_device()
-        )
+        return self._attr_entity_registry_enabled_default or self._has_matching_enabled_mac_device()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -437,23 +433,20 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         matching network MAC connection. That auto-link path only runs when
         the scanner entity does not provide its own device info.
 
-        When a matching device exists, return ``None`` so the base scanner
-        implementation links this tracker to that device. When no matching
-        device exists, return the historical hass-opnsense device info so Home
-        Assistant still creates the manually associated tracker device.
+        When a matching enabled device exists, return ``None`` so the base
+        scanner implementation links this tracker to that device. When no
+        matching enabled device exists, return the historical hass-opnsense
+        device info so Home Assistant still creates the manually associated
+        tracker device or preserves disabled-device behavior.
 
         Returns:
-            ``None`` for an existing MAC-matched device, otherwise fallback
-            device registry metadata for the tracked MAC address.
+            ``None`` for an existing enabled MAC-matched device, otherwise
+            fallback device registry metadata for the tracked MAC address.
         """
         # Returning None here opts into ScannerEntity's existing-device linking
         # path. Returning DeviceInfo below preserves the previous fallback
         # behavior for trackers whose MAC is not already in the device registry.
-        if (
-            self.mac_address is not None
-            and getattr(self, "hass", None) is not None
-            and self._has_matching_enabled_mac_device()
-        ):
+        if self._has_matching_enabled_mac_device():
             return None
 
         return DeviceInfo(

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -309,15 +309,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         self._attr_icon: str | None = None
 
     @property
-    def source_type(self) -> SourceType:
-        """Return the tracker source type.
-
-        Returns:
-            The source type reported to Home Assistant.
-        """
-        return self._attr_source_type
-
-    @property
     def is_connected(self) -> bool:
         """Return if the tracker is connected.
 
@@ -325,33 +316,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
             ``True`` when the device is currently considered connected.
         """
         return self._is_connected
-
-    @property
-    def ip_address(self) -> str | None:
-        """Return the IP address.
-
-        Returns:
-            The current IP address, or ``None`` when unavailable.
-        """
-        return self._attr_ip_address
-
-    @property
-    def mac_address(self) -> str | None:
-        """Return the MAC address.
-
-        Returns:
-            The tracked MAC address, or ``None`` when unavailable.
-        """
-        return self._attr_mac_address
-
-    @property
-    def hostname(self) -> str | None:
-        """Return the hostname.
-
-        Returns:
-            The current hostname, or ``None`` when unavailable.
-        """
-        return self._attr_hostname
 
     @property
     def unique_id(self) -> str | None:

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -307,6 +307,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         self._attr_mac_address: str | None = mac
         self._attr_source_type: SourceType = SourceType.ROUTER
         self._attr_icon: str | None = None
+        self._fallback_device_info_consumed: bool = False
 
     def _has_matching_enabled_mac_device(self) -> bool:
         """Return whether a matching MAC device exists and is not disabled."""
@@ -351,7 +352,11 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         Returns:
             ``True`` when the entity should be enabled by default.
         """
-        return self._attr_entity_registry_enabled_default or self._has_matching_enabled_mac_device()
+        if self._attr_entity_registry_enabled_default:
+            return True
+        if self._fallback_device_info_consumed:
+            return False
+        return self._has_matching_enabled_mac_device()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -449,6 +454,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         if self._has_matching_enabled_mac_device():
             return None
 
+        self._fallback_device_info_consumed = True
         return DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self.mac_address or "")},
             default_manufacturer=self._mac_vendor or "",

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -464,8 +464,12 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         if not has_matching_enabled_mac_device:
             self._fallback_device_info_consumed = True
 
+        connections: set[tuple[str, str]] = set()
+        if self.mac_address is not None:
+            connections.add((CONNECTION_NETWORK_MAC, self.mac_address))
+
         return DeviceInfo(
-            connections={(CONNECTION_NETWORK_MAC, self.mac_address or "")},
+            connections=connections,
             default_manufacturer=self._mac_vendor or "",
             default_name=self.name if isinstance(self.name, str) else "",
             via_device=(DOMAIN, self._device_unique_id),

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -308,6 +308,24 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         self._attr_source_type: SourceType = SourceType.ROUTER
         self._attr_icon: str | None = None
 
+    def _has_matching_enabled_mac_device(self) -> bool:
+        """Return whether a matching MAC device exists and is not disabled."""
+        if self.mac_address is None:
+            return False
+
+        hass = getattr(self, "hass", None)
+        if hass is None:
+            return False
+
+        device_registry = async_get_dev_reg(hass)
+        existing_device = device_registry.async_get_device(
+            connections={(CONNECTION_NETWORK_MAC, self.mac_address)}
+        )
+        if existing_device is None:
+            return False
+
+        return getattr(existing_device, "disabled_by", None) is None
+
     @property
     def is_connected(self) -> bool:
         """Return if the tracker is connected.
@@ -336,7 +354,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         return self._attr_entity_registry_enabled_default or (
             self.mac_address is not None
             and getattr(self, "hass", None) is not None
-            and self.find_device_entry() is not None
+            and self._has_matching_enabled_mac_device()
         )
 
     @callback
@@ -434,7 +452,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         if (
             self.mac_address is not None
             and getattr(self, "hass", None) is not None
-            and self.find_device_entry() is not None
+            and self._has_matching_enabled_mac_device()
         ):
             return None
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -439,22 +439,31 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         the scanner entity does not provide its own device info.
 
         When a matching enabled device exists, return ``None`` so the base
-        scanner implementation links this tracker to that device. When no
-        matching enabled device exists, return the historical hass-opnsense
-        device info so Home Assistant still creates the manually associated
-        tracker device or preserves disabled-device behavior.
+        scanner implementation links this tracker to that device, unless
+        ``pref_disable_new_entities`` is enabled on the config entry.
+        In that preference-enabled case, return device info so the entity is
+        linked to an existing device during registry creation while the entity
+        remains disabled by preference.
+
+        When no matching enabled device exists, return the historical
+        hass-opnsense device info so Home Assistant still creates the manually
+        associated tracker device or preserves disabled-device behavior.
 
         Returns:
-            ``None`` for an existing enabled MAC-matched device, otherwise
-            fallback device registry metadata for the tracked MAC address.
+            ``None`` for an existing enabled MAC-matched device, except when
+            ``pref_disable_new_entities`` is enabled, otherwise fallback
+            device registry metadata for the tracked MAC address.
         """
         # Returning None here opts into ScannerEntity's existing-device linking
         # path. Returning DeviceInfo below preserves the previous fallback
         # behavior for trackers whose MAC is not already in the device registry.
-        if self._has_matching_enabled_mac_device():
+        has_matching_enabled_mac_device = self._has_matching_enabled_mac_device()
+        if has_matching_enabled_mac_device and not self.config_entry.pref_disable_new_entities:
             return None
 
-        self._fallback_device_info_consumed = True
+        if not has_matching_enabled_mac_device:
+            self._fallback_device_info_consumed = True
+
         return DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self.mac_address or "")},
             default_manufacturer=self._mac_vendor or "",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,7 +350,10 @@ def fake_reg_factory() -> Any:
     """
 
     def _make(
-        device_exists: bool = False, device_id: str = "dev", remove_result: Any | None = None
+        device_exists: bool = False,
+        device_id: str = "dev",
+        remove_result: Any | None = None,
+        config_entries: set[str] | None = None,
     ) -> Any:
         """Create a fake device registry with configurable lookup and removal behavior.
 
@@ -358,15 +361,18 @@ def fake_reg_factory() -> Any:
             device_exists: Whether ``async_get_device`` should return a device record.
             device_id: Device identifier returned when ``device_exists`` is true.
             remove_result: Value returned by ``async_remove_device``.
+            config_entries: Config entries already linked to the fake device.
         """
 
         class _FakeReg:
             def __init__(self) -> None:
                 """Initialize _FakeReg."""
                 self.removed = False
+                self.updated_devices: list[tuple[str, dict[str, Any]]] = []
                 self._device_exists = device_exists
                 self._device_id = device_id
                 self._remove_result = remove_result
+                self._config_entries = config_entries or set()
 
             def async_get_device(self, *args, **kwargs) -> Any:
                 """Return a fake device entry when the fixture is configured to find one.
@@ -379,9 +385,19 @@ def fake_reg_factory() -> Any:
 
                     class _D:
                         id = self._device_id
+                        config_entries = self._config_entries
 
                     return _D()
                 return None
+
+            def async_update_device(self, device_id: str, **kwargs: Any) -> None:
+                """Record device updates for assertions.
+
+                Args:
+                    device_id: Device identifier being updated.
+                    **kwargs: Device update keyword arguments.
+                """
+                self.updated_devices.append((device_id, kwargs))
 
             def async_remove_device(self, *args, **kwargs) -> Any:
                 # mirror previous tests which sometimes inspect a `removed` flag

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,7 @@ def fake_reg_factory() -> Any:
         device_id: str = "dev",
         remove_result: Any | None = None,
         config_entries: set[str] | None = None,
+        disabled_by: str | None = None,
     ) -> Any:
         """Create a fake device registry with configurable lookup and removal behavior.
 
@@ -362,6 +363,7 @@ def fake_reg_factory() -> Any:
             device_id: Device identifier returned when ``device_exists`` is true.
             remove_result: Value returned by ``async_remove_device``.
             config_entries: Config entries already linked to the fake device.
+            disabled_by: Disable source reported by the fake device entry.
         """
 
         class _FakeReg:
@@ -373,6 +375,7 @@ def fake_reg_factory() -> Any:
                 self._device_id = device_id
                 self._remove_result = remove_result
                 self._config_entries = config_entries or set()
+                self._disabled_by = disabled_by
 
             def async_get_device(self, *args, **kwargs) -> Any:
                 """Return a fake device entry when the fixture is configured to find one.
@@ -386,6 +389,7 @@ def fake_reg_factory() -> Any:
                     class _D:
                         id = self._device_id
                         config_entries = self._config_entries
+                        disabled_by = self._disabled_by
 
                     return _D()
                 return None

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -304,9 +304,64 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
     )
     ent.hass = ph_hass
     device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
-    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
 
     assert ent.entity_registry_enabled_default is True
+
+
+def test_entity_registry_enabled_default_fallback_when_no_matching_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Auto-discovered trackers should stay disabled when no matching device exists."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+    )
+    ent.hass = ph_hass
+    device_reg = fake_reg_factory(device_exists=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+
+    assert ent.entity_registry_enabled_default is False
+    assert ent.device_info is not None
+
+
+def test_entity_registry_enabled_default_falls_back_for_disabled_mac_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Disabled matching MAC devices should keep fallback device_info-based linking."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+    )
+    ent.hass = ph_hass
+
+    class _DisabledDevice:
+        def __init__(self) -> None:
+            self.id: str = "existing-disabled-device"
+            self.disabled_by: str = "user"
+            self.config_entries: set[str] = set()
+
+    class _RegMock:
+        def async_get_device(self, *args: Any, **kwargs: Any) -> Any:
+            return _DisabledDevice()
+
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: _RegMock())
+    assert ent.entity_registry_enabled_default is False
+
+    device_info = ent.device_info
+    assert device_info is not None
+    assert isinstance(device_info, MutableMapping)
+    connections = device_info.get("connections", [])
+    assert any(conn[1] == "aa:bb:cc" for conn in connections)
 
 
 def test_device_data_from_arp_entry_normalizes_hostname_and_filters_manufacturer() -> None:
@@ -718,6 +773,7 @@ async def test_async_internal_added_to_hass_links_existing_mac_device(
     entity_reg.async_update_entity.return_value = updated_registry_entry
     monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
     monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda hass: entity_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
 
     await ent.async_internal_added_to_hass()
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -289,6 +289,26 @@ def test_scanner_entity_uses_attr_backed_home_assistant_properties() -> None:
     }.isdisjoint(locally_defined_properties)
 
 
+def test_entity_registry_enabled_default_uses_existing_mac_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Auto-discovered trackers should be enabled when HA can link a MAC device."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+    )
+    ent.hass = ph_hass
+    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
+    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
+
+    assert ent.entity_registry_enabled_default is True
+
+
 def test_device_data_from_arp_entry_normalizes_hostname_and_filters_manufacturer() -> None:
     """ARP setup data should normalize hostnames and ignore non-string manufacturer."""
     device = dt_mod._device_data_from_arp_entry(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -314,7 +314,6 @@ def test_entity_registry_enabled_default_fallback_when_no_matching_device(
     ph_hass: Any,
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
-    fake_reg_factory: Any,
 ) -> None:
     """Auto-discovered trackers should stay disabled when no matching device exists."""
     ent = _make_scanner_entity(
@@ -323,11 +322,33 @@ def test_entity_registry_enabled_default_fallback_when_no_matching_device(
         coordinator_data={"arp_table": []},
     )
     ent.hass = ph_hass
-    device_reg = fake_reg_factory(device_exists=False)
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+    matched_state = {"has_device": False}
 
+    class _FallbackDevice:
+        """Simple stand-in for a registry entry."""
+
+        id = "fallback-device-id"
+        disabled_by = None
+
+    class _TrackingRegistry:
+        """Mock device registry that can emulate fallback device appearance."""
+
+        def __init__(self) -> None:
+            """Initialize the tracking registry."""
+            self._device = _FallbackDevice()
+
+        def async_get_device(self, *_args: Any, **_kwargs: Any) -> Any:
+            """Return the fallback device only after it is marked as present."""
+            return self._device if matched_state["has_device"] else None
+
+    registry = _TrackingRegistry()
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: registry)
+
+    fallback_device_info = ent.device_info
+    assert fallback_device_info is not None
+    matched_state["has_device"] = True
+    assert ent.device_info is None
     assert ent.entity_registry_enabled_default is False
-    assert ent.device_info is not None
 
 
 def test_entity_registry_enabled_default_falls_back_for_disabled_mac_device(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -17,6 +17,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.opnsense.device_tracker import OPNsenseScannerEntity
 
 dt_mod = importlib.import_module("custom_components.opnsense.device_tracker")
+ha_dt_entity_mod = importlib.import_module("homeassistant.components.device_tracker.entity")
 pkg = importlib.import_module("custom_components.opnsense")
 
 
@@ -660,6 +661,90 @@ async def test_async_added_to_hass_calls_restore(
 
     await ent.async_added_to_hass()
     assert ent._restore_last_state.called
+
+
+@pytest.mark.asyncio
+async def test_async_internal_added_to_hass_links_existing_mac_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Scanner entity should link to an existing registry device with the same MAC."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    ent.hass = ph_hass
+    ent.platform = MagicMock(config_entry=entry, platform_name=dt_mod.DOMAIN)
+    ent.registry_entry = MagicMock()
+    ent.registry_entry.device_id = None
+    ent.registry_entry.disabled_by = None
+    ent.entity_id = "device_tracker.opnsense_existing"
+
+    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
+    entity_reg = MagicMock()
+    updated_registry_entry = MagicMock()
+    updated_registry_entry.device_id = "existing-device"
+    updated_registry_entry.disabled_by = None
+    entity_reg.async_update_entity.return_value = updated_registry_entry
+    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda hass: entity_reg)
+
+    await ent.async_internal_added_to_hass()
+
+    entity_reg.async_update_entity.assert_called_once_with(
+        "device_tracker.opnsense_existing", device_id="existing-device"
+    )
+    assert ent.registry_entry is updated_registry_entry
+    assert device_reg.updated_devices == [("existing-device", {"add_config_entry_id": "entry-1"})]
+
+
+@pytest.mark.asyncio
+async def test_async_internal_added_to_hass_keeps_fallback_device_info_without_match(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Scanner entity should keep its fallback device info when no MAC device exists."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=entry,
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    ent.hass = ph_hass
+    ent.platform = MagicMock(config_entry=entry, platform_name=dt_mod.DOMAIN)
+    ent.registry_entry = MagicMock()
+    ent.registry_entry.device_id = None
+    ent.registry_entry.disabled_by = None
+    ent.entity_id = "device_tracker.opnsense_fallback"
+
+    device_reg = fake_reg_factory(device_exists=False)
+    entity_reg = MagicMock()
+    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda hass: entity_reg)
+
+    await ent.async_internal_added_to_hass()
+
+    entity_reg.async_update_entity.assert_not_called()
+    assert device_reg.updated_devices == []
+    assert ent.device_info is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -335,6 +335,7 @@ def test_entity_registry_enabled_default_falls_back_for_disabled_mac_device(
     ph_hass: Any,
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
 ) -> None:
     """Disabled matching MAC devices should keep fallback device_info-based linking."""
     ent = _make_scanner_entity(
@@ -344,17 +345,12 @@ def test_entity_registry_enabled_default_falls_back_for_disabled_mac_device(
     )
     ent.hass = ph_hass
 
-    class _DisabledDevice:
-        def __init__(self) -> None:
-            self.id: str = "existing-disabled-device"
-            self.disabled_by: str = "user"
-            self.config_entries: set[str] = set()
-
-    class _RegMock:
-        def async_get_device(self, *args: Any, **kwargs: Any) -> Any:
-            return _DisabledDevice()
-
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: _RegMock())
+    device_reg = fake_reg_factory(
+        device_exists=True,
+        device_id="existing-disabled-device",
+        disabled_by="user",
+    )
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
     assert ent.entity_registry_enabled_default is False
 
     device_info = ent.device_info

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -268,6 +268,26 @@ def test_handle_coordinator_update_entry_present(
     assert ent.source_type == dt_mod.SourceType.ROUTER
 
 
+def test_scanner_entity_uses_attr_backed_home_assistant_properties() -> None:
+    """Scanner entity should rely on Home Assistant attr-backed properties."""
+    locally_defined_properties = {
+        name
+        for name, value in vars(dt_mod.OPNsenseScannerEntity).items()
+        if isinstance(value, property)
+    }
+
+    assert "unique_id" in locally_defined_properties
+    assert "device_info" in locally_defined_properties
+    assert "entity_registry_enabled_default" in locally_defined_properties
+    assert "is_connected" in locally_defined_properties
+    assert {
+        "hostname",
+        "ip_address",
+        "mac_address",
+        "source_type",
+    }.isdisjoint(locally_defined_properties)
+
+
 def test_device_data_from_arp_entry_normalizes_hostname_and_filters_manufacturer() -> None:
     """ARP setup data should normalize hostnames and ignore non-string manufacturer."""
     device = dt_mod._device_data_from_arp_entry(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -108,8 +108,8 @@ async def test_async_setup_entry_configured_devices(
         entry_id="eid",
     )
     setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-    entry.add_update_listener = lambda f: lambda: None
-    entry.async_on_unload = lambda x: None
+    entry.add_update_listener = lambda _listener: lambda: None
+    entry.async_on_unload = lambda _unload: None
     hass = ph_hass
     hass.config_entries.async_update_entry = MagicMock()
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
@@ -117,7 +117,7 @@ async def test_async_setup_entry_configured_devices(
     hass.data = {}
 
     fake = fake_reg_factory(device_exists=False)
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
 
     added: list[Any] = []
 
@@ -171,8 +171,8 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
         entry_id="eid_remove",
     )
     setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-    entry.add_update_listener = lambda f: lambda: None
-    entry.async_on_unload = lambda x: None
+    entry.add_update_listener = lambda _listener: lambda: None
+    entry.async_on_unload = lambda _unload: None
 
     hass = ph_hass
     hass.config_entries.async_update_entry = MagicMock()
@@ -181,7 +181,7 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     hass.data = {}
 
     fake = fake_reg_factory(device_exists=True, device_id="removed-device-id")
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
 
     added: list[Any] = []
 
@@ -308,7 +308,7 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
     )
     ent.hass = ph_hass
     device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
 
     assert ent.entity_registry_enabled_default is True
     assert ent.device_info is None
@@ -342,6 +342,13 @@ def test_entity_registry_enabled_default_without_mac_stays_disabled(
     )
 
     assert ent.entity_registry_enabled_default is False
+    device_info = ent.device_info
+    assert device_info is not None
+    if isinstance(device_info, MutableMapping):
+        connections = device_info.get("connections", [])
+    else:
+        connections = getattr(device_info, "connections", [])
+    assert all(connection[1] != "" for connection in connections)
 
 
 def test_entity_registry_enabled_default_pref_disable_new_entities_keeps_device_link(
@@ -360,7 +367,7 @@ def test_entity_registry_enabled_default_pref_disable_new_entities_keeps_device_
     ent.hass = ph_hass
     object.__setattr__(ent.config_entry, "pref_disable_new_entities", True)
     device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
 
     assert ent.entity_registry_enabled_default is True
     device_info = ent.device_info
@@ -406,7 +413,7 @@ def test_entity_registry_enabled_default_fallback_when_no_matching_device(
             return self._device if matched_state["has_device"] else None
 
     registry = _TrackingRegistry()
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: registry)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: registry)
 
     fallback_device_info = ent.device_info
     assert fallback_device_info is not None
@@ -434,7 +441,7 @@ def test_entity_registry_enabled_default_falls_back_for_disabled_mac_device(
         device_id="existing-disabled-device",
         disabled_by="user",
     )
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
     assert ent.entity_registry_enabled_default is False
 
     device_info = ent.device_info
@@ -851,9 +858,9 @@ async def test_async_internal_added_to_hass_links_existing_mac_device(
     updated_registry_entry.device_id = "existing-device"
     updated_registry_entry.disabled_by = None
     entity_reg.async_update_entity.return_value = updated_registry_entry
-    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
-    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda hass: entity_reg)
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda _hass: device_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda _hass: entity_reg)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
 
     await ent.async_internal_added_to_hass()
 
@@ -893,8 +900,8 @@ async def test_async_internal_added_to_hass_keeps_fallback_device_info_without_m
 
     device_reg = fake_reg_factory(device_exists=False)
     entity_reg = MagicMock()
-    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda hass: device_reg)
-    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda hass: entity_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.dr, "async_get", lambda _hass: device_reg)
+    monkeypatch.setattr(ha_dt_entity_mod.er, "async_get", lambda _hass: entity_reg)
 
     await ent.async_internal_added_to_hass()
 
@@ -921,7 +928,7 @@ async def test_async_setup_entry_state_not_mapping(
     hass.data = {}
     hass.config_entries.async_update_entry = MagicMock()
     fake = fake_reg_factory(device_exists=False)
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
 
     await dt_mod.async_setup_entry(hass, entry, added.extend)
     assert len(added) == 0
@@ -947,11 +954,11 @@ async def test_async_setup_entry_removes_previous_mac(
     hass.data = {}
 
     fake = fake_reg_factory(device_exists=True, device_id="dev_to_remove")
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
 
     hass.config_entries.async_update_entry = MagicMock()
 
-    await dt_mod.async_setup_entry(hass, entry, lambda x: None)
+    await dt_mod.async_setup_entry(hass, entry, lambda _x: None)
     assert fake.removed is True
     assert hass.config_entries.async_update_entry.called
 
@@ -1096,7 +1103,7 @@ async def test_async_setup_entry_from_arp_entries(
     hass.data = {}
     hass.config_entries.async_update_entry = MagicMock()
     fake = fake_reg_factory(device_exists=False)
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
 
     added: list[Any] = []
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -26,6 +26,8 @@ def _make_scanner_entity(
     make_config_entry: Callable[..., MockConfigEntry],
     *,
     coordinator_data: object | None = None,
+    enabled_default: bool = False,
+    mac: str | None = "aa:bb:cc",
 ) -> OPNsenseScannerEntity:
     """Create a scanner entity with coordinator runtime data wired in.
 
@@ -33,9 +35,11 @@ def _make_scanner_entity(
         coordinator: Device tracker coordinator used by the entity.
         make_config_entry: Fixture that creates a mock config entry.
         coordinator_data: Optional coordinator data to install before creating the entity.
+        enabled_default: Whether the entity should be enabled by default.
+        mac: MAC address tracked by the entity.
 
     Returns:
-        A scanner entity for the standard tracked MAC used in these tests.
+        A scanner entity for the requested MAC address.
     """
     coordinator.data = {"arp_table": []} if coordinator_data is None else coordinator_data
     entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
@@ -43,8 +47,8 @@ def _make_scanner_entity(
     return dt_mod.OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
+        enabled_default=enabled_default,
+        mac=mac,
         mac_vendor=None,
         hostname=None,
     )
@@ -308,6 +312,36 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
 
     assert ent.entity_registry_enabled_default is True
     assert ent.device_info is None
+
+
+def test_entity_registry_enabled_default_respects_configured_enabled_default(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Configured trackers should keep their requested enabled-by-default state."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+        enabled_default=True,
+    )
+
+    assert ent.entity_registry_enabled_default is True
+
+
+def test_entity_registry_enabled_default_without_mac_stays_disabled(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Trackers without a MAC cannot link to an enabled MAC device."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+        mac=None,
+    )
+
+    assert ent.entity_registry_enabled_default is False
 
 
 def test_entity_registry_enabled_default_pref_disable_new_entities_keeps_device_link(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -307,6 +307,36 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
 
     assert ent.entity_registry_enabled_default is True
+    assert ent.device_info is None
+
+
+def test_entity_registry_enabled_default_pref_disable_new_entities_keeps_device_link(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Existing MAC matches should still link while the new-entity preference is enabled."""
+    ent = _make_scanner_entity(
+        coordinator=coordinator,
+        make_config_entry=make_config_entry,
+        coordinator_data={"arp_table": []},
+    )
+    ent.hass = ph_hass
+    object.__setattr__(ent.config_entry, "pref_disable_new_entities", True)
+    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: device_reg)
+
+    assert ent.entity_registry_enabled_default is True
+    device_info = ent.device_info
+    assert device_info is not None
+
+    if isinstance(device_info, MutableMapping):
+        connections = device_info.get("connections", [])
+    else:
+        connections = getattr(device_info, "connections", [])
+    assert any(conn[1] == "aa:bb:cc" for conn in connections)
 
 
 def test_entity_registry_enabled_default_fallback_when_no_matching_device(
@@ -347,7 +377,6 @@ def test_entity_registry_enabled_default_fallback_when_no_matching_device(
     fallback_device_info = ent.device_info
     assert fallback_device_info is not None
     matched_state["has_device"] = True
-    assert ent.device_info is None
     assert ent.entity_registry_enabled_default is False
 
 


### PR DESCRIPTION
## Summary
Refines the OPNsense device tracker entity to better align with Home Assistant's current scanner entity model. The tracker now uses HA's attr-backed scanner properties where possible and prefers HA's existing MAC-based device linking before falling back to hass-opnsense's manual device metadata.

## What Changed
- Removed local `@property` wrappers for scanner properties that Home Assistant already backs with `_attr_*` values.
- Updated `device_info` so existing MAC-matched devices are linked through Home Assistant's scanner attach path.
- Preserved the previous fallback `DeviceInfo` behavior when no existing MAC-matched device is found.
- Expanded device tracker tests to cover attr-backed property usage, existing-device linking, and fallback device info creation.
- Extended the fake device registry fixture so tests can assert device update behavior.

## Why
Home Assistant's device tracker model now provides more of the scanner entity behavior directly. This keeps hass-opnsense closer to the upstream model while preserving the integration's existing behavior for manually associated tracker devices.

## Validation
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m prek run -a`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device tracking so entities can link to existing devices more reliably by MAC address.
  * Fixed default enablement behavior for trackers, including better handling when a device is already known, disabled, or missing.
  * Preserved fallback device details when no matching device is found, helping avoid unexpected missing device links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->