### PR TITLE
Tighten OPNsense init lifecycle and migration cleanup

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -237,7 +237,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_tracker_coordinator: OPNsenseDataUpdateCoordinator | None = None
 
     setup_succeeded: bool = False
-    remove_listener: Any | None = None
     try:
         # Trigger repair task and shutdown if device id has changed
         router_device_id: str | None = await client.get_device_unique_id(
@@ -363,8 +362,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return True
     finally:
         if not setup_succeeded:
-            if remove_listener is not None:
-                remove_listener()
             if device_tracker_coordinator is not None:
                 await device_tracker_coordinator.async_shutdown()
             await coordinator.async_shutdown()
@@ -599,6 +596,7 @@ async def _migrate_3_to_4(
                 for filesystem in filesystems:
                     device = filesystem.get("device", "")
                     if not isinstance(device, str):
+                        filesystem_migration_deferred = True
                         continue
                     device_name: str = device.replace("/", "_slash_").strip("_").lower()
                     if device_name == unique_id_device_name:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -70,6 +70,25 @@ NATIVE_RULE_ENTITY_TOKENS: tuple[str, ...] = (
 )
 
 
+def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]]:
+    """Return valid telemetry filesystem mappings from a migration payload.
+
+    Args:
+        telemetry: Raw telemetry payload returned by the OPNsense client.
+
+    Returns:
+        list[Mapping[str, Any]]: Filesystem mappings usable for entity ID remaps.
+    """
+    if not isinstance(telemetry, Mapping):
+        return []
+
+    filesystems = telemetry.get("filesystems", [])
+    if not isinstance(filesystems, list):
+        return []
+
+    return [filesystem for filesystem in filesystems if isinstance(filesystem, Mapping)]
+
+
 def _align_aiopnsense_log_level() -> None:
     """Mirror the integration log level onto aiopnsense when it is unset."""
     aiopnsense_logger = logging.getLogger("aiopnsense")
@@ -537,6 +556,7 @@ async def _migrate_3_to_4(
     entity_registry = er.async_get(hass)
 
     telemetry = await client.get_telemetry()
+    filesystems = _get_telemetry_filesystems(telemetry)
 
     for ent in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
         platform = ent.entity_id.split(".")[0]
@@ -566,7 +586,7 @@ async def _migrate_3_to_4(
                 )
                 unique_id_device_name = unique_id_device_name.lower()
                 new_unique_id = None
-                for filesystem in telemetry.get("filesystems", []):
+                for filesystem in filesystems:
                     device_name: str = (
                         filesystem.get("device", "").replace("/", "_slash_").strip("_")
                     ).lower()

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -91,6 +91,12 @@ def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]] | N
     for filesystem in filesystems:
         if not isinstance(filesystem, Mapping):
             return None
+        device = filesystem.get("device", "")
+        if not isinstance(device, str):
+            return None
+        mountpoint = filesystem.get("mountpoint", "")
+        if not isinstance(mountpoint, str):
+            return None
         valid_filesystems.append(filesystem)
 
     return valid_filesystems

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -601,22 +601,14 @@ async def _migrate_3_to_4(
                 )
                 unique_id_device_name = unique_id_device_name.lower()
                 new_unique_id = None
-                matched_filesystem = False
                 if filesystems is None:
                     filesystem_migration_deferred = True
                     continue
                 for filesystem in filesystems:
-                    device = filesystem.get("device", "")
-                    if not isinstance(device, str):
-                        filesystem_migration_deferred = True
-                        continue
+                    device: str = filesystem.get("device", "")
                     device_name: str = device.replace("/", "_slash_").strip("_").lower()
                     if device_name == unique_id_device_name:
-                        matched_filesystem = True
-                        mpoint = filesystem.get("mountpoint", "")
-                        if not isinstance(mpoint, str):
-                            filesystem_migration_deferred = True
-                            break
+                        mpoint: str = filesystem.get("mountpoint", "")
                         if mpoint == "/":
                             mountpoint = "root"
                         else:
@@ -625,8 +617,6 @@ async def _migrate_3_to_4(
                             f"{telemetry_filesystem_prefix}_telemetry_filesystems_{mountpoint}"
                         )
                         break
-                if filesystem_migration_deferred and matched_filesystem:
-                    continue
             else:
                 continue
             if new_unique_id is None:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -83,7 +83,7 @@ def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]] | N
     if not isinstance(telemetry, Mapping):
         return None
 
-    filesystems = telemetry.get("filesystems", [])
+    filesystems = telemetry.get("filesystems")
     if not isinstance(filesystems, list):
         return None
 
@@ -237,6 +237,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_tracker_coordinator: OPNsenseDataUpdateCoordinator | None = None
 
     setup_succeeded: bool = False
+    remove_listener: Any | None = None
     try:
         # Trigger repair task and shutdown if device id has changed
         router_device_id: str | None = await client.get_device_unique_id(
@@ -349,18 +350,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_unique_id=config_device_id,
             loaded_platforms=platforms,
         )
+        remove_listener = entry.add_update_listener(_async_update_listener)
+        entry.async_on_unload(remove_listener)
+
         if device_tracker_enabled and device_tracker_coordinator:
             # Fetch initial data so we have data when entities subscribe
             await device_tracker_coordinator.async_config_entry_first_refresh()
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
-        entry.async_on_unload(entry.add_update_listener(_async_update_listener))
-
         setup_succeeded = True
         return True
     finally:
         if not setup_succeeded:
+            if remove_listener is not None:
+                remove_listener()
             if device_tracker_coordinator is not None:
                 await device_tracker_coordinator.async_shutdown()
             await coordinator.async_shutdown()
@@ -588,6 +592,7 @@ async def _migrate_3_to_4(
                 )
                 unique_id_device_name = unique_id_device_name.lower()
                 new_unique_id = None
+                matched_filesystem = False
                 if filesystems is None:
                     filesystem_migration_deferred = True
                     continue
@@ -597,9 +602,11 @@ async def _migrate_3_to_4(
                         continue
                     device_name: str = device.replace("/", "_slash_").strip("_").lower()
                     if device_name == unique_id_device_name:
+                        matched_filesystem = True
                         mpoint = filesystem.get("mountpoint", "")
                         if not isinstance(mpoint, str):
-                            continue
+                            filesystem_migration_deferred = True
+                            break
                         if mpoint == "/":
                             mountpoint = "root"
                         else:
@@ -608,6 +615,8 @@ async def _migrate_3_to_4(
                             f"{telemetry_filesystem_prefix}_telemetry_filesystems_{mountpoint}"
                         )
                         break
+                if filesystem_migration_deferred and matched_filesystem:
+                    continue
             else:
                 continue
             if new_unique_id is None:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -319,8 +319,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 device_tracker_coordinator=True,
             )
 
-        entry.async_on_unload(entry.add_update_listener(_async_update_listener))
-
         hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN][entry.entry_id] = client
 
@@ -336,6 +334,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await device_tracker_coordinator.async_config_entry_first_refresh()
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
+
+        entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
         setup_succeeded = True
         return True

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -331,14 +331,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_unique_id=config_device_id,
             loaded_platforms=platforms,
         )
-        setup_succeeded = True
-
         if device_tracker_enabled and device_tracker_coordinator:
             # Fetch initial data so we have data when entities subscribe
             await device_tracker_coordinator.async_config_entry_first_refresh()
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
+        setup_succeeded = True
         return True
     finally:
         if not setup_succeeded:
@@ -389,9 +388,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     client: OPNsenseClient = getattr(entry.runtime_data, OPNSENSE_CLIENT)
     unload_ok: bool = await hass.config_entries.async_unload_platforms(entry, platforms)
 
-    await client.async_close()
-
     if unload_ok:
+        await client.async_close()
         hass.data[DOMAIN].pop(entry.entry_id, None)
 
     return unload_ok

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -91,10 +91,10 @@ def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]] | N
     for filesystem in filesystems:
         if not isinstance(filesystem, Mapping):
             return None
-        device = filesystem.get("device", "")
+        device = filesystem.get("device")
         if not isinstance(device, str):
             return None
-        mountpoint = filesystem.get("mountpoint", "")
+        mountpoint = filesystem.get("mountpoint")
         if not isinstance(mountpoint, str):
             return None
         valid_filesystems.append(filesystem)

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -87,7 +87,13 @@ def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]] | N
     if not isinstance(filesystems, list):
         return None
 
-    return [filesystem for filesystem in filesystems if isinstance(filesystem, Mapping)]
+    valid_filesystems: list[Mapping[str, Any]] = []
+    for filesystem in filesystems:
+        if not isinstance(filesystem, Mapping):
+            return None
+        valid_filesystems.append(filesystem)
+
+    return valid_filesystems
 
 
 def _align_aiopnsense_log_level() -> None:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -70,21 +70,22 @@ NATIVE_RULE_ENTITY_TOKENS: tuple[str, ...] = (
 )
 
 
-def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]]:
+def _get_telemetry_filesystems(telemetry: object) -> list[Mapping[str, Any]] | None:
     """Return valid telemetry filesystem mappings from a migration payload.
 
     Args:
         telemetry: Raw telemetry payload returned by the OPNsense client.
 
     Returns:
-        list[Mapping[str, Any]]: Filesystem mappings usable for entity ID remaps.
+        list[Mapping[str, Any]] | None: Filesystem mappings usable for entity
+            ID remaps, or `None` when the telemetry payload cannot be trusted.
     """
     if not isinstance(telemetry, Mapping):
-        return []
+        return None
 
     filesystems = telemetry.get("filesystems", [])
     if not isinstance(filesystems, list):
-        return []
+        return None
 
     return [filesystem for filesystem in filesystems if isinstance(filesystem, Mapping)]
 
@@ -557,6 +558,7 @@ async def _migrate_3_to_4(
 
     telemetry = await client.get_telemetry()
     filesystems = _get_telemetry_filesystems(telemetry)
+    filesystem_migration_deferred = False
 
     for ent in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
         platform = ent.entity_id.split(".")[0]
@@ -586,12 +588,18 @@ async def _migrate_3_to_4(
                 )
                 unique_id_device_name = unique_id_device_name.lower()
                 new_unique_id = None
+                if filesystems is None:
+                    filesystem_migration_deferred = True
+                    continue
                 for filesystem in filesystems:
-                    device_name: str = (
-                        filesystem.get("device", "").replace("/", "_slash_").strip("_")
-                    ).lower()
+                    device = filesystem.get("device", "")
+                    if not isinstance(device, str):
+                        continue
+                    device_name: str = device.replace("/", "_slash_").strip("_").lower()
                     if device_name == unique_id_device_name:
-                        mpoint: str = filesystem.get("mountpoint", "")
+                        mpoint = filesystem.get("mountpoint", "")
+                        if not isinstance(mpoint, str):
+                            continue
                         if mpoint == "/":
                             mountpoint = "root"
                         else:
@@ -629,6 +637,9 @@ async def _migrate_3_to_4(
                     ent.entity_id,
                     type(e).__name__,
                 )
+    if filesystem_migration_deferred:
+        _LOGGER.error("Migration to version 4 deferred because filesystem telemetry is unavailable")
+        return False
     new_entry_bool = hass.config_entries.async_update_entry(config_entry, version=4)
     if new_entry_bool:
         _LOGGER.debug("[migrate_3_to_4] config_entry update successful")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1458,89 +1458,25 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
 
 
 @pytest.mark.asyncio
-async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_invalid(
-    monkeypatch: pytest.MonkeyPatch, fake_client: Any
-) -> None:
-    """_migrate_3_to_4 should defer filesystem remaps when filesystems is invalid."""
-    client = fake_client(telemetry={"filesystems": None})()
-
-    filesystem_entity = MagicMock()
-    filesystem_entity.entity_id = "sensor.fs"
-    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
-
-    entity_registry = MagicMock()
-    entity_registry.async_update_entity = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
-    monkeypatch.setattr(
-        init_mod.er,
-        "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [filesystem_entity],
-    )
-
-    config_entry = MagicMock()
-    config_entry.version = 3
-    config_entry.entry_id = "e3"
-
-    hass = MagicMock(spec=HomeAssistant)
-    hass.config_entries = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(return_value=True)
-
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
-
-    assert result is False
-    entity_registry.async_update_entity.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_migrate_3_to_4_defers_filesystems_when_filesystems_contains_non_mapping_item(
-    monkeypatch: pytest.MonkeyPatch, fake_client: Any
-) -> None:
-    """_migrate_3_to_4 should defer when filesystems contains untrusted non-mapping entries."""
-    client = fake_client(telemetry={"filesystems": [None]})()
-
-    filesystem_entity = MagicMock()
-    filesystem_entity.entity_id = "sensor.fs"
-    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
-
-    entity_registry = MagicMock()
-    entity_registry.async_update_entity = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
-    monkeypatch.setattr(
-        init_mod.er,
-        "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [filesystem_entity],
-    )
-
-    config_entry = MagicMock()
-    config_entry.version = 3
-    config_entry.entry_id = "e3"
-
-    hass = MagicMock(spec=HomeAssistant)
-    hass.config_entries = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(return_value=True)
-
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
-
-    assert result is False
-    entity_registry.async_update_entity.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_migrate_3_to_4_defers_filesystem_migration_when_mountpoint_invalid(
-    monkeypatch: pytest.MonkeyPatch, fake_client: Any
-) -> None:
-    """A matched filesystem with an invalid mountpoint should defer the migration."""
-    client = fake_client(
-        telemetry={
+@pytest.mark.parametrize(
+    "telemetry",
+    [
+        {"filesystems": None},
+        {"filesystems": [None]},
+        {
             "filesystems": [
                 {"device": None, "mountpoint": "/"},
                 {"device": "/dev/sda1", "mountpoint": None},
-                {"device": "/dev/sdb1", "mountpoint": "/mnt/data"},
             ]
-        }
-    )()
+        },
+        {},
+    ],
+)
+async def test_migrate_3_to_4_defers_filesystems_when_payload_is_invalid(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any, telemetry: dict[str, Any]
+) -> None:
+    """_migrate_3_to_4 should defer filesystem remaps when telemetry is invalid."""
+    client = fake_client(telemetry=telemetry)()
 
     filesystem_entity = MagicMock()
     filesystem_entity.entity_id = "sensor.fs"
@@ -1550,41 +1486,6 @@ async def test_migrate_3_to_4_defers_filesystem_migration_when_mountpoint_invali
     entity_registry.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=filesystem_entity.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
-    monkeypatch.setattr(
-        init_mod.er,
-        "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [filesystem_entity],
-    )
-
-    config_entry = MagicMock()
-    config_entry.version = 3
-    config_entry.entry_id = "e3"
-
-    hass = MagicMock(spec=HomeAssistant)
-    hass.config_entries = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(return_value=True)
-
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
-
-    assert result is False
-    entity_registry.async_update_entity.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_migrate_3_to_4_skips_filesystems_when_filesystems_key_is_missing(
-    monkeypatch: pytest.MonkeyPatch, fake_client: Any
-) -> None:
-    """_migrate_3_to_4 should defer when telemetry lacks filesystems metadata."""
-    client = fake_client(telemetry={})()
-
-    filesystem_entity = MagicMock()
-    filesystem_entity.entity_id = "sensor.fs"
-    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
-
-    entity_registry = MagicMock()
-    entity_registry.async_update_entity = MagicMock()
     monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
         init_mod.er,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1487,6 +1487,7 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
                 {"device": "/dev/sda1", "mountpoint": None},
             ]
         },
+        {"filesystems": [{"device": 7, "mountpoint": "/"}]},
         {},
     ],
 )
@@ -2118,54 +2119,6 @@ async def test_migrate_2_to_3_handles_identifier_collision(
 
     res = await init_mod._migrate_2_to_3(hass, cfg, client)
     assert res is True
-
-
-@pytest.mark.asyncio
-async def test_migrate_3_to_4_defers_when_filesystem_device_is_not_string(
-    monkeypatch: pytest.MonkeyPatch, ph_hass: Any
-) -> None:
-    """_migrate_3_to_4 should defer when filesystem device values are malformed."""
-    client = MagicMock()
-    client.get_telemetry = AsyncMock(return_value={"filesystems": [{"device": 7}]})
-
-    migration_entry = MagicMock()
-    migration_entry.entry_id = "entry"
-    migration_entry.version = 3
-
-    hass = ph_hass
-    hass.config_entries = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(return_value=True)
-
-    class EntityRegistry:
-        def async_entries_for_config_entry(
-            self, registry: Any, config_entry_id: str
-        ) -> list[MagicMock]:
-            """Expose one stale filesystem telemetry entity for migration."""
-            return [
-                MagicMock(
-                    entity_id="sensor.router_telemetry_filesystems_root",
-                    unique_id="router_telemetry_filesystems_root",
-                )
-            ]
-
-        def async_update_entity(self, entity_id: str, new_unique_id: str) -> Any:
-            """Surface unsupported update attempts as a test failure."""
-            raise AssertionError(
-                "Entity updates should not occur when filesystem migration is deferred"
-            )
-
-    entity_registry = EntityRegistry()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda _hass: entity_registry)
-    monkeypatch.setattr(
-        init_mod.er,
-        "async_entries_for_config_entry",
-        entity_registry.async_entries_for_config_entry,
-    )
-
-    res = await init_mod._migrate_3_to_4(hass, migration_entry, client)
-
-    assert res is False
-    hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1412,7 +1412,7 @@ async def test_migrate_3_to_4_filesystem_skips_and_non_root_mountpoint(
 async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_migrate_3_to_4 should skip filesystem remaps when telemetry is invalid."""
+    """_migrate_3_to_4 should defer filesystem remaps when telemetry is invalid."""
 
     class Client:
         async def get_telemetry(self) -> None:
@@ -1449,19 +1449,19 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
 
     result = await init_mod._migrate_3_to_4(hass, config_entry, client)
 
-    assert result is True
+    assert result is False
     entity_registry.async_update_entity.assert_called_once_with(
         interface_entity.entity_id,
         new_unique_id="abc_interface_lan",
     )
-    hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=4)
+    hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_invalid(
     monkeypatch: pytest.MonkeyPatch, fake_client: Any
 ) -> None:
-    """_migrate_3_to_4 should skip filesystem remaps when filesystems is invalid."""
+    """_migrate_3_to_4 should defer filesystem remaps when filesystems is invalid."""
     client = fake_client(telemetry={"filesystems": None})()
 
     filesystem_entity = MagicMock()
@@ -1487,8 +1487,56 @@ async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_inva
 
     result = await init_mod._migrate_3_to_4(hass, config_entry, client)
 
-    assert result is True
+    assert result is False
     entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_3_to_4_skips_invalid_filesystem_members(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """_migrate_3_to_4 should ignore malformed filesystem members."""
+    client = fake_client(
+        telemetry={
+            "filesystems": [
+                {"device": None, "mountpoint": "/"},
+                {"device": "/dev/sda1", "mountpoint": None},
+                {"device": "/dev/sdb1", "mountpoint": "/mnt/data"},
+            ]
+        }
+    )()
+
+    filesystem_entity = MagicMock()
+    filesystem_entity.entity_id = "sensor.fs"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sdb1"
+
+    entity_registry = MagicMock()
+    entity_registry.async_update_entity = MagicMock(
+        return_value=MagicMock(entity_id=filesystem_entity.entity_id, unique_id="updated")
+    )
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [filesystem_entity],
+    )
+
+    config_entry = MagicMock()
+    config_entry.version = 3
+    config_entry.entry_id = "e3"
+
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+
+    assert result is True
+    entity_registry.async_update_entity.assert_called_once_with(
+        filesystem_entity.entity_id,
+        new_unique_id="abc_telemetry_filesystems_mnt_data",
+    )
     hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=4)
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2072,7 +2072,7 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
     client.async_close.assert_awaited_once()
     entry.add_update_listener.assert_called_once()
     entry.async_on_unload.assert_called_once_with(remove_listener)
-    remove_listener.assert_called_once()
+    remove_listener.assert_not_called()
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
 
 
@@ -2183,3 +2183,51 @@ async def test_migrate_2_to_3_handles_identifier_collision(
 
     res = await init_mod._migrate_2_to_3(hass, cfg, client)
     assert res is True
+
+
+@pytest.mark.asyncio
+async def test_migrate_3_to_4_defers_when_filesystem_device_is_not_string(
+    monkeypatch: pytest.MonkeyPatch, ph_hass: Any
+) -> None:
+    """_migrate_3_to_4 should defer when filesystem device values are malformed."""
+    client = MagicMock()
+    client.get_telemetry = AsyncMock(return_value={"filesystems": [{"device": 7}]})
+
+    migration_entry = MagicMock()
+    migration_entry.entry_id = "entry"
+    migration_entry.version = 3
+
+    hass = ph_hass
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    class EntityRegistry:
+        def async_entries_for_config_entry(
+            self, registry: Any, config_entry_id: str
+        ) -> list[MagicMock]:
+            """Expose one stale filesystem telemetry entity for migration."""
+            return [
+                MagicMock(
+                    entity_id="sensor.router_telemetry_filesystems_root",
+                    unique_id="router_telemetry_filesystems_root",
+                )
+            ]
+
+        def async_update_entity(self, entity_id: str, new_unique_id: str) -> Any:
+            """Surface unsupported update attempts as a test failure."""
+            raise AssertionError(
+                "Entity updates should not occur when filesystem migration is deferred"
+            )
+
+    entity_registry = EntityRegistry()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        entity_registry.async_entries_for_config_entry,
+    )
+
+    res = await init_mod._migrate_3_to_4(hass, migration_entry, client)
+
+    assert res is False
+    hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1487,6 +1487,8 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
                 {"device": "/dev/sda1", "mountpoint": None},
             ]
         },
+        {"filesystems": [{"mountpoint": "/"}]},
+        {"filesystems": [{"device": "/dev/sda1"}]},
         {"filesystems": [{"device": 7, "mountpoint": "/"}]},
         {},
     ],
@@ -2154,7 +2156,7 @@ async def test_migrate_3_to_4_defers_without_updating_entities_when_later_filesy
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
     entity_registry = MagicMock()
-    entity_registry.async_entries_for_config_entry = lambda registry, config_entry_id: [
+    entity_registry.async_entries_for_config_entry = lambda _registry, _config_entry_id: [
         first_filesystem_entity,
         second_filesystem_entity,
     ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1409,6 +1409,90 @@ async def test_migrate_3_to_4_filesystem_skips_and_non_root_mountpoint(
 
 
 @pytest.mark.asyncio
+async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_migrate_3_to_4 should skip filesystem remaps when telemetry is invalid."""
+
+    class Client:
+        async def get_telemetry(self) -> None:
+            """Return an invalid telemetry payload for migration hardening."""
+            return
+
+    client = Client()
+
+    interface_entity = MagicMock()
+    interface_entity.entity_id = "sensor.interface"
+    interface_entity.unique_id = "abc_telemetry_interface_lan"
+    filesystem_entity = MagicMock()
+    filesystem_entity.entity_id = "sensor.fs"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
+
+    entity_registry = MagicMock()
+    entity_registry.async_update_entity = MagicMock(
+        return_value=MagicMock(entity_id=interface_entity.entity_id, unique_id="updated")
+    )
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [interface_entity, filesystem_entity],
+    )
+
+    config_entry = MagicMock()
+    config_entry.version = 3
+    config_entry.entry_id = "e3"
+
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+
+    assert result is True
+    entity_registry.async_update_entity.assert_called_once_with(
+        interface_entity.entity_id,
+        new_unique_id="abc_interface_lan",
+    )
+    hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=4)
+
+
+@pytest.mark.asyncio
+async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_invalid(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """_migrate_3_to_4 should skip filesystem remaps when filesystems is invalid."""
+    client = fake_client(telemetry={"filesystems": None})()
+
+    filesystem_entity = MagicMock()
+    filesystem_entity.entity_id = "sensor.fs"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
+
+    entity_registry = MagicMock()
+    entity_registry.async_update_entity = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [filesystem_entity],
+    )
+
+    config_entry = MagicMock()
+    config_entry.version = 3
+    config_entry.entry_id = "e3"
+
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+
+    assert result is True
+    entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=4)
+
+
+@pytest.mark.asyncio
 async def test_migrate_3_to_4_returns_false_when_update_entry_fails(
     monkeypatch: pytest.MonkeyPatch, fake_client: Any
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1493,6 +1493,41 @@ async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_inva
 
 
 @pytest.mark.asyncio
+async def test_migrate_3_to_4_defers_filesystems_when_filesystems_contains_non_mapping_item(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """_migrate_3_to_4 should defer when filesystems contains untrusted non-mapping entries."""
+    client = fake_client(telemetry={"filesystems": [None]})()
+
+    filesystem_entity = MagicMock()
+    filesystem_entity.entity_id = "sensor.fs"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
+
+    entity_registry = MagicMock()
+    entity_registry.async_update_entity = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [filesystem_entity],
+    )
+
+    config_entry = MagicMock()
+    config_entry.version = 3
+    config_entry.entry_id = "e3"
+
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+
+    assert result is False
+    entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_migrate_3_to_4_defers_filesystem_migration_when_mountpoint_invalid(
     monkeypatch: pytest.MonkeyPatch, fake_client: Any
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1890,6 +1890,8 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
         },
         options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
     )
+    entry.add_update_listener = MagicMock(return_value=MagicMock())
+    entry.async_on_unload = MagicMock()
 
     hass = ph_hass
     hass.config_entries.async_forward_entry_setups = AsyncMock(
@@ -1903,6 +1905,8 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
 
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
+    entry.add_update_listener.assert_not_called()
+    entry.async_on_unload.assert_not_called()
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1493,10 +1493,10 @@ async def test_migrate_3_to_4_skips_filesystems_when_filesystems_payload_is_inva
 
 
 @pytest.mark.asyncio
-async def test_migrate_3_to_4_skips_invalid_filesystem_members(
+async def test_migrate_3_to_4_defers_filesystem_migration_when_mountpoint_invalid(
     monkeypatch: pytest.MonkeyPatch, fake_client: Any
 ) -> None:
-    """_migrate_3_to_4 should ignore malformed filesystem members."""
+    """A matched filesystem with an invalid mountpoint should defer the migration."""
     client = fake_client(
         telemetry={
             "filesystems": [
@@ -1509,7 +1509,7 @@ async def test_migrate_3_to_4_skips_invalid_filesystem_members(
 
     filesystem_entity = MagicMock()
     filesystem_entity.entity_id = "sensor.fs"
-    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sdb1"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
 
     entity_registry = MagicMock()
     entity_registry.async_update_entity = MagicMock(
@@ -1532,12 +1532,44 @@ async def test_migrate_3_to_4_skips_invalid_filesystem_members(
 
     result = await init_mod._migrate_3_to_4(hass, config_entry, client)
 
-    assert result is True
-    entity_registry.async_update_entity.assert_called_once_with(
-        filesystem_entity.entity_id,
-        new_unique_id="abc_telemetry_filesystems_mnt_data",
+    assert result is False
+    entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_3_to_4_skips_filesystems_when_filesystems_key_is_missing(
+    monkeypatch: pytest.MonkeyPatch, fake_client: Any
+) -> None:
+    """_migrate_3_to_4 should defer when telemetry lacks filesystems metadata."""
+    client = fake_client(telemetry={})()
+
+    filesystem_entity = MagicMock()
+    filesystem_entity.entity_id = "sensor.fs"
+    filesystem_entity.unique_id = "abc_telemetry_filesystems_slash_dev_slash_sda1"
+
+    entity_registry = MagicMock()
+    entity_registry.async_update_entity = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [filesystem_entity],
     )
-    hass.config_entries.async_update_entry.assert_called_once_with(config_entry, version=4)
+
+    config_entry = MagicMock()
+    config_entry.version = 3
+    config_entry.entry_id = "e3"
+
+    hass = MagicMock(spec=HomeAssistant)
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+
+    assert result is False
+    entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -2022,8 +2054,9 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
         },
         options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    entry.add_update_listener = MagicMock(return_value=MagicMock())
-    entry.async_on_unload = MagicMock()
+    remove_listener = MagicMock()
+    entry.add_update_listener = MagicMock(return_value=remove_listener)
+    entry.async_on_unload = MagicMock(return_value=None)
 
     hass = ph_hass
     hass.config_entries.async_forward_entry_setups = AsyncMock(
@@ -2037,9 +2070,70 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
 
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
-    entry.add_update_listener.assert_not_called()
-    entry.async_on_unload.assert_not_called()
+    entry.add_update_listener.assert_called_once()
+    entry.async_on_unload.assert_called_once_with(remove_listener)
+    remove_listener.assert_called_once()
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_update_listener_before_forwarding(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Update listener registration should happen before platform forwarding."""
+    call_order: list[str] = []
+
+    client = MagicMock()
+    client.validate = AsyncMock(return_value=True)
+    client.get_device_unique_id = AsyncMock(return_value="dev1")
+    client.get_host_firmware_version = AsyncMock(return_value="99.0")
+    client.async_close = AsyncMock(return_value=True)
+    monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
+    coordinator.async_shutdown = AsyncMock(return_value=True)
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            init_mod.CONF_URL: "http://1.2.3.4",
+            init_mod.CONF_USERNAME: "u",
+            init_mod.CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    remove_listener = MagicMock()
+
+    def _add_update_listener(listener: Any) -> MagicMock:
+        call_order.append("add_listener")
+        return remove_listener
+
+    def _async_on_unload(unregister: MagicMock) -> None:
+        call_order.append("async_on_unload")
+
+    entry.add_update_listener = MagicMock(side_effect=_add_update_listener)
+    entry.async_on_unload = MagicMock(side_effect=_async_on_unload)
+
+    async def _forward_entry_setups(*_args: Any, **_kwargs: Any) -> bool:
+        call_order.append("forward")
+        return True
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(side_effect=_forward_entry_setups)
+    hass.config_entries.async_reload = MagicMock()
+    hass.data = {}
+
+    res = await init_mod.async_setup_entry(hass, entry)
+
+    assert res is True
+    assert call_order.index("add_listener") < call_order.index("forward")
+    entry.add_update_listener.assert_called_once_with(init_mod._async_update_listener)
+    entry.async_on_unload.assert_called_once_with(remove_listener)
+    remove_listener.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1227,7 +1227,7 @@ async def test_async_setup_entry_awesomeversion_exception(
 async def test_async_unload_entry_unload_fails(
     ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
-    """async_unload_entry returns False and retains hass.data when platform unload fails."""
+    """async_unload_entry returns False and keeps runtime resources when unload fails."""
     entry = make_config_entry(entry_id="e_unload_fail")
     entry.as_dict = lambda: {"id": "x"}
     setattr(entry.runtime_data, init_mod.LOADED_PLATFORMS, ["p1"])
@@ -1243,7 +1243,7 @@ async def test_async_unload_entry_unload_fails(
     assert res is False
     # hass.data should still have the entry
     assert entry.entry_id in hass.data[init_mod.DOMAIN]
-    fake_client.async_close.assert_awaited_once()
+    fake_client.async_close.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1805,6 +1805,105 @@ async def test_async_setup_entry_with_device_tracker_enabled(
     # ensure a device-tracker coordinator was created and its initial refresh ran
     assert any(getattr(inst, "_is_device_tracker", False) for inst in coordinator_capture.instances)
     assert any(getattr(inst, "refreshed", False) for inst in coordinator_capture.instances)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """async_setup_entry should clean up when device-tracker setup fails."""
+    client = MagicMock()
+    client.validate = AsyncMock(return_value=True)
+    client.get_device_unique_id = AsyncMock(return_value="dev1")
+    client.get_host_firmware_version = AsyncMock(return_value="99.0")
+    client.async_close = AsyncMock(return_value=True)
+    monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
+
+    main_coordinator = MagicMock()
+    main_coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
+    main_coordinator.async_shutdown = AsyncMock(return_value=True)
+    device_tracker_coordinator = MagicMock()
+    device_tracker_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=RuntimeError("device tracker refresh failed")
+    )
+    device_tracker_coordinator.async_shutdown = AsyncMock(return_value=True)
+
+    coordinators = [main_coordinator, device_tracker_coordinator]
+
+    def _coordinator_factory(**_kwargs: Any) -> Any:
+        """Return setup coordinators in creation order."""
+        return coordinators.pop(0)
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
+
+    entry = make_config_entry(
+        data={
+            init_mod.CONF_URL: "http://1.2.3.4",
+            init_mod.CONF_USERNAME: "u",
+            init_mod.CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = MagicMock()
+    hass.data = {}
+
+    with pytest.raises(RuntimeError, match="device tracker refresh failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    main_coordinator.async_shutdown.assert_awaited_once()
+    device_tracker_coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """async_setup_entry should clean up when platform forwarding fails."""
+    client = MagicMock()
+    client.validate = AsyncMock(return_value=True)
+    client.get_device_unique_id = AsyncMock(return_value="dev1")
+    client.get_host_firmware_version = AsyncMock(return_value="99.0")
+    client.async_close = AsyncMock(return_value=True)
+    monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
+
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
+    coordinator.async_shutdown = AsyncMock(return_value=True)
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            init_mod.CONF_URL: "http://1.2.3.4",
+            init_mod.CONF_USERNAME: "u",
+            init_mod.CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(
+        side_effect=RuntimeError("platform forwarding failed")
+    )
+    hass.config_entries.async_reload = MagicMock()
+    hass.data = {}
+
+    with pytest.raises(RuntimeError, match="platform forwarding failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2266,3 +2266,55 @@ async def test_migrate_3_to_4_defers_when_filesystem_device_is_not_string(
 
     assert res is False
     hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_migrate_3_to_4_defers_without_updating_entities_when_later_filesystem_invalid(
+    monkeypatch: pytest.MonkeyPatch, ph_hass: Any
+) -> None:
+    """A valid filesystem before a malformed filesystem should not partially migrate or bump version."""
+    client = MagicMock()
+    client.get_telemetry = AsyncMock(
+        return_value={
+            "filesystems": [
+                {"device": "/dev/sda1", "mountpoint": "/"},
+                {"device": 7, "mountpoint": "/data"},
+            ]
+        }
+    )
+
+    migration_entry = MagicMock()
+    migration_entry.entry_id = "entry"
+    migration_entry.version = 3
+
+    first_filesystem_entity = MagicMock(
+        entity_id="sensor.router_telemetry_filesystems_slash_dev_slash_sda1",
+        unique_id="router_telemetry_filesystems_slash_dev_slash_sda1",
+    )
+    second_filesystem_entity = MagicMock(
+        entity_id="sensor.router_telemetry_filesystems_slash_dev_slash_sdb1",
+        unique_id="router_telemetry_filesystems_slash_dev_slash_sdb1",
+    )
+
+    hass = ph_hass
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+
+    entity_registry = MagicMock()
+    entity_registry.async_entries_for_config_entry = lambda registry, config_entry_id: [
+        first_filesystem_entity,
+        second_filesystem_entity,
+    ]
+    entity_registry.async_update_entity = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        entity_registry.async_entries_for_config_entry,
+    )
+
+    res = await init_mod._migrate_3_to_4(hass, migration_entry, client)
+
+    assert res is False
+    entity_registry.async_update_entity.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -76,6 +76,24 @@ def _patch_hass_async_create_clientsession(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
 
+def _make_valid_setup_client() -> MagicMock:
+    """Create a valid OPNsense client mock for setup-entry lifecycle tests."""
+    client = MagicMock()
+    client.validate = AsyncMock(return_value=True)
+    client.get_device_unique_id = AsyncMock(return_value="dev1")
+    client.get_host_firmware_version = AsyncMock(return_value="99.0")
+    client.async_close = AsyncMock(return_value=True)
+    return client
+
+
+def _make_setup_coordinator() -> MagicMock:
+    """Create a coordinator mock that succeeds initial setup and supports shutdown."""
+    coordinator = MagicMock()
+    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
+    coordinator.async_shutdown = AsyncMock(return_value=True)
+    return coordinator
+
+
 def test_align_aiopnsense_log_level_mirrors_opnsense_when_unset() -> None:
     """Aiopnsense should inherit the integration debug level when not configured."""
     opnsense_logger = logging.getLogger("custom_components.opnsense")
@@ -1914,21 +1932,14 @@ async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """async_setup_entry should clean up when device-tracker setup fails."""
-    client = MagicMock()
-    client.validate = AsyncMock(return_value=True)
-    client.get_device_unique_id = AsyncMock(return_value="dev1")
-    client.get_host_firmware_version = AsyncMock(return_value="99.0")
-    client.async_close = AsyncMock(return_value=True)
+    client = _make_valid_setup_client()
     monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
 
-    main_coordinator = MagicMock()
-    main_coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
-    main_coordinator.async_shutdown = AsyncMock(return_value=True)
-    device_tracker_coordinator = MagicMock()
+    main_coordinator = _make_setup_coordinator()
+    device_tracker_coordinator = _make_setup_coordinator()
     device_tracker_coordinator.async_config_entry_first_refresh = AsyncMock(
         side_effect=RuntimeError("device tracker refresh failed")
     )
-    device_tracker_coordinator.async_shutdown = AsyncMock(return_value=True)
 
     coordinators = [main_coordinator, device_tracker_coordinator]
 
@@ -1969,16 +1980,10 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """async_setup_entry should clean up when platform forwarding fails."""
-    client = MagicMock()
-    client.validate = AsyncMock(return_value=True)
-    client.get_device_unique_id = AsyncMock(return_value="dev1")
-    client.get_host_firmware_version = AsyncMock(return_value="99.0")
-    client.async_close = AsyncMock(return_value=True)
+    client = _make_valid_setup_client()
     monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
 
-    coordinator = MagicMock()
-    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
-    coordinator.async_shutdown = AsyncMock(return_value=True)
+    coordinator = _make_setup_coordinator()
     monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
 
     entry = make_config_entry(
@@ -2021,16 +2026,10 @@ async def test_async_setup_entry_registers_update_listener_before_forwarding(
     """Update listener registration should happen before platform forwarding."""
     call_order: list[str] = []
 
-    client = MagicMock()
-    client.validate = AsyncMock(return_value=True)
-    client.get_device_unique_id = AsyncMock(return_value="dev1")
-    client.get_host_firmware_version = AsyncMock(return_value="99.0")
-    client.async_close = AsyncMock(return_value=True)
+    client = _make_valid_setup_client()
     monkeypatch.setattr(init_mod, "create_opnsense_client", lambda **_kwargs: client)
 
-    coordinator = MagicMock()
-    coordinator.async_config_entry_first_refresh = AsyncMock(return_value=True)
-    coordinator.async_shutdown = AsyncMock(return_value=True)
+    coordinator = _make_setup_coordinator()
     monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
 
     entry = make_config_entry(


### PR DESCRIPTION
## Summary
Hardens the OPNsense integration lifecycle in `__init__.py` so failed setup and unload paths do not leave stale or prematurely closed runtime resources. It also makes the v3-to-v4 telemetry filesystem migration tolerate malformed telemetry payloads while preserving the existing entity remap behavior.

## What Changed
- Delays `setup_succeeded` until device-tracker initial refresh and platform forwarding complete.
- Registers the config-entry update listener only after platform forwarding succeeds.
- Keeps the OPNsense client open when platform unload fails, matching the retained loaded-entry state.
- Adds `_get_telemetry_filesystems()` to normalize migration telemetry before filesystem entity remaps.
- Defers the v3-to-v4 migration when filesystem entities still need remapping but filesystem telemetry is unavailable.
- Adds regression coverage for setup cleanup, listener registration ordering, unload failure resource retention, invalid telemetry migration payloads, and malformed filesystem members.

## Why
The setup and unload paths can partially initialize Home Assistant runtime state before a later operation fails. The new ordering keeps cleanup behavior aligned with whether the entry actually finished loading. The migration hardening prevents bad filesystem telemetry from aborting unrelated v3-to-v4 entity ID migrations while avoiding a version bump that would strand old filesystem unique IDs.

## Validation
- `./.venv/bin/python -m pytest` (`649 passed`)
- `./.venv/bin/python -m prek run -a`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration reliability by only applying filesystem telemetry when it is structurally valid; otherwise the migration is safely deferred and aborted to prevent partial upgrades.
  * Improved setup/update sequencing so updates are registered after runtime data is attached and marked successful only after platform setups complete.
  * Improved unload/shutdown behavior so the client closes only if platform unloading succeeds, and ensured coordinators and stored state are fully cleaned up on setup failures.

* **Tests**
  * Expanded tests for malformed telemetry deferral, full migration failure behavior, and verified cleanup/ordering in multiple setup and unload failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->