### PR TITLE
Refine coordinator counter handling

### DIFF
--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -327,17 +327,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             },
         ]
         self._state.update(await self._get_states(categories))
-        if self._state.get("device_unique_id") is None:
-            _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
-            return {}
-        if self._state.get("device_unique_id") != self._device_unique_id:
-            _LOGGER.error(
-                "Coordinator error. OPNsense Router Device ID (%s) differs from the one saved in "
-                "hass-opnsense (%s)",
-                self._state.get("device_unique_id"),
-                self._device_unique_id,
-            )
-            # Create repair task here
+        if not await self._check_device_unique_id():
             return {}
         restapi_count = await self._client.get_query_counts()
         _LOGGER.debug(

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -358,10 +358,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                         f"previous_state.{vpn_type}.{clients_servers}",
                         {},
                     )
-                    if (
-                        not isinstance(previous_clients_servers, MutableMapping)
-                        or instance_name not in previous_clients_servers
-                    ):
+                    if not isinstance(previous_clients_servers, MutableMapping):
                         continue
 
                     previous_instance = previous_clients_servers.get(instance_name)
@@ -510,7 +507,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             change: float = current_parent_value - previous_parent_value
             rate: float = max(change, 0) / elapsed_time
-        except TypeError, KeyError, ZeroDivisionError:
+        except TypeError, ZeroDivisionError:
             rate = 0
 
         value: float = 0
@@ -519,11 +516,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             value = rate
         elif "bytes" in prop_name:
             label = "kilobytes_per_second"
-            # 1 Byte = 8 bits
-            # 1 byte is equal to 0.001 kilobytes
-            kbs: float = rate / 1000
-            # Kbs = kbs * 8
-            value = kbs
+            value = rate / 1000
         new_property: str = f"{prop_name}_{label}"
         value = round(value)
         return new_property, value

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -40,6 +40,13 @@ if TYPE_CHECKING:
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
+_PREVIOUS_STATE_KEYS: tuple[str, ...] = (
+    "update_time",
+    "interfaces",
+    "openvpn",
+    "wireguard",
+)
+
 
 class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
     """Coordinator class for OPNsense."""
@@ -97,6 +104,18 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         )
         # await self._client.get_host_firmware_version() # Already triggered in
         # __init__.py async_setup_entry
+
+    def _build_previous_state_snapshot(self) -> dict[str, Any]:
+        """Build the previous-state subset used by derived counter rates.
+
+        Returns:
+            dict[str, Any]: Deep-copied counter source fields from the current state.
+        """
+        return {
+            key: copy.deepcopy(self._state[key])
+            for key in _PREVIOUS_STATE_KEYS
+            if key in self._state
+        }
 
     async def _get_states(self, categories: list) -> dict[str, Any]:
         """Fetch state payloads for the requested category call definitions.
@@ -453,8 +472,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             )
             await self._client.reset_query_counts()
 
-            previous_state: dict[str, Any] = copy.deepcopy(self._state)
-            previous_state.pop("previous_state", None)
+            previous_state: dict[str, Any] = self._build_previous_state_snapshot()
 
             # ensure clean state each interval
             self._state = {}

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -338,9 +338,12 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             if vpn_type == "wireguard":
                 cs = ["clients", "servers"]
             for clients_servers in cs:
-                for instance_name in (
-                    dict_get(self._state, f"{vpn_type}.{clients_servers}", {}) or {}
-                ):
+                instances = dict_get(self._state, f"{vpn_type}.{clients_servers}", {}) or {}
+                if not isinstance(instances, Mapping):
+                    continue
+                for instance_name, instance in instances.items():
+                    if not isinstance(instance, MutableMapping):
+                        continue
                     previous_clients_servers = dict_get(
                         self._state,
                         f"previous_state.{vpn_type}.{clients_servers}",
@@ -352,32 +355,25 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     ):
                         continue
 
-                    instance: dict[str, Any] = (
-                        self._state.get(vpn_type, {})
-                        .get(clients_servers, {})
-                        .get(instance_name, {})
-                    )
-                    previous_instance: dict[str, Any] = (
-                        self._state.get("previous_state", {})
-                        .get(vpn_type, {})
-                        .get(clients_servers, {})
-                        .get(instance_name, {})
-                    )
+                    previous_instance = previous_clients_servers.get(instance_name)
+                    if not isinstance(previous_instance, Mapping):
+                        continue
 
                     for prop_name in (
                         "total_bytes_recv",
                         "total_bytes_sent",
                     ):
-                        if "pkts" in prop_name or "bytes" in prop_name:
-                            (
-                                new_property,
-                                value,
-                            ) = await OPNsenseDataUpdateCoordinator._calculate_speed(
-                                prop_name=prop_name,
-                                elapsed_time=elapsed_time,
-                                current_parent_value=instance[prop_name],
-                                previous_parent_value=previous_instance[prop_name],
-                            )
+                        if prop_name not in instance or prop_name not in previous_instance:
+                            continue
+                        (
+                            new_property,
+                            value,
+                        ) = await OPNsenseDataUpdateCoordinator._calculate_speed(
+                            prop_name=prop_name,
+                            elapsed_time=elapsed_time,
+                            current_parent_value=instance[prop_name],
+                            previous_parent_value=previous_instance[prop_name],
+                        )
 
                         instance[new_property] = value
 
@@ -387,12 +383,17 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         Args:
             elapsed_time: Seconds between current and previous coordinator updates.
         """
-        for interface_name, interface in (dict_get(self._state, "interfaces", {}) or {}).items():
+        interfaces = dict_get(self._state, "interfaces", {}) or {}
+        if not isinstance(interfaces, Mapping):
+            return
+        for interface_name, interface in interfaces.items():
+            if not isinstance(interface, MutableMapping):
+                continue
             previous_interface = dict_get(
                 self._state,
                 f"previous_state.interfaces.{interface_name}",
             )
-            if previous_interface is None:
+            if not isinstance(previous_interface, Mapping):
                 continue
 
             for prop_name in (
@@ -401,18 +402,19 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                 "inpkts",
                 "outpkts",
             ):
-                if "pkts" in prop_name or "bytes" in prop_name:
-                    (
-                        new_property,
-                        value,
-                    ) = await OPNsenseDataUpdateCoordinator._calculate_speed(
-                        prop_name=prop_name,
-                        elapsed_time=elapsed_time,
-                        current_parent_value=interface[prop_name],
-                        previous_parent_value=previous_interface[prop_name],
-                    )
+                if prop_name not in interface or prop_name not in previous_interface:
+                    continue
+                (
+                    new_property,
+                    value,
+                ) = await OPNsenseDataUpdateCoordinator._calculate_speed(
+                    prop_name=prop_name,
+                    elapsed_time=elapsed_time,
+                    current_parent_value=interface[prop_name],
+                    previous_parent_value=previous_interface[prop_name],
+                )
 
-                    interface[new_property] = value
+                interface[new_property] = value
 
     async def _calculate_entity_speeds(self) -> None:
         """Populate derived speed metrics for enabled interface and VPN categories."""
@@ -498,8 +500,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             tuple[str, int]: Tuple of derived property name and rounded rate value.
         """
         try:
-            change: float = abs(current_parent_value - previous_parent_value)
-            rate: float = change / elapsed_time
+            change: float = current_parent_value - previous_parent_value
+            rate: float = max(change, 0) / elapsed_time
         except TypeError, KeyError, ZeroDivisionError:
             rate = 0
 

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -278,7 +278,9 @@ async def _get_clients(
         try:
             device_entry = dr.async_get(hass).async_get(opndevice_id)
         except (TypeError, AttributeError, HomeAssistantError) as err:
-            _LOGGER.debug("Unable to resolve OPNsense service device target: %s", err)
+            _LOGGER.debug(
+                "Unable to resolve OPNsense service device target %r: %s", opndevice_id, err
+            )
         else:
             # _LOGGER.debug(f"[get_clients] device_id: {opndevice_id}, device_entry:
             # {device_entry}")
@@ -288,7 +290,9 @@ async def _get_clients(
         try:
             entity_entry = er.async_get(hass).async_get(opnentity_id)
         except (TypeError, AttributeError, HomeAssistantError) as err:
-            _LOGGER.debug("Unable to resolve OPNsense service entity target: %s", err)
+            _LOGGER.debug(
+                "Unable to resolve OPNsense service entity target %r: %s", opnentity_id, err
+            )
         else:
             # _LOGGER.debug(f"[get_clients] entity_id: {opnentity_id}, entity_entry:
             # {entity_entry}")

--- a/custom_components/opnsense/services.py
+++ b/custom_components/opnsense/services.py
@@ -277,8 +277,8 @@ async def _get_clients(
     if opndevice_id:
         try:
             device_entry = dr.async_get(hass).async_get(opndevice_id)
-        except TypeError, AttributeError, HomeAssistantError:
-            pass
+        except (TypeError, AttributeError, HomeAssistantError) as err:
+            _LOGGER.debug("Unable to resolve OPNsense service device target: %s", err)
         else:
             # _LOGGER.debug(f"[get_clients] device_id: {opndevice_id}, device_entry:
             # {device_entry}")
@@ -287,8 +287,8 @@ async def _get_clients(
     if opnentity_id:
         try:
             entity_entry = er.async_get(hass).async_get(opnentity_id)
-        except TypeError, AttributeError, HomeAssistantError:
-            pass
+        except (TypeError, AttributeError, HomeAssistantError) as err:
+            _LOGGER.debug("Unable to resolve OPNsense service entity target: %s", err)
         else:
             # _LOGGER.debug(f"[get_clients] entity_id: {opnentity_id}, entity_entry:
             # {entity_entry}")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1367,3 +1367,55 @@ async def test_async_update_dt_data_device_id_branches(
         # Should return empty dict and not call get_query_counts
         assert res == {}
         assert client.get_query_counts.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+) -> None:
+    """Device-tracker refreshes should use the shared device-ID mismatch policy."""
+    entry = make_config_entry({"device_unique_id": "id"})
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+        device_tracker_coordinator=True,
+    )
+
+    async def fake_get_states(categories: list[dict[str, str]]) -> dict[str, Any]:
+        """Return a mismatched device ID for the device-tracker refresh."""
+        return {
+            "device_unique_id": "other",
+            "host_firmware_version": "fv",
+            "system_info": {"name": "opn"},
+            "arp_table": [],
+        }
+
+    called: dict[str, Any] = {"issue": 0, "shutdown": 0}
+
+    async def fake_shutdown() -> None:
+        """Record coordinator shutdown requests."""
+        called["shutdown"] += 1
+
+    def fake_async_create_issue(**kwargs: Any) -> None:
+        """Record repair issue creation requests."""
+        called["issue"] += 1
+
+    monkeypatch.setattr(coord, "_get_states", fake_get_states)
+    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    object.__setattr__(coord, "async_shutdown", fake_shutdown)
+    object.__setattr__(client, "get_query_counts", AsyncMock(return_value=3))
+
+    assert await coord._async_update_dt_data() == {}
+    assert await coord._async_update_dt_data() == {}
+    assert await coord._async_update_dt_data() == {}
+
+    assert coord._mismatched_count == 3
+    assert called == {"issue": 1, "shutdown": 1}
+    client.get_query_counts.assert_not_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -487,10 +487,10 @@ async def test_calculate_entity_speeds_applies_calculations(
 
 
 @pytest.mark.asyncio
-async def test_calculate_entity_speeds_handles_counter_rollover(
+async def test_calculate_entity_speeds_treats_counter_decrease_as_reset(
     make_config_entry: Callable[..., MockConfigEntry], fake_client: Any
 ) -> None:
-    """Regression: ensure rates never go negative when counters decrease (device reset/rollback)."""
+    """Counter resets should not be reported as traffic spikes."""
     entry = make_config_entry(
         {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_INTERFACES: True, CONF_SYNC_VPN: True}
     )
@@ -519,26 +519,60 @@ async def test_calculate_entity_speeds_handles_counter_rollover(
         },
     }
 
-    # run calculation; code should clamp or avoid negative rates
     await coord._calculate_entity_speeds()
 
-    # interfaces rates exist and are non-negative
     eth0 = coord._state["interfaces"]["eth0"]
-    assert "inbytes_kilobytes_per_second" in eth0
-    assert "outbytes_kilobytes_per_second" in eth0
-    assert "inpkts_packets_per_second" in eth0
-    assert "outpkts_packets_per_second" in eth0
-    assert eth0["inbytes_kilobytes_per_second"] >= 0
-    assert eth0["outbytes_kilobytes_per_second"] >= 0
-    assert eth0["inpkts_packets_per_second"] >= 0
-    assert eth0["outpkts_packets_per_second"] >= 0
+    assert eth0["inbytes_kilobytes_per_second"] == 0
+    assert eth0["outbytes_kilobytes_per_second"] == 0
+    assert eth0["inpkts_packets_per_second"] == 0
+    assert eth0["outpkts_packets_per_second"] == 0
 
-    # openvpn rates exist and are non-negative
     s1 = coord._state["openvpn"]["servers"]["s1"]
-    assert "total_bytes_recv_kilobytes_per_second" in s1
-    assert "total_bytes_sent_kilobytes_per_second" in s1
-    assert s1["total_bytes_recv_kilobytes_per_second"] >= 0
-    assert s1["total_bytes_sent_kilobytes_per_second"] >= 0
+    assert s1["total_bytes_recv_kilobytes_per_second"] == 0
+    assert s1["total_bytes_sent_kilobytes_per_second"] == 0
+
+
+@pytest.mark.asyncio
+async def test_calculate_entity_speeds_skips_missing_counter_values(
+    make_config_entry: Callable[..., MockConfigEntry], fake_client: Any
+) -> None:
+    """Missing counter values should not abort a coordinator refresh."""
+    entry = make_config_entry(
+        {CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_INTERFACES: True, CONF_SYNC_VPN: True}
+    )
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    now = time.time()
+    coord._state = {
+        "update_time": now,
+        "interfaces": {"eth0": {"inbytes": 200, "inpkts": 300}},
+        "openvpn": {"servers": {"s1": {"total_bytes_recv": 1000}}},
+        "wireguard": {"clients": {"c1": {"total_bytes_sent": 2000}}},
+        "previous_state": {
+            "update_time": now - 2,
+            "interfaces": {"eth0": {"inbytes": 100}},
+            "openvpn": {"servers": {"s1": {}}},
+            "wireguard": {"clients": {"c1": {"total_bytes_sent": 1000}}},
+        },
+    }
+
+    await coord._calculate_entity_speeds()
+
+    eth0 = coord._state["interfaces"]["eth0"]
+    assert eth0["inbytes_kilobytes_per_second"] == 0
+    assert "outbytes_kilobytes_per_second" not in eth0
+    assert "inpkts_packets_per_second" not in eth0
+    assert "outpkts_packets_per_second" not in eth0
+    assert "total_bytes_recv_kilobytes_per_second" not in coord._state["openvpn"]["servers"]["s1"]
+    assert coord._state["wireguard"]["clients"]["c1"]["total_bytes_sent_kilobytes_per_second"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1128,12 +1128,12 @@ async def test_build_categories_keeps_firewall_polling_for_legacy_firmware(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_strips_nested_previous_state(
+async def test_async_update_data_preserves_only_counter_snapshot(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
 ) -> None:
-    """Nested previous-state snapshots should not recurse indefinitely."""
+    """Previous state should keep only fields needed for counter rates."""
     entry = make_config_entry({"device_unique_id": "id", CONF_SYNC_INTERFACES: True})
     client = fake_client()()
     coord = OPNsenseDataUpdateCoordinator(
@@ -1145,9 +1145,14 @@ async def test_async_update_data_strips_nested_previous_state(
         config_entry=entry,
     )
 
+    now = time.time()
     coord._state = {
+        "update_time": now,
         "previous_state": {"inner": 1},
         "device_unique_id": "id",
+        "interfaces": {"eth0": {"inbytes": 100}},
+        "openvpn": {"servers": {"s1": {"total_bytes_recv": 1000}}},
+        "firewall": {"rules": {"r1": {"description": "large payload"}}},
         "extra": "keep",
     }
 
@@ -1171,8 +1176,11 @@ async def test_async_update_data_strips_nested_previous_state(
     assert isinstance(out, MutableMapping)
     assert "previous_state" in out
     assert "previous_state" not in out["previous_state"]
-    assert out["previous_state"].get("device_unique_id") == "id"
-    assert out["previous_state"].get("extra") == "keep"
+    assert out["previous_state"] == {
+        "update_time": now,
+        "interfaces": {"eth0": {"inbytes": 100}},
+        "openvpn": {"servers": {"s1": {"total_bytes_recv": 1000}}},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -576,6 +576,88 @@ async def test_calculate_entity_speeds_skips_missing_counter_values(
 
 
 @pytest.mark.asyncio
+async def test_calculate_vpn_speeds_skips_malformed_payloads(
+    make_config_entry: Callable[..., MockConfigEntry], fake_client: Any
+) -> None:
+    """Malformed VPN counter payloads should be ignored without mutating valid rows."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_VPN: True})
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    coord._state = {
+        "openvpn": {
+            "servers": ["malformed"],
+        },
+        "wireguard": {
+            "clients": {
+                "bad_current": [],
+                "bad_previous_parent": {"total_bytes_recv": 200},
+            },
+            "servers": {
+                "bad_previous_instance": {"total_bytes_recv": 200},
+            },
+        },
+        "previous_state": {
+            "wireguard": {
+                "clients": ["malformed"],
+                "servers": {"bad_previous_instance": []},
+            },
+        },
+    }
+
+    await coord._calculate_vpn_speeds(elapsed_time=2)
+
+    assert coord._state["wireguard"]["clients"]["bad_previous_parent"] == {"total_bytes_recv": 200}
+    assert coord._state["wireguard"]["servers"]["bad_previous_instance"] == {
+        "total_bytes_recv": 200
+    }
+
+
+@pytest.mark.asyncio
+async def test_calculate_interface_speeds_skips_malformed_payloads(
+    make_config_entry: Callable[..., MockConfigEntry], fake_client: Any
+) -> None:
+    """Malformed interface counter payloads should be ignored without mutating valid rows."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_INTERFACES: True})
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+
+    coord._state = {"interfaces": ["malformed"]}
+    await coord._calculate_interface_speeds(elapsed_time=2)
+    assert coord._state["interfaces"] == ["malformed"]
+
+    coord._state = {
+        "interfaces": {
+            "bad_current": [],
+            "bad_previous": {"inbytes": 200},
+        },
+        "previous_state": {
+            "interfaces": {
+                "bad_previous": [],
+            },
+        },
+    }
+
+    await coord._calculate_interface_speeds(elapsed_time=2)
+
+    assert coord._state["interfaces"]["bad_previous"] == {"inbytes": 200}
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_reentrancy_and_full_flow(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -446,13 +446,10 @@ async def test_async_remove_config_entry_device_branches(
     device.via_device_id = False
     device.id = "d2"
 
-    class EntityRegistry:
-        pass
-
     # fake registry that returns one entity with matching device_id
     ent = MagicMock()
     ent.device_id = "d2"
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: EntityRegistry())
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: object())
     monkeypatch.setattr(
         init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -148,8 +148,7 @@ class _FakeRuntimeClient:
 class _FakeCoordinator:
     """Minimal coordinator stand‑in used for async_setup_entry tests."""
 
-    def __init__(self, **kwargs: Any) -> None:  # pragma: no cover - simple init
-        # capture flags we care about for assertions if needed
+    def __init__(self, **kwargs: Any) -> None:
         """Capture the flags needed by async setup tests.
 
         Args:
@@ -168,7 +167,7 @@ class _FakeCoordinator:
         self._refreshed = True
         return True
 
-    async def async_shutdown(self) -> bool:  # pragma: no cover - not used in happy path
+    async def async_shutdown(self) -> bool:
         """Return a successful shutdown result for setup failure branches.
 
         Returns:
@@ -232,7 +231,7 @@ def _build_mock_hass() -> Any:
 
         async def async_forward_entry_setups(
             self, entry: MockConfigEntry, platforms: Iterable[str]
-        ) -> bool:  # pragma: no cover
+        ) -> bool:
             """Async forward entry setups.
 
             Args:
@@ -243,7 +242,7 @@ def _build_mock_hass() -> Any:
 
         async def async_unload_platforms(
             self, entry: MockConfigEntry, platforms: Iterable[str]
-        ) -> bool:  # pragma: no cover
+        ) -> bool:
             """Async unload platforms.
 
             Args:
@@ -252,9 +251,7 @@ def _build_mock_hass() -> Any:
             """
             return True
 
-        async def async_reload(
-            self, entry_id: str
-        ) -> None:  # pragma: no cover - reload path not asserted
+        async def async_reload(self, entry_id: str) -> None:
             """Async reload.
 
             Args:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1448,6 +1448,57 @@ def test_interface_sensor_with_dotted_key_parses_interface_name(
     assert sensor.native_value == 321
 
 
+@pytest.mark.asyncio
+async def test_interface_rate_sensor_unavailable_when_counter_disappears_mid_refresh(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Interface rate sensors should become unavailable when a derived counter disappears."""
+    state = {
+        "interfaces": {
+            "eth0": {
+                "name": "eth0",
+                "inbytes_kilobytes_per_second": 123,
+                "inbytes": 2048,
+                "status": "up",
+                "interface": "eth0",
+                "device": "eth0",
+            }
+        }
+    }
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+
+    entities = await sensor_module._compile_interface_sensors(entry, coordinator, state)
+    rate_sensor = next(
+        entity
+        for entity in entities
+        if entity.entity_description.key == "interface.eth0.inbytes_kilobytes_per_second"
+    )
+    rate_sensor.hass = MagicMock()
+    rate_sensor.entity_id = "sensor.eth0_inbytes_kilobytes_per_second"
+    object.__setattr__(rate_sensor, "async_write_ha_state", lambda: None)
+
+    rate_sensor._handle_coordinator_update()
+    assert rate_sensor.available is True
+    assert rate_sensor.native_value == 123
+
+    coordinator.data = {
+        "interfaces": {
+            "eth0": {
+                "name": "eth0",
+                "inbytes": 4096,
+                "status": "up",
+                "interface": "eth0",
+                "device": "eth0",
+            }
+        }
+    }
+
+    rate_sensor._handle_coordinator_update()
+    assert rate_sensor.available is False
+
+
 @pytest.mark.parametrize("description_key", ["interface", "interface.lan"])
 def test_interface_sensor_invalid_description_key_unavailable(
     description_key: str,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,6 +4,7 @@ These tests exercise service helpers, validation paths, and error handling
 for operations such as starting/stopping services and generating vouchers.
 """
 
+import logging
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
@@ -93,7 +94,9 @@ async def test_get_clients_single_and_multiple(monkeypatch: pytest.MonkeyPatch) 
 
 
 @pytest.mark.asyncio
-async def test_get_clients_registry_errors_are_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_get_clients_registry_errors_are_ignored(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Verify that _get_clients returns all configured clients even when registry lookups raise exceptions. Device or entity registry lookups may raise exceptions; ensure these are ignored."""
     hass_local = MagicMock(spec=HomeAssistant)
     c1, c2 = MagicMock(name="c1"), MagicMock(name="c2")
@@ -123,8 +126,16 @@ async def test_get_clients_registry_errors_are_ignored(monkeypatch: pytest.Monke
 
     monkeypatch.setattr(services_mod.dr, "async_get", _raises(TypeError()))
     monkeypatch.setattr(services_mod.er, "async_get", _raises(AttributeError()))
-    res = await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
+    with caplog.at_level(logging.DEBUG, logger=services_mod._LOGGER.name):
+        res = await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
     assert res == [c1, c2]
+    debug_args = [
+        record.args
+        for record in caplog.records
+        if record.name == services_mod._LOGGER.name and isinstance(record.args, tuple)
+    ]
+    assert any(args[0] == "d" for args in debug_args)
+    assert any(args[0] == "e" for args in debug_args)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Refines OPNsense coordinator refresh handling for derived counter rates, previous-state snapshots, and device-ID validation. The coordinator now avoids false traffic spikes after counter resets and is more resilient to partial external API payloads.

## What Changed
- Treat counter decreases as resets so derived rate sensors report zero instead of inflated traffic.
- Skip incomplete interface and VPN counter pairs instead of aborting the coordinator refresh.
- Narrow previous-state snapshots to only the fields needed for derived counter rates.
- Reuse the shared device-ID mismatch policy for device-tracker coordinator refreshes.
- Add coordinator regression coverage for reset handling, missing counters, snapshot scope, and device-tracker mismatch escalation.
- Clean up the counter helper implementation after the behavior changes were locked by tests.

## Why
External OPNsense payloads can be partial, and router/interface resets can lower counters. Those cases should not take all coordinator-backed entities stale or create misleading rate sensor values. Sharing the device-ID validation path also keeps standard and device-tracker coordinator behavior consistent.

## Related Issues
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speed calculations so reset or decreased counters now report `0` instead of a negative rate.
  * More reliably handles missing or malformed VPN/interface data during refreshes, keeping valid sensor data intact.
  * Device-tracker updates now follow the same mismatch handling as other updates, reducing inconsistent behavior.
  * Rate sensors now become unavailable when their source counter disappears during a refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->