### PR TITLE
Refine coordinator update handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ junit.xml
 pytest.xml
 pythonenv*
 Thumbs.db
+uv.lock
 venv.bak/
 venv/
 *.egg-info/

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -246,27 +246,23 @@ class OPNsenseInterfaceEnabledBinarySensor(OPNsenseBinarySensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3 or key_parts[0] != "interface" or key_parts[2] != "enabled":
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         interface_name = key_parts[1]
         interface = dict_get(state, f"interfaces.{interface_name}", {})
         if not isinstance(interface, Mapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         enabled = coerce_bool(interface.get("enabled"))
         if enabled is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -286,21 +282,18 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3 or key_parts[0] != "smart" or key_parts[2] != "status":
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         expected_device_slug = key_parts[1]
 
         smart_devices = state.get("smart")
         if not isinstance(smart_devices, list):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         smart_device: Mapping[str, Any] | None = None
@@ -315,8 +308,7 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
                 break
 
         if smart_device is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         device_name = smart_device.get("device")
@@ -350,8 +342,7 @@ class OPNsenseSmartStatusBinarySensor(OPNsenseBinarySensor):
             status_passed = smart_status.strip().upper() == "PASSED"
 
         if status_passed is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -380,14 +371,12 @@ class OPNsensePendingNoticesPresentBinarySensor(OPNsenseBinarySensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             self._attr_is_on = state["notices"]["pending_notices_present"]
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -364,8 +364,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         state: dict[str, Any] = self.coordinator.data
         arp_table = dict_get(state, "arp_table")
         if not isinstance(arp_table, list) or not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         entry: MutableMapping[str, Any] | None = None

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -1,5 +1,6 @@
 """Define the base entities for OPNsense."""
 
+from collections.abc import MutableMapping
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -79,6 +80,59 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         """
         state = self.coordinator.data
         return dict_get(state, path)
+
+    def _coordinator_mapping(self) -> MutableMapping[str, Any] | None:
+        """Return coordinator data when it is a mapping.
+
+        Returns:
+            MutableMapping[str, Any] | None: Current coordinator payload, or ``None``
+                when the payload shape is not usable for entity updates.
+        """
+        state = self.coordinator.data
+        return state if isinstance(state, MutableMapping) else None
+
+    def _mapping_at(self, path: str) -> MutableMapping[str, Any] | None:
+        """Return a nested mapping from coordinator data.
+
+        Args:
+            path: Dot-delimited key path inside the coordinator state payload.
+
+        Returns:
+            MutableMapping[str, Any] | None: Nested mapping at ``path``, or ``None``
+                when the value is missing or malformed.
+        """
+        state = self._coordinator_mapping()
+        if state is None:
+            return None
+        value = dict_get(state, path)
+        return value if isinstance(value, MutableMapping) else None
+
+    def _list_at(self, path: str) -> list[Any] | None:
+        """Return a nested list from coordinator data.
+
+        Args:
+            path: Dot-delimited key path inside the coordinator state payload.
+
+        Returns:
+            list[Any] | None: Nested list at ``path``, or ``None`` when missing or malformed.
+        """
+        state = self._coordinator_mapping()
+        if state is None:
+            return None
+        value = dict_get(state, path)
+        return value if isinstance(value, list) else None
+
+    def _mark_unavailable(self, *, clear_attributes: bool = False) -> None:
+        """Mark the entity unavailable and publish the state.
+
+        Args:
+            clear_attributes: Whether to clear extra state attributes while marking
+                the entity unavailable.
+        """
+        self._available = False
+        if clear_attributes:
+            self._attr_extra_state_attributes = {}
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Attach runtime client and trigger an immediate coordinator update callback."""

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1318,8 +1318,7 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
         """Handle coordinator update."""
         value = self._get_opnsense_state_value(self.entity_description.key)
         if value is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         if (
@@ -1327,8 +1326,7 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
             and self._previous_value is None
             and self.entity_description.key == "telemetry.cpu.usage_total"
         ):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         if self.entity_description.key == "telemetry.system.boottime":
@@ -1339,8 +1337,7 @@ class OPNsenseStaticKeySensor(OPNsenseSensor):
                 value = self._previous_value
 
             if value == 0:
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
         elif self.entity_description.key == "certificates":
             value = len(value)
@@ -1372,27 +1369,23 @@ class OPNsenseVnstatSensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         _, interface_name, metric_name = key_parts
 
         metric = dict_get(state, f"vnstat.interfaces.{interface_name}.metrics.{metric_name}", {})
         if not isinstance(metric, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         total = metric.get("total_bytes")
         if not isinstance(total, int):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -1417,27 +1410,23 @@ class OPNsenseSpeedtestSensor(OPNsenseSensor):
         """Handle coordinator updates for speedtest sensors."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         _, speedtest_section, metric_name = key_parts
 
         metric = dict_get(state, f"speedtest.{speedtest_section}.{metric_name}", {})
         if not isinstance(metric, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         value = metric.get("value")
         if not isinstance(value, (int, float)):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -1463,25 +1452,21 @@ class OPNsenseSmartSensor(OPNsenseSensor):
         """Handle coordinator updates for SMART disk sensors."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         _, expected_device_slug, prop_name = key_parts
         if prop_name != "temperature":
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         smart_devices = state.get("smart")
         if not isinstance(smart_devices, list):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         smart_device: Mapping[str, Any] | None = None
@@ -1496,8 +1481,7 @@ class OPNsenseSmartSensor(OPNsenseSensor):
                 break
 
         if smart_device is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         device_name = smart_device.get("device")
@@ -1507,19 +1491,16 @@ class OPNsenseSmartSensor(OPNsenseSensor):
             smart_info.get(normalized_device_name) if isinstance(smart_info, Mapping) else None
         )
         if not isinstance(device_info, Mapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         temperature_entry = device_info.get("temperature")
         if not isinstance(temperature_entry, (Mapping, int, float)):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         if isinstance(temperature_entry, bool):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         temperature: int | float | None = None
@@ -1533,8 +1514,7 @@ class OPNsenseSmartSensor(OPNsenseSensor):
                     temperature = None
 
         if temperature is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -1595,40 +1575,34 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         key_parts = self.entity_description.key.split(".", 1)
         if len(key_parts) != 2:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         interface_and_prop = key_parts[1]
         interface_name_parts = interface_and_prop.rsplit(".", 1)
         if len(interface_name_parts) != 2:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         interface_name, prop_name = interface_name_parts
         interface: dict[str, Any] = {}
         interfaces = state.get("interfaces")
         if not isinstance(interfaces, Mapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         for i_interface_name, iface in interfaces.items():
             if i_interface_name == interface_name:
                 interface = iface
                 break
         if not interface:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             self._attr_native_value = interface[prop_name]
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -1652,8 +1626,7 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
                 self._attr_extra_state_attributes[attr] = interface[attr]
         if interface.get("enabled") is not None and not coerce_bool(interface.get("enabled")):
             self._attr_native_value = None
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self.async_write_ha_state()
 
@@ -1678,13 +1651,11 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
         carp_interface: dict[str, Any] = {}
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         key_data = _parse_carp_interface_sensor_key(self.entity_description.key)
         if key_data is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         expected_interface_slug, expected_subnet_slug = key_data
         carp_interfaces = dict_get(state, "carp.interfaces", []) or []
@@ -1713,15 +1684,13 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
             carp_interface = dict(i_interface)
             break
         if not carp_interface:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         try:
             self._attr_native_value = carp_interface["status"]
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -1760,20 +1729,17 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         summary_raw = dict_get(state, "carp.status_summary")
         if not isinstance(summary_raw, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         summary = dict(summary_raw)
         raw_summary_state = summary.get("state")
         if not isinstance(raw_summary_state, str) or not raw_summary_state:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         self._available = True
@@ -1838,25 +1804,21 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         key_parts = self.entity_description.key.split(".", 1)
         if len(key_parts) != 2:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         gateway_and_prop = key_parts[1]
         gateway_name_parts = gateway_and_prop.rsplit(".", 1)
         if len(gateway_name_parts) != 2:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         gateway_name, prop_name = gateway_name_parts
         gateway: dict[str, Any] = self._opnsense_get_gateway_entry(gateway_name)
         if not gateway:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             value = gateway[prop_name]
@@ -1866,14 +1828,12 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
                     value = float(value)
 
             if isinstance(value, str) and len(value) < 1:
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
 
             self._attr_native_value = value
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -2069,14 +2029,12 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         if_name: str = self.entity_description.key.split(".")[1].strip()
         dhcp_leases = state.get("dhcp_leases")
         if not isinstance(dhcp_leases, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         if if_name.lower() == "all":
             leases = dhcp_leases.get("leases", {})
@@ -2084,8 +2042,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
             if not isinstance(leases, MutableMapping) or not isinstance(
                 lease_interfaces, MutableMapping
             ):
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
             self._available = True
             total_lease_count: int = 0
@@ -2103,8 +2060,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                         if_count,
                     )
             except TypeError, KeyError, ZeroDivisionError:
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
             sorted_lease_counts: dict[str, Any] = {
                 key: lease_counts[key] for key in sorted(lease_counts)
@@ -2115,21 +2071,18 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
         else:
             leases = dhcp_leases.get("leases", {})
             if not isinstance(leases, MutableMapping):
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
             interface = leases.get(if_name, [])
             if not isinstance(interface, list):
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
             try:
                 self._attr_native_value = sum(
                     1 for d in interface if d.get("address") not in {None, ""}
                 )
             except TypeError, KeyError, ZeroDivisionError:
-                self._available = False
-                self.async_write_ha_state()
+                self._mark_unavailable()
                 return
             self._available = True
             self._attr_extra_state_attributes = {"Leases": interface}

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1999,7 +1999,11 @@ class OPNsenseTempSensor(OPNsenseSensor):
         if not isinstance(state, MutableMapping):
             self._mark_unavailable()
             return
-        sensor_temp_device: str = self.entity_description.key.split(".")[2]
+        key_parts = self.entity_description.key.split(".")
+        if len(key_parts) != 3:
+            self._mark_unavailable()
+            return
+        sensor_temp_device: str = key_parts[2]
         temps = self._mapping_at("telemetry.temps")
         if temps is None:
             self._mark_unavailable()

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1556,13 +1556,11 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
         filesystem: dict[str, Any] = {}
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         filesystems = self._list_at("telemetry.filesystems")
         if filesystems is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         for fsystem in filesystems:
             if not isinstance(fsystem, MutableMapping):
@@ -1573,15 +1571,13 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
             ):
                 filesystem = dict(fsystem)
         if not filesystem:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         try:
             self._attr_native_value = filesystem["used_pct"]
         except TypeError, KeyError, AttributeError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
 
@@ -1903,8 +1899,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         """Handle coordinator update."""
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 4:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         vpn_type = key_parts[0]
         clients_servers = key_parts[1]
@@ -1912,13 +1907,11 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         prop_name = key_parts[3]
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         instances = self._mapping_at(f"{vpn_type}.{clients_servers}")
         if instances is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         instance: dict[str, Any] = {}
         for instance_uuid, ins in instances.items():
@@ -1930,8 +1923,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             and instance.get("enabled", None) is not None
             and not instance.get("enabled")
         ):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         try:
@@ -1944,8 +1936,7 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             else:
                 self._attr_native_value = instance.get(prop_name)
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
 
@@ -2039,14 +2030,12 @@ class OPNsenseTempSensor(OPNsenseSensor):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         sensor_temp_device: str = self.entity_description.key.split(".")[2]
         temps = self._mapping_at("telemetry.temps")
         if temps is None:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         temp: dict[str, Any] = {}
         for temp_device, temp_temp in temps.items():
@@ -2054,15 +2043,13 @@ class OPNsenseTempSensor(OPNsenseSensor):
                 temp = temp_temp
                 break
         if not temp:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
 
         try:
             self._attr_native_value = temp["temperature"]
         except TypeError, KeyError, ZeroDivisionError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -2005,6 +2005,17 @@ class OPNsenseTempSensor(OPNsenseSensor):
         self.async_write_ha_state()
 
 
+def _count_active_dhcp_leases(leases: Iterable[Any]) -> int | None:
+    """Return active DHCP lease count, or ``None`` when a lease row is malformed."""
+    lease_count = 0
+    for lease in leases:
+        if not isinstance(lease, MutableMapping):
+            return None
+        if lease.get("address") not in {None, ""}:
+            lease_count += 1
+    return lease_count
+
+
 class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
     """Class for OPNsense DHCP Leases Sensors."""
 
@@ -2031,13 +2042,10 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
             lease_counts: dict[str, Any] = {}
             try:
                 for ifn, if_descr in lease_interfaces.items():
-                    if_count: int = 0
-                    for lease in leases.get(ifn, []):
-                        if not isinstance(lease, MutableMapping):
-                            self._mark_unavailable()
-                            return
-                        if lease.get("address") not in {None, ""}:
-                            if_count += 1
+                    if_count = _count_active_dhcp_leases(leases.get(ifn, []))
+                    if if_count is None:
+                        self._mark_unavailable()
+                        return
                     lease_counts[if_descr] = f"{if_count} leases"
                     total_lease_count += if_count
                     _LOGGER.debug(
@@ -2064,13 +2072,10 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                 self._mark_unavailable()
                 return
             try:
-                lease_count = 0
-                for lease in interface:
-                    if not isinstance(lease, MutableMapping):
-                        self._mark_unavailable()
-                        return
-                    if lease.get("address") not in {None, ""}:
-                        lease_count += 1
+                lease_count = _count_active_dhcp_leases(interface)
+                if lease_count is None:
+                    self._mark_unavailable()
+                    return
                 self._attr_native_value = lease_count
             except TypeError, KeyError, AttributeError, ZeroDivisionError:
                 self._mark_unavailable()

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1873,15 +1873,19 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         if instances is None:
             self._mark_unavailable()
             return
-        instance: dict[str, Any] = {}
+        instance: MutableMapping[str, Any] = {}
         for instance_uuid, ins in instances.items():
             if uuid == instance_uuid:
                 instance = ins
                 break
-        if not instance or (
-            prop_name != "status"
-            and instance.get("enabled", None) is not None
-            and not instance.get("enabled")
+        if (
+            not isinstance(instance, MutableMapping)
+            or not instance
+            or (
+                prop_name != "status"
+                and instance.get("enabled", None) is not None
+                and not instance.get("enabled")
+            )
         ):
             self._mark_unavailable()
             return
@@ -1955,6 +1959,9 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         ):
             self._attr_extra_state_attributes["clients"] = []
             for clnt in instance.get("clients", {}):
+                if not isinstance(clnt, MutableMapping):
+                    self._mark_unavailable()
+                    return
                 client: dict[str, Any] = {}
                 for client_attr in (
                     "name",
@@ -2049,9 +2056,13 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
             lease_counts: dict[str, Any] = {}
             try:
                 for ifn, if_descr in lease_interfaces.items():
-                    if_count: int = sum(
-                        1 for d in leases.get(ifn, []) if d.get("address") not in {None, ""}
-                    )
+                    if_count: int = 0
+                    for lease in leases.get(ifn, []):
+                        if not isinstance(lease, MutableMapping):
+                            self._mark_unavailable()
+                            return
+                        if lease.get("address") not in {None, ""}:
+                            if_count += 1
                     lease_counts[if_descr] = f"{if_count} leases"
                     total_lease_count += if_count
                     _LOGGER.debug(
@@ -2078,9 +2089,14 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                 self._mark_unavailable()
                 return
             try:
-                self._attr_native_value = sum(
-                    1 for d in interface if d.get("address") not in {None, ""}
-                )
+                lease_count = 0
+                for lease in interface:
+                    if not isinstance(lease, MutableMapping):
+                        self._mark_unavailable()
+                        return
+                    if lease.get("address") not in {None, ""}:
+                        lease_count += 1
+                self._attr_native_value = lease_count
             except TypeError, KeyError, ZeroDivisionError:
                 self._mark_unavailable()
                 return

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -2074,7 +2074,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                         if_descr,
                         if_count,
                     )
-            except TypeError, KeyError, ZeroDivisionError:
+            except TypeError, KeyError, AttributeError, ZeroDivisionError:
                 self._mark_unavailable()
                 return
             sorted_lease_counts: dict[str, Any] = {
@@ -2101,7 +2101,7 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
                     if lease.get("address") not in {None, ""}:
                         lease_count += 1
                 self._attr_native_value = lease_count
-            except TypeError, KeyError, ZeroDivisionError:
+            except TypeError, KeyError, AttributeError, ZeroDivisionError:
                 self._mark_unavailable()
                 return
             self._available = True

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1559,12 +1559,19 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
             self._available = False
             self.async_write_ha_state()
             return
-        for fsystem in state.get("telemetry", {}).get("filesystems", []):
+        filesystems = self._list_at("telemetry.filesystems")
+        if filesystems is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
+        for fsystem in filesystems:
+            if not isinstance(fsystem, MutableMapping):
+                continue
             if (
                 self.entity_description.key == "telemetry.filesystems."
                 f"{slugify_filesystem_mountpoint(fsystem.get('mountpoint', None))}"
             ):
-                filesystem = fsystem
+                filesystem = dict(fsystem)
         if not filesystem:
             self._available = False
             self.async_write_ha_state()
@@ -1908,10 +1915,13 @@ class OPNsenseVPNSensor(OPNsenseSensor):
             self._available = False
             self.async_write_ha_state()
             return
+        instances = self._mapping_at(f"{vpn_type}.{clients_servers}")
+        if instances is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
         instance: dict[str, Any] = {}
-        for instance_uuid, ins in (
-            dict_get(state, f"{vpn_type}.{clients_servers}", {}) or {}
-        ).items():
+        for instance_uuid, ins in instances.items():
             if uuid == instance_uuid:
                 instance = ins
                 break
@@ -2033,8 +2043,13 @@ class OPNsenseTempSensor(OPNsenseSensor):
             self.async_write_ha_state()
             return
         sensor_temp_device: str = self.entity_description.key.split(".")[2]
+        temps = self._mapping_at("telemetry.temps")
+        if temps is None:
+            self._available = False
+            self.async_write_ha_state()
+            return
         temp: dict[str, Any] = {}
-        for temp_device, temp_temp in state.get("telemetry", {}).get("temps", {}).items():
+        for temp_device, temp_temp in temps.items():
             if temp_device == sensor_temp_device:
                 temp = temp_temp
                 break

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1534,10 +1534,6 @@ class OPNsenseFilesystemSensor(OPNsenseSensor):
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
         filesystem: dict[str, Any] = {}
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         filesystems = self._list_at("telemetry.filesystems")
         if filesystems is None:
             self._mark_unavailable()
@@ -1573,10 +1569,6 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         key_parts = self.entity_description.key.split(".", 1)
         if len(key_parts) != 2:
             self._mark_unavailable()
@@ -1588,8 +1580,8 @@ class OPNsenseInterfaceSensor(OPNsenseSensor):
             return
         interface_name, prop_name = interface_name_parts
         interface: dict[str, Any] = {}
-        interfaces = state.get("interfaces")
-        if not isinstance(interfaces, Mapping):
+        interfaces = self._mapping_at("interfaces")
+        if interfaces is None:
             self._mark_unavailable()
             return
         for i_interface_name, iface in interfaces.items():
@@ -1649,16 +1641,15 @@ class OPNsenseCarpInterfaceSensor(OPNsenseSensor):
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
         carp_interface: dict[str, Any] = {}
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         key_data = _parse_carp_interface_sensor_key(self.entity_description.key)
         if key_data is None:
             self._mark_unavailable()
             return
         expected_interface_slug, expected_subnet_slug = key_data
-        carp_interfaces = dict_get(state, "carp.interfaces", []) or []
+        carp_interfaces = self._list_at("carp.interfaces")
+        if carp_interfaces is None:
+            self._mark_unavailable()
+            return
         for i_interface in carp_interfaces:
             if not isinstance(i_interface, MutableMapping):
                 _LOGGER.debug(
@@ -1727,12 +1718,8 @@ class OPNsenseCarpStatusSensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
-        summary_raw = dict_get(state, "carp.status_summary")
-        if not isinstance(summary_raw, MutableMapping):
+        summary_raw = self._mapping_at("carp.status_summary")
+        if summary_raw is None:
             self._mark_unavailable()
             return
 
@@ -1780,8 +1767,8 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
 
     def _opnsense_get_gateway_entry(self, gateway_name: str) -> dict[str, Any]:
         """Return matching gateway payload by mapping key or display name."""
-        gateways = self.coordinator.data.get("gateways", {})
-        if not isinstance(gateways, Mapping):
+        gateways = self._mapping_at("gateways")
+        if gateways is None:
             return {}
         if isinstance(gateways.get(gateway_name), Mapping):
             return dict(gateways[gateway_name])
@@ -1802,10 +1789,6 @@ class OPNsenseGatewaySensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         key_parts = self.entity_description.key.split(".", 1)
         if len(key_parts) != 2:
             self._mark_unavailable()
@@ -1865,10 +1848,6 @@ class OPNsenseVPNSensor(OPNsenseSensor):
         clients_servers = key_parts[1]
         uuid = key_parts[2]
         prop_name = key_parts[3]
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         instances = self._mapping_at(f"{vpn_type}.{clients_servers}")
         if instances is None:
             self._mark_unavailable()
@@ -1995,10 +1974,6 @@ class OPNsenseTempSensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         key_parts = self.entity_description.key.split(".")
         if len(key_parts) != 3 or key_parts[:2] != ["telemetry", "temps"]:
             self._mark_unavailable()
@@ -2038,13 +2013,9 @@ class OPNsenseDHCPLeasesSensor(OPNsenseSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle coordinator update."""
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         if_name: str = self.entity_description.key.split(".")[1].strip()
-        dhcp_leases = state.get("dhcp_leases")
-        if not isinstance(dhcp_leases, MutableMapping):
+        dhcp_leases = self._mapping_at("dhcp_leases")
+        if dhcp_leases is None:
             self._mark_unavailable()
             return
         if if_name.lower() == "all":

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -2000,7 +2000,7 @@ class OPNsenseTempSensor(OPNsenseSensor):
             self._mark_unavailable()
             return
         key_parts = self.entity_description.key.split(".")
-        if len(key_parts) != 3:
+        if len(key_parts) != 3 or key_parts[:2] != ["telemetry", "temps"]:
             self._mark_unavailable()
             return
         sensor_temp_device: str = key_parts[2]

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -829,14 +829,12 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
             return
         rule = self._opnsense_get_rule()
         if not rule:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             self._attr_is_on = bool(rule.get("enabled", "1") == "1")
         except TypeError, KeyError, AttributeError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -965,14 +963,12 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
             return
         rule = self._opnsense_get_rule()
         if not rule:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             self._attr_is_on = bool(rule.get("enabled", "1") == "1")
         except TypeError, KeyError, AttributeError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -1151,8 +1147,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         try:
             self._attr_is_on = self._service[self._prop_name]
         except TypeError, KeyError, AttributeError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}
@@ -1226,8 +1221,7 @@ class OPNsenseUnboundBlocklistSwitchLegacy(OPNsenseSwitch):
             return
         dnsbl = self._mapping_at(f"{ATTR_UNBOUND_BLOCKLIST}.legacy")
         if not isinstance(dnsbl, MutableMapping) or len(dnsbl) == 0:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_is_on = dnsbl.get("enabled", "0") == "1"
@@ -1313,13 +1307,11 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
             return
         state: dict[str, Any] = self.coordinator.data
         if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         dnsbl = self._mapping_at(f"{ATTR_UNBOUND_BLOCKLIST}.{self._uuid}")
         if not isinstance(dnsbl, MutableMapping) or len(dnsbl) == 0:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_is_on = dnsbl.get("enabled", "0") == "1"
@@ -1404,14 +1396,12 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             return
         instance = self._mapping_at(f"{self._vpn_type}.{self._clients_servers}.{self._uuid}")
         if not isinstance(instance, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         try:
             self._attr_is_on = instance["enabled"]
         except TypeError, KeyError, AttributeError:
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
         self._attr_extra_state_attributes = {}

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1394,7 +1394,11 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         if self.delay_update:
             _LOGGER.debug("Skipping coordinator update for VPN switch %s due to delay", self.name)
             return
-        instance = self._mapping_at(f"{self._vpn_type}.{self._clients_servers}.{self._uuid}")
+        vpn_instances = self._mapping_at(f"{self._vpn_type}.{self._clients_servers}")
+        if not isinstance(vpn_instances, MutableMapping):
+            self._mark_unavailable()
+            return
+        instance = vpn_instances.get(self._uuid)
         if not isinstance(instance, MutableMapping):
             self._mark_unavailable()
             return

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -813,10 +813,11 @@ class OPNsenseFirewallRuleSwitch(OPNsenseSwitch):
         Returns:
             MutableMapping[str, Any] | None: The rule data if available, None otherwise.
         """
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
+        rules = self._mapping_at("firewall.rules")
+        if rules is None:
             return None
-        return state.get("firewall", {}).get("rules", {}).get(self._rule_id, None)
+        rule = rules.get(self._rule_id)
+        return rule if isinstance(rule, MutableMapping) else None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -950,15 +951,11 @@ class OPNsenseNATRuleSwitch(OPNsenseSwitch):
         Returns:
             MutableMapping[str, Any] | None: The rule data if available, None otherwise.
         """
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
+        rules = self._mapping_at(f"firewall.nat.{self._nat_rule_type}")
+        if rules is None:
             return None
-        return (
-            state.get("firewall", {})
-            .get("nat", {})
-            .get(self._nat_rule_type, {})
-            .get(self._rule_id, None)
-        )
+        rule = rules.get(self._rule_id)
+        return rule if isinstance(rule, MutableMapping) else None
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -1125,11 +1122,16 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         Returns:
             MutableMapping[str, Any] | None: The service data if available, None otherwise.
         """
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
+        state = self._coordinator_mapping()
+        if state is None:
             return None
         service_id: str = self._opnsense_get_service_id()
-        for service in state.get("services", []):
+        services = state.get("services", [])
+        if not isinstance(services, list):
+            return None
+        for service in services:
+            if not isinstance(service, MutableMapping):
+                continue
             if service.get("id", None) == service_id:
                 return service
         return None
@@ -1144,6 +1146,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
             return
         self._service = self._opnsense_get_service()
         if not isinstance(self._service, MutableMapping):
+            self._mark_unavailable()
             return
         try:
             self._attr_is_on = self._service[self._prop_name]
@@ -1221,7 +1224,7 @@ class OPNsenseUnboundBlocklistSwitchLegacy(OPNsenseSwitch):
                 self.name,
             )
             return
-        dnsbl = self.coordinator.data.get(ATTR_UNBOUND_BLOCKLIST, {}).get("legacy", {})
+        dnsbl = self._mapping_at(f"{ATTR_UNBOUND_BLOCKLIST}.legacy")
         if not isinstance(dnsbl, MutableMapping) or len(dnsbl) == 0:
             self._available = False
             self.async_write_ha_state()
@@ -1313,7 +1316,7 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
             self._available = False
             self.async_write_ha_state()
             return
-        dnsbl = self.coordinator.data.get(ATTR_UNBOUND_BLOCKLIST, {}).get(self._uuid, {})
+        dnsbl = self._mapping_at(f"{ATTR_UNBOUND_BLOCKLIST}.{self._uuid}")
         if not isinstance(dnsbl, MutableMapping) or len(dnsbl) == 0:
             self._available = False
             self.async_write_ha_state()
@@ -1399,14 +1402,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
         if self.delay_update:
             _LOGGER.debug("Skipping coordinator update for VPN switch %s due to delay", self.name)
             return
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._available = False
-            self.async_write_ha_state()
-            return
-        instance: dict[str, Any] = (
-            state.get(self._vpn_type, {}).get(self._clients_servers, {}).get(self._uuid, {})
-        )
+        instance = self._mapping_at(f"{self._vpn_type}.{self._clients_servers}.{self._uuid}")
         if not isinstance(instance, MutableMapping):
             self._available = False
             self.async_write_ha_state()

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1305,12 +1305,8 @@ class OPNsenseUnboundBlocklistSwitch(OPNsenseSwitch):
                 self.name,
             )
             return
-        state: dict[str, Any] = self.coordinator.data
-        if not isinstance(state, MutableMapping):
-            self._mark_unavailable()
-            return
         dnsbl = self._mapping_at(f"{ATTR_UNBOUND_BLOCKLIST}.{self._uuid}")
-        if not isinstance(dnsbl, MutableMapping) or len(dnsbl) == 0:
+        if dnsbl is None or len(dnsbl) == 0:
             self._mark_unavailable()
             return
         self._available = True
@@ -1395,7 +1391,7 @@ class OPNsenseVPNSwitch(OPNsenseSwitch):
             _LOGGER.debug("Skipping coordinator update for VPN switch %s due to delay", self.name)
             return
         vpn_instances = self._mapping_at(f"{self._vpn_type}.{self._clients_servers}")
-        if not isinstance(vpn_instances, MutableMapping):
+        if vpn_instances is None:
             self._mark_unavailable()
             return
         instance = vpn_instances.get(self._uuid)

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -171,8 +171,7 @@ class OPNsenseFirmwareUpdatesAvailableUpdate(OPNsenseUpdate):
         """Handle coordinator update."""
         state: dict[str, Any] = self.coordinator.data
         if not self._is_update_available(state):
-            self._available = False
-            self.async_write_ha_state()
+            self._mark_unavailable()
             return
         self._available = True
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -78,6 +78,36 @@ def test_get_opnsense_state_value_nested_lookup(
     assert ent._get_opnsense_state_value("non.existent.path") is None
 
 
+def test_entity_helpers_fail_closed_for_non_mapping_coordinator_data(
+    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
+) -> None:
+    """Entity helper lookups should return ``None`` when coordinator data is malformed."""
+    entry = make_config_entry()
+    coord = dummy_coordinator
+    coord.data = []
+    ent = OPNsenseBaseEntity(config_entry=entry, coordinator=coord, unique_id_suffix="test")
+
+    assert ent._mapping_at("anything") is None
+    assert ent._list_at("anything") is None
+
+
+def test_mark_unavailable_can_clear_attributes(
+    make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
+) -> None:
+    """Marking unavailable can clear stale attributes when requested."""
+    entry = make_config_entry()
+    coord = dummy_coordinator
+    ent = OPNsenseBaseEntity(config_entry=entry, coordinator=coord, unique_id_suffix="test")
+    ent._available = True
+    ent._attr_extra_state_attributes = {"stale": "value"}
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._mark_unavailable(clear_attributes=True)
+
+    assert ent.available is False
+    assert ent.extra_state_attributes == {}
+
+
 @pytest.mark.asyncio
 async def test_async_added_to_hass_sets_client_and_calls_update(
     make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -28,6 +28,7 @@ from custom_components.opnsense.sensor import (
     OPNsenseCarpInterfaceSensor,
     OPNsenseCarpStatusSensor,
     OPNsenseDHCPLeasesSensor,
+    OPNsenseFilesystemSensor,
     OPNsenseGatewaySensor,
     OPNsenseInterfaceSensor,
     OPNsenseSmartSensor,
@@ -1136,6 +1137,27 @@ def test_vpn_sensor_handles_exceptions_from_instance_get(
     assert s.available is False
 
 
+def test_vpn_sensor_fails_closed_for_malformed_instance_collection(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """VPN sensor should mark unavailable when the instance collection is malformed."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"openvpn": {"servers": "not-a-mapping"}}
+    desc = MagicMock()
+    desc.key = "openvpn.servers.uuid1.status"
+    desc.name = "VPN Malformed"
+
+    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.vpn_malformed"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
 @pytest.mark.parametrize(
     ("coord_data", "expected_available", "expected_value", "expect_device"),
     [
@@ -1225,6 +1247,48 @@ def test_temp_sensor_handles_index_exceptions(
     s.hass = MagicMock()
     s.entity_id = "sensor.temp_broken"
     object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
+def test_temp_sensor_fails_closed_for_malformed_telemetry_payload(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Temp sensor should mark unavailable when telemetry is not a mapping."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"telemetry": "not-a-mapping"}
+    desc = MagicMock()
+    desc.key = "telemetry.temps.sensor1"
+    desc.name = "Temp Malformed"
+
+    s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.temp_malformed"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
+def test_filesystem_sensor_fails_closed_for_malformed_telemetry_payload(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Filesystem sensor should mark unavailable when telemetry is not a mapping."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"telemetry": "not-a-mapping"}
+    desc = MagicMock()
+    desc.key = "telemetry.filesystems.root"
+    desc.name = "Filesystem Malformed"
+
+    s = OPNsenseFilesystemSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.filesystem_malformed"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+
     s._handle_coordinator_update()
 
     assert s.available is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1236,6 +1236,27 @@ def test_temp_sensor_basic_variants(
             assert attrs.get("device_id") == "dev0"
 
 
+def test_temp_sensor_key_malformed_key_marked_unavailable(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed temp sensor keys should fail closed to unavailable instead of raising."""
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}}}
+    entry = make_config_entry()
+
+    desc = MagicMock()
+    desc.key = "telemetry.temps"
+    desc.name = "Malformed Temp Key"
+
+    s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.temp_malformed_key"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_temp_sensor_handles_index_exceptions(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1331,6 +1331,27 @@ def test_temp_sensor_key_malformed_key_marked_unavailable(
     assert s.available is False
 
 
+def test_temp_sensor_key_wrong_prefix_marked_unavailable(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Wrong key prefix should fail closed even when matching telemetry value exists."""
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}}}
+    entry = make_config_entry()
+
+    desc = MagicMock()
+    desc.key = "foo.bar.sensor1"
+    desc.name = "Wrong Prefix Temp Key"
+
+    s = OPNsenseTempSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.temp_wrong_prefix_key"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
 def test_temp_sensor_handles_index_exceptions(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2386,52 +2386,6 @@ def test_dhcp_leases_per_interface_handles_exceptions(
     assert any(w is False for w in writes), f"expected a False write captured, got {writes}"
 
 
-def test_dhcp_leases_coverage_tracer(make_config_entry: Callable[..., MockConfigEntry]) -> None:
-    """Exercise the BrokenLease path and verify the observable failure behavior.
-
-    Instead of inspecting source lines directly, the test triggers the same
-    lease-access failure and asserts that the sensor becomes unavailable and
-    writes state.
-    """
-
-    class BrokenLease:
-        def get(self, *args, **kwargs) -> Never:
-            """Raise ``TypeError`` when the sensor reads the tracer lease mapping.
-
-            Args:
-                *args: Additional positional arguments forwarded by the function.
-                **kwargs: Additional keyword arguments forwarded by the function.
-
-            Raises:
-                TypeError: If a supplied argument has an unsupported type.
-            """
-            raise TypeError("simulated")
-
-    entry = make_config_entry()
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"dhcp_leases": {"leases": {"lan": [BrokenLease()]}}}
-
-    desc = MagicMock()
-    desc.key = "dhcp_leases.lan"
-    desc.name = "DHCP Per-Interface Collector"
-
-    s = OPNsenseDHCPLeasesSensor(config_entry=entry, coordinator=coord, entity_description=desc)
-    s.hass = MagicMock()
-    s.entity_id = "sensor.dhcp_per_if_collector"
-
-    writes: list[bool] = []
-
-    def collector() -> None:
-        """Collector."""
-        writes.append(bool(getattr(s, "_available", None)))
-
-    object.__setattr__(s, "async_write_ha_state", collector)
-    s._handle_coordinator_update()
-
-    assert writes, "async_write_ha_state was not called"
-    assert any(w is False for w in writes), f"expected a False write captured, got {writes}"
-
-
 def _setup_entry_with_all_syncs(
     state: dict, make_config_entry: Callable[..., MockConfigEntry]
 ) -> Any:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1159,6 +1159,39 @@ def test_vpn_sensor_fails_closed_for_malformed_instance_collection(
 
 
 @pytest.mark.parametrize(
+    ("coord_data", "key"),
+    [
+        ({"openvpn": {"servers": {"uuid1": "not-a-mapping"}}}, "openvpn.servers.uuid1.status"),
+        (
+            {"openvpn": {"servers": {"uuid1": {"clients": ["not-a-mapping"], "status": "up"}}}},
+            "openvpn.servers.uuid1.status",
+        ),
+    ],
+)
+def test_vpn_sensor_fails_closed_for_malformed_instance_members(
+    coord_data: dict[str, Any],
+    key: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """VPN sensor should mark unavailable when matched instance members are malformed."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+    desc = MagicMock()
+    desc.key = key
+    desc.name = "VPN Malformed Member"
+
+    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.vpn_malformed_member"
+    object.__setattr__(s, "async_write_ha_state", lambda: None)
+
+    s._handle_coordinator_update()
+
+    assert s.available is False
+
+
+@pytest.mark.parametrize(
     ("coord_data", "expected_available", "expected_value", "expect_device"),
     [
         ([], False, None, False),
@@ -1820,6 +1853,57 @@ def test_dhcp_leases_interface_sensor_handles_non_mapping_leases(
         writes.append(bool(getattr(s, "_available", None)))
 
     object.__setattr__(s, "async_write_ha_state", collector)
+    s._handle_coordinator_update()
+
+    assert s.available is False
+    assert writes == [False]
+
+
+@pytest.mark.parametrize(
+    ("key", "coord_data"),
+    [
+        (
+            "dhcp_leases.all",
+            {
+                "dhcp_leases": {
+                    "leases": {"lan": ["not-a-mapping"]},
+                    "lease_interfaces": {"lan": "LAN"},
+                }
+            },
+        ),
+        (
+            "dhcp_leases.lan",
+            {"dhcp_leases": {"leases": {"lan": ["not-a-mapping"]}}},
+        ),
+    ],
+)
+def test_dhcp_leases_sensor_fails_closed_for_scalar_lease_rows(
+    key: str,
+    coord_data: dict[str, Any],
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """DHCP leases sensors should mark unavailable when a lease row is malformed."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+
+    desc = MagicMock()
+    desc.key = key
+    desc.name = "DHCP Scalar Lease"
+
+    s = OPNsenseDHCPLeasesSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    s.hass = MagicMock()
+    s.entity_id = "sensor.dhcp_scalar_lease"
+
+    writes: list[bool] = []
+
+    def collector() -> None:
+        """Collect availability when the entity state is written."""
+        writes.append(bool(getattr(s, "_available", None)))
+
+    object.__setattr__(s, "async_write_ha_state", collector)
+    s._available = True
+
     s._handle_coordinator_update()
 
     assert s.available is False

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2106,7 +2106,7 @@ def test_dhcp_leases_sensor_fails_closed_for_scalar_lease_rows(
     assert writes == [False]
 
 
-@pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
+@pytest.mark.parametrize("exc_type", [TypeError, KeyError, AttributeError, ZeroDivisionError])
 def test_dhcp_leases_handles_exceptions(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -2159,7 +2159,7 @@ def test_dhcp_leases_handles_exceptions(
     assert s.available is False
 
 
-@pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
+@pytest.mark.parametrize("exc_type", [TypeError, KeyError, AttributeError, ZeroDivisionError])
 def test_dhcp_lease_interfaces_items_raises(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -2196,7 +2196,7 @@ def test_dhcp_lease_interfaces_items_raises(
     assert s.available is False
 
 
-@pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
+@pytest.mark.parametrize("exc_type", [TypeError, KeyError, AttributeError, ZeroDivisionError])
 def test_dhcp_leases_iterable_raises_on_iter(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -2329,7 +2329,7 @@ def test_dhcp_leases_items_except_writes_unavailable(
     assert any(w is False for w in writes), f"expected a False write captured, got {writes}"
 
 
-@pytest.mark.parametrize("exc_type", [TypeError, KeyError, ZeroDivisionError])
+@pytest.mark.parametrize("exc_type", [TypeError, KeyError, AttributeError, ZeroDivisionError])
 def test_dhcp_leases_per_interface_handles_exceptions(
     exc_type: type[Exception], make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -226,6 +226,50 @@ def test_sensors_unavailable_on_non_mapping_state(
 
 
 @pytest.mark.parametrize(
+    ("coord_data", "desc_key"),
+    [
+        ([], "vnstat.igc0.vnstat_today"),
+        ({"vnstat": {"interfaces": {"igc0": {"metrics": {}}}}}, "vnstat.igc0"),
+        (
+            {"vnstat": {"interfaces": {"igc0": {"metrics": {"vnstat_today": []}}}}},
+            "vnstat.igc0.vnstat_today",
+        ),
+        (
+            {
+                "vnstat": {
+                    "interfaces": {"igc0": {"metrics": {"vnstat_today": {"total_bytes": "100"}}}}
+                }
+            },
+            "vnstat.igc0.vnstat_today",
+        ),
+    ],
+    ids=["state-not-mapping", "invalid-key", "metric-not-mapping", "total-not-int"],
+)
+def test_vnstat_sensor_fails_closed_for_malformed_payloads(
+    coord_data: Any,
+    desc_key: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Vnstat sensors should become unavailable for malformed payload shapes."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+
+    desc = MagicMock()
+    desc.key = desc_key
+    desc.name = "Vnstat Malformed"
+
+    sensor = OPNsenseVnstatSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.vnstat_malformed"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+@pytest.mark.parametrize(
     ("prop_name", "input_value", "expected_available", "expected_value", "expect_down_icon"),
     [
         ("status", "online", True, "online", False),
@@ -737,6 +781,34 @@ def test_carp_status_sensor_normalizes_state_spacing_and_icon(
     assert sensor.icon == "mdi:backup-restore"
 
 
+@pytest.mark.parametrize("summary_state", [None, ""])
+def test_carp_status_sensor_fails_closed_for_missing_state(
+    summary_state: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """CARP status sensor should be unavailable when summary state is missing."""
+    entry = make_config_entry()
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"carp": {"status_summary": {"state": summary_state}}}
+
+    desc = MagicMock()
+    desc.key = "carp.status_summary"
+    desc.name = "CARP Status"
+
+    sensor = OPNsenseCarpStatusSensor(
+        config_entry=entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.carp_status_missing"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
 @pytest.mark.parametrize(
     ("interface_name", "subnet", "expected_key"),
     [
@@ -1097,13 +1169,14 @@ def test_vpn_sensor_handles_exceptions_from_instance_get(
     requested exception so the handler exercises its defensive exception path.
     """
 
-    class BrokenInstance:
+    class BrokenInstance(dict):
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenInstance.
 
             Args:
                 exc: Exc provided by pytest or the test case.
             """
+            super().__init__({"enabled": True})
             self._exc = exc
 
         def get(self, *args, **kwargs) -> Never:
@@ -1196,6 +1269,7 @@ def test_vpn_sensor_fails_closed_for_malformed_instance_members(
     [
         ([], False, None, False),
         ({"telemetry": {}}, False, None, False),
+        ({"telemetry": {"temps": {"other": {"temperature": 55}}}}, False, None, False),
         (
             {"telemetry": {"temps": {"sensor1": {"temperature": 55, "device_id": "dev0"}}}},
             True,
@@ -1349,6 +1423,49 @@ def test_filesystem_sensor_fails_closed_for_malformed_telemetry_payload(
 
 
 @pytest.mark.parametrize(
+    "coord_data",
+    [
+        [],
+        {"telemetry": {"filesystems": "not-a-list"}},
+        {"telemetry": {"filesystems": ["not-a-mapping"]}},
+        {"telemetry": {"filesystems": [{"mountpoint": "/var", "used_pct": 5}]}},
+        {"telemetry": {"filesystems": [{"mountpoint": "/", "device": "/dev/gpt/rootfs"}]}},
+    ],
+    ids=[
+        "state-not-mapping",
+        "filesystems-not-list",
+        "entry-not-mapping",
+        "filesystem-not-found",
+        "missing-used-pct",
+    ],
+)
+def test_filesystem_sensor_fails_closed_for_malformed_filesystems(
+    coord_data: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Filesystem sensor should become unavailable for malformed filesystem payloads."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+    desc = MagicMock()
+    desc.key = "telemetry.filesystems.root"
+    desc.name = "Filesystem Root"
+
+    sensor = OPNsenseFilesystemSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.filesystem_root"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+@pytest.mark.parametrize(
     ("desc_key", "state", "expect_close_icon"),
     [
         (
@@ -1454,6 +1571,7 @@ def test_normalize_filesystem_mountpoint(input_value: Any, expected: str) -> Non
     ("cpu_map", "previous", "expected_available", "expected_value"),
     [
         ({"usage_total": 0}, None, False, None),
+        ({"usage_total": 0}, 0, False, None),
         ({"usage_total": 0, "usage_1": 1}, 7, True, 7),
     ],
 )
@@ -1788,6 +1906,36 @@ def test_interface_sensor_enabled_state_handling(
 
 
 @pytest.mark.parametrize(
+    "coord_data",
+    [
+        {"interfaces": "not-a-mapping"},
+        {"interfaces": {"lan": {"name": "LAN", "status": "up"}}},
+    ],
+    ids=["interfaces-not-mapping", "interface-not-found"],
+)
+def test_interface_sensor_fails_closed_for_missing_interface_payloads(
+    coord_data: dict[str, Any],
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Interface sensor should be unavailable when interface state cannot be found."""
+    entry = make_config_entry()
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = coord_data
+    desc = MagicMock()
+    desc.key = "interface.wan.status"
+    desc.name = "WAN Status"
+
+    sensor = OPNsenseInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.wan_status"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
+
+
+@pytest.mark.parametrize(
     ("leases_val", "lease_interfaces_val"),
     [
         ([], {"lan": "LAN"}),
@@ -1878,6 +2026,33 @@ def test_dhcp_leases_interface_sensor_handles_non_mapping_leases(
 
     assert s.available is False
     assert writes == [False]
+
+
+def test_dhcp_leases_interface_sensor_handles_non_list_interface(
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """DHCP interface lease sensor should be unavailable when interface leases are not a list."""
+    entry = make_config_entry()
+
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"dhcp_leases": {"leases": {"lan": "not-a-list"}}}
+
+    desc = MagicMock()
+    desc.key = "dhcp_leases.lan"
+    desc.name = "DHCP LAN"
+
+    sensor = OPNsenseDHCPLeasesSensor(
+        config_entry=entry,
+        coordinator=coord,
+        entity_description=desc,
+    )
+    sensor.hass = MagicMock()
+    sensor.entity_id = "sensor.dhcp_lan"
+    object.__setattr__(sensor, "async_write_ha_state", lambda: None)
+
+    sensor._handle_coordinator_update()
+
+    assert sensor.available is False
 
 
 @pytest.mark.parametrize(
@@ -2164,13 +2339,14 @@ def test_dhcp_leases_per_interface_handles_exceptions(
     lease object raises inside the surrounding exception handler.
     """
 
-    class BrokenLease:
+    class BrokenLease(dict):
         def __init__(self, exc: type[Exception]) -> None:
             """Initialize BrokenLease.
 
             Args:
                 exc: Exc provided by pytest or the test case.
             """
+            super().__init__({"address": "192.168.1.2"})
             self._exc = exc
 
         def get(self, *args, **kwargs) -> Never:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2000,6 +2000,128 @@ def test_switch_handlers_fail_closed_for_malformed_nested_payloads(
     assert writes == 1
 
 
+@pytest.mark.parametrize(
+    ("entity", "key", "state"),
+    [
+        pytest.param(
+            OPNsenseFirewallRuleSwitch,
+            "firewall.rule.r1",
+            {"firewall": {"rules": {"r1": "not-a-mapping"}}},
+            id="firewall-rule-not-mapping",
+        ),
+        pytest.param(
+            OPNsenseNATRuleSwitch,
+            "firewall.nat.source_nat.n1",
+            {"firewall": {"nat": {"source_nat": {"n1": "not-a-mapping"}}}},
+            id="nat-rule-not-mapping",
+        ),
+        pytest.param(
+            OPNsenseUnboundBlocklistSwitch,
+            "unbound_blocklist.switch.u1",
+            [],
+            id="unbound-state-not-mapping",
+        ),
+    ],
+)
+def test_switch_handlers_fail_closed_for_missing_mapping_entries(
+    entity: type[
+        OPNsenseFirewallRuleSwitch | OPNsenseNATRuleSwitch | OPNsenseUnboundBlocklistSwitch
+    ],
+    key: str,
+    state: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Switch handlers should mark unavailable when expected entries are malformed."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = state
+    ent = entity(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key=key, name="Malformed Entry"),
+    )
+    ent.entity_id = "switch.malformed_entry"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
+@pytest.mark.parametrize(
+    ("entity", "key", "state"),
+    [
+        pytest.param(
+            OPNsenseFirewallRuleSwitch,
+            "firewall.rule.r1",
+            {"firewall": {"rules": {"r1": None}}},
+            id="firewall-rule-get-raises",
+        ),
+        pytest.param(
+            OPNsenseNATRuleSwitch,
+            "firewall.nat.source_nat.n1",
+            {"firewall": {"nat": {"source_nat": {"n1": None}}}},
+            id="nat-rule-get-raises",
+        ),
+    ],
+)
+def test_rule_switch_handlers_fail_closed_when_enabled_lookup_raises(
+    entity: type[OPNsenseFirewallRuleSwitch | OPNsenseNATRuleSwitch],
+    key: str,
+    state: dict[str, Any],
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Rule switches should be unavailable when reading the enabled flag fails."""
+
+    class BrokenRule(dict):
+        def __init__(self) -> None:
+            """Initialize a truthy mapping whose reads fail."""
+            super().__init__({"enabled": "1"})
+
+        def get(self, *args: Any, **kwargs: Any) -> Any:
+            """Raise ``TypeError`` when the handler reads the enabled flag."""
+            raise TypeError("simulated")
+
+    if entity is OPNsenseFirewallRuleSwitch:
+        state["firewall"]["rules"]["r1"] = BrokenRule()
+    else:
+        state["firewall"]["nat"]["source_nat"]["n1"] = BrokenRule()
+
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = state
+    ent = entity(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key=key, name="Broken Rule"),
+    )
+    ent.entity_id = "switch.broken_rule"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
+def test_service_switch_ignores_malformed_service_rows(
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Service lookup should skip non-mapping service rows without raising."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = {"services": ["not-a-mapping"]}
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Service"),
+    )
+
+    assert ent._opnsense_get_service() is None
+
+
 def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None:
     """Switch entities expose the correct platform icons based on type."""
     # firewall icon

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2735,6 +2735,32 @@ def test_vpn_instance_non_mapping_sets_unavailable(
     assert ent.available is False
 
 
+def test_vpn_handle_numeric_string_uuid_looks_up_string_key(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Numeric-style UUIDs are resolved without coercing coordinator keys."""
+    desc = SwitchEntityDescription(key="openvpn.clients.1", name="VPN1")
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseVPNSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=desc,
+    )
+    coordinator.data = {
+        "openvpn": {
+            "clients": {"1": {"enabled": True, "name": "Client1", "uuid": "1"}},
+        },
+        "wireguard": {"clients": {}, "servers": {}},
+    }
+    ent.coordinator = make_coord(coordinator.data)
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+    assert ent.available is True
+    assert ent.is_on is True
+
+
 @pytest.mark.asyncio
 async def test_service_async_turn_on_off_failure(
     coordinator: MagicMock, ph_hass: Any, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1972,11 +1972,20 @@ def test_switch_handlers_fail_closed_for_malformed_nested_payloads(
         entity_description=SwitchEntityDescription(key=keys[entity], name="Malformed"),
     )
     ent.entity_id = "switch.malformed"
-    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+    writes = 0
+
+    def collect_write() -> None:
+        """Count Home Assistant state writes."""
+        nonlocal writes
+        writes += 1
+
+    object.__setattr__(ent, "async_write_ha_state", collect_write)
+    ent._available = True
 
     ent._handle_coordinator_update()
 
     assert ent.available is False
+    assert writes == 1
 
 
 def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1895,6 +1895,90 @@ async def test_switch_handle_error_sets_unavailable(
             loop.close()
 
 
+def test_service_switch_missing_service_marks_unavailable(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Service switch should clear stale availability when the service disappears."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Svc"),
+    )
+    coordinator.data = {"services": []}
+    ent.entity_id = "switch.svc"
+    writes = 0
+
+    def collect_write() -> None:
+        """Count Home Assistant state writes."""
+        nonlocal writes
+        writes += 1
+
+    object.__setattr__(ent, "async_write_ha_state", collect_write)
+    ent._available = True
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+    assert writes == 1
+
+
+@pytest.mark.parametrize(
+    ("entity", "state"),
+    [
+        (
+            OPNsenseFirewallRuleSwitch,
+            {"firewall": "not-a-mapping"},
+        ),
+        (
+            OPNsenseNATRuleSwitch,
+            {"firewall": {"nat": "not-a-mapping"}},
+        ),
+        (
+            OPNsenseUnboundBlocklistSwitchLegacy,
+            {"unbound_blocklist": "not-a-mapping"},
+        ),
+        (
+            OPNsenseVPNSwitch,
+            {"openvpn": "not-a-mapping"},
+        ),
+    ],
+)
+def test_switch_handlers_fail_closed_for_malformed_nested_payloads(
+    entity: type[
+        OPNsenseFirewallRuleSwitch
+        | OPNsenseNATRuleSwitch
+        | OPNsenseUnboundBlocklistSwitchLegacy
+        | OPNsenseVPNSwitch
+    ],
+    state: dict[str, Any],
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Switch handlers should mark unavailable instead of raising on malformed payloads."""
+    keys = {
+        OPNsenseFirewallRuleSwitch: "firewall.rule.r1",
+        OPNsenseNATRuleSwitch: "firewall.nat.source_nat.n1",
+        OPNsenseUnboundBlocklistSwitchLegacy: "unbound.dnsbl.legacy",
+        OPNsenseVPNSwitch: "openvpn.clients.c1",
+    }
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = state
+    ent = entity(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key=keys[entity], name="Malformed"),
+    )
+    ent.entity_id = "switch.malformed"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is False
+
+
 def test_entity_icons(make_config_entry: Callable[..., MockConfigEntry]) -> None:
     """Switch entities expose the correct platform icons based on type."""
     # firewall icon

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1936,7 +1936,15 @@ def test_service_switch_missing_service_marks_unavailable(
             {"firewall": {"nat": "not-a-mapping"}},
         ),
         (
+            OPNsenseServiceSwitch,
+            {"services": "not-a-list"},
+        ),
+        (
             OPNsenseUnboundBlocklistSwitchLegacy,
+            {"unbound_blocklist": "not-a-mapping"},
+        ),
+        (
+            OPNsenseUnboundBlocklistSwitch,
             {"unbound_blocklist": "not-a-mapping"},
         ),
         (
@@ -1949,7 +1957,9 @@ def test_switch_handlers_fail_closed_for_malformed_nested_payloads(
     entity: type[
         OPNsenseFirewallRuleSwitch
         | OPNsenseNATRuleSwitch
+        | OPNsenseServiceSwitch
         | OPNsenseUnboundBlocklistSwitchLegacy
+        | OPNsenseUnboundBlocklistSwitch
         | OPNsenseVPNSwitch
     ],
     state: dict[str, Any],
@@ -1960,7 +1970,9 @@ def test_switch_handlers_fail_closed_for_malformed_nested_payloads(
     keys = {
         OPNsenseFirewallRuleSwitch: "firewall.rule.r1",
         OPNsenseNATRuleSwitch: "firewall.nat.source_nat.n1",
+        OPNsenseServiceSwitch: "service.svc1.status",
         OPNsenseUnboundBlocklistSwitchLegacy: "unbound.dnsbl.legacy",
+        OPNsenseUnboundBlocklistSwitch: "unbound_blocklist.switch.u1",
         OPNsenseVPNSwitch: "openvpn.clients.c1",
     }
     config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})


### PR DESCRIPTION
## Summary
Hardens OPNsense coordinator update handlers so malformed or missing nested payloads fail closed instead of raising or leaving stale entity availability. The follow-up cleanup consolidates repeated unavailable state writes through shared entity helpers.

## What Changed
- Added shared coordinator payload helpers for mapping/list lookup and unavailable state writes.
- Updated sensor and switch handlers to use guarded nested payload access for firewall/NAT, services, Unbound, VPN, filesystem, temperature, and related coordinator data.
- Normalized unavailable handling across sensor, binary sensor, device tracker, switch, and update entities with `_mark_unavailable()`.
- Added regression tests for malformed nested coordinator payloads and stale service-switch availability.

## Why
Coordinator payloads come from external OPNsense/API data and can be partially missing or malformed during refreshes, firmware/API changes, or disabled features. These handlers should consistently mark entities unavailable and write state rather than raising or preserving stale availability.

## Validation
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m prek run -a`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved availability handling so OPNsense entities now better detect missing or malformed data and show as unavailable instead of failing or showing stale values.
  * Added broader support for sensor, switch, device tracker, update, and binary sensor edge cases, including firewall, VPN, DHCP, filesystem, temperature, and SMART statuses.

* **Tests**
  * Expanded coverage for malformed payloads and unavailable-state behavior across multiple entity types.

* **Chores**
  * Updated ignore rules for local lockfile artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->