### PR TITLE
Handle initial firmware probe timeouts

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -181,6 +181,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 cookie_jar=aiohttp.CookieJar(unsafe=is_private_ip(url)),
             ),
             opts={"verify_ssl": verify_ssl},
+            probe_timeout_fallback=True,
             name=entry.title,
         )
     except MissingExternalAiopnsenseDependency:

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -568,7 +568,9 @@ async def _try_external_client_after_probe_timeout(
     await _close_client(client)
     if initial:
         raise probe_error
-    return LegacyOPNsenseClient(**kwargs)
+    legacy_client = LegacyOPNsenseClient(**kwargs)
+    object.__setattr__(legacy_client, "_firmware_version", firmware)
+    return legacy_client
 
 
 async def create_opnsense_client(

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -551,7 +551,11 @@ async def _try_external_client_after_probe_timeout(
         return LegacyOPNsenseClient(**kwargs)
 
     if supported_firmware:
-        aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+        try:
+            aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+        except asyncio.CancelledError:
+            await _close_client(client)
+            raise
         if aiopnsense_version:
             _LOGGER.info(
                 "Using aiopnsense %s after legacy firmware probe timeout for firmware %s",
@@ -645,7 +649,11 @@ async def create_opnsense_client(
         ):
             await _close_client(probe_client)
             client = await _create_external_client(**kwargs)
-            aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+            try:
+                aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+            except asyncio.CancelledError:
+                await _close_client(client)
+                raise
             if aiopnsense_version:
                 _LOGGER.info(
                     "Using aiopnsense %s for firmware >= %s",

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -522,37 +522,38 @@ async def _try_external_client_after_probe_timeout(
 
     try:
         firmware = await client.get_host_firmware_version()
-        if awesomeversion.AwesomeVersion(firmware) >= awesomeversion.AwesomeVersion(
-            AIOPNSENSE_MIN_FIRMWARE
-        ):
-            aiopnsense_version: str | None = await _get_external_aiopnsense_version()
-            if aiopnsense_version:
-                _LOGGER.info(
-                    "Using aiopnsense %s after legacy firmware probe timeout for firmware %s",
-                    aiopnsense_version,
-                    firmware,
-                )
-            else:
-                _LOGGER.info(
-                    "Using aiopnsense after legacy firmware probe timeout for firmware %s",
-                    firmware,
-                )
-            return client
+        supported_firmware = awesomeversion.AwesomeVersion(
+            firmware
+        ) >= awesomeversion.AwesomeVersion(AIOPNSENSE_MIN_FIRMWARE)
     except (
+        TimeoutError,
+        aiohttp.ServerTimeoutError,
+        aiohttp.ClientError,
         awesomeversion.exceptions.AwesomeVersionCompareException,
         TypeError,
         ValueError,
-    ):
+    ) as err:
+        await _close_client(client)
         _LOGGER.debug(
-            "aiopnsense fallback could not compare firmware after legacy probe timeout",
+            "aiopnsense fallback could not confirm supported firmware after legacy probe timeout",
             exc_info=True,
         )
-    except TimeoutError, aiohttp.ServerTimeoutError:
-        _LOGGER.debug(
-            "aiopnsense fallback also timed out after legacy firmware probe timeout",
-            exc_info=True,
-        )
-        raise
+        raise probe_error from err
+
+    if supported_firmware:
+        aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+        if aiopnsense_version:
+            _LOGGER.info(
+                "Using aiopnsense %s after legacy firmware probe timeout for firmware %s",
+                aiopnsense_version,
+                firmware,
+            )
+        else:
+            _LOGGER.info(
+                "Using aiopnsense after legacy firmware probe timeout for firmware %s",
+                firmware,
+            )
+        return client
 
     await _close_client(client)
     raise probe_error

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -437,6 +437,20 @@ def _add_core_compat(client: OPNsenseClientProtocol) -> OPNsenseClientProtocol:
     return client
 
 
+async def _close_client(client: OPNsenseClientProtocol) -> None:
+    """Close a backend client when it exposes an async close hook.
+
+    Args:
+        client: Backend client instance to close.
+
+    Returns:
+        None: Closes the client if supported.
+    """
+    close_method: Callable[[], Any] | None = getattr(client, "async_close", None)
+    if close_method is not None:
+        await close_method()
+
+
 async def _create_external_client(**kwargs: Any) -> OPNsenseClientProtocol:
     """Create an external `aiopnsense` client instance.
 
@@ -471,6 +485,77 @@ async def _create_external_client(**kwargs: Any) -> OPNsenseClientProtocol:
             ) from err
 
     return _add_core_compat(_add_plugin_compat(_add_query_count_compat(client)))
+
+
+async def _try_external_client_after_probe_timeout(
+    *,
+    kwargs: dict[str, Any],
+    probe_error: TimeoutError | aiohttp.ServerTimeoutError,
+) -> OPNsenseClientProtocol:
+    """Try external aiopnsense when the initial legacy firmware probe times out.
+
+    Args:
+        kwargs: Normalized constructor arguments for the external client.
+        probe_error: Timeout raised by the bundled legacy firmware probe.
+
+    Returns:
+        OPNsenseClientProtocol: External client when it confirms firmware supported by
+            the external backend.
+
+    Raises:
+        TimeoutError | aiohttp.ServerTimeoutError: Original timeout when external
+            fallback is unavailable or cannot confirm new firmware.
+    """
+    _LOGGER.warning(
+        "Legacy firmware probe timed out during initial setup; trying aiopnsense fallback "
+        "for OPNsense firmware >= %s",
+        AIOPNSENSE_MIN_FIRMWARE,
+    )
+    try:
+        client = await _create_external_client(**kwargs)
+    except MissingExternalAiopnsenseDependency as err:
+        _LOGGER.debug(
+            "aiopnsense fallback unavailable after legacy firmware probe timeout",
+            exc_info=True,
+        )
+        raise probe_error from err
+
+    try:
+        firmware = await client.get_host_firmware_version()
+        if awesomeversion.AwesomeVersion(firmware) >= awesomeversion.AwesomeVersion(
+            AIOPNSENSE_MIN_FIRMWARE
+        ):
+            aiopnsense_version: str | None = await _get_external_aiopnsense_version()
+            if aiopnsense_version:
+                _LOGGER.info(
+                    "Using aiopnsense %s after legacy firmware probe timeout for firmware %s",
+                    aiopnsense_version,
+                    firmware,
+                )
+            else:
+                _LOGGER.info(
+                    "Using aiopnsense after legacy firmware probe timeout for firmware %s",
+                    firmware,
+                )
+            return client
+    except (
+        awesomeversion.exceptions.AwesomeVersionCompareException,
+        TypeError,
+        ValueError,
+    ):
+        _LOGGER.debug(
+            "aiopnsense fallback could not compare firmware after legacy probe timeout",
+            exc_info=True,
+        )
+    except TimeoutError, aiohttp.ServerTimeoutError:
+        _LOGGER.debug(
+            "aiopnsense fallback also timed out after legacy firmware probe timeout",
+            exc_info=True,
+        )
+        raise
+
+    await _close_client(client)
+    raise probe_error
 
 
 async def create_opnsense_client(
@@ -513,9 +598,17 @@ async def create_opnsense_client(
     probe_client: OPNsenseClientProtocol = LegacyOPNsenseClient(**kwargs)
     try:
         firmware = await probe_client.get_host_firmware_version()
+    except (TimeoutError, aiohttp.ServerTimeoutError) as err:
+        await _close_client(probe_client)
+        if initial:
+            return await _try_external_client_after_probe_timeout(
+                kwargs=kwargs,
+                probe_error=err,
+            )
+        raise
     except Exception:  # noqa: BLE001
         try:
-            await probe_client.async_close()
+            await _close_client(probe_client)
         finally:
             raise
     # _LOGGER.debug("Client factory detected firmware: %s", firmware)

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -567,6 +567,7 @@ async def create_opnsense_client(
     session: aiohttp.ClientSession,
     opts: MutableMapping[str, Any] | None = None,
     initial: bool = False,
+    probe_timeout_fallback: bool = False,
     name: str | None = None,
 ) -> OPNsenseClientProtocol:
     """Create the backend client selected by detected firmware.
@@ -578,6 +579,9 @@ async def create_opnsense_client(
         session: Shared aiohttp session used by created clients.
         opts: Optional transport options, such as SSL verification flags.
         initial: Whether the client is being created for initial setup validation.
+        probe_timeout_fallback: Whether to use strict temporary probe behavior so
+            firmware probe timeouts can try the external backend without changing
+            the returned client's normal error handling.
         name: Optional display name for logs and diagnostics.
 
     Returns:
@@ -596,12 +600,15 @@ async def create_opnsense_client(
         initial=initial,
         name=name,
     )
-    probe_client: OPNsenseClientProtocol = LegacyOPNsenseClient(**kwargs)
+    probe_kwargs = dict(kwargs)
+    if probe_timeout_fallback:
+        probe_kwargs["initial"] = True
+    probe_client: OPNsenseClientProtocol = LegacyOPNsenseClient(**probe_kwargs)
     try:
         firmware = await probe_client.get_host_firmware_version()
     except (TimeoutError, aiohttp.ServerTimeoutError) as err:
         await _close_client(probe_client)
-        if initial:
+        if initial or probe_timeout_fallback:
             return await _try_external_client_after_probe_timeout(
                 kwargs=kwargs,
                 probe_error=err,
@@ -618,7 +625,7 @@ async def create_opnsense_client(
         if awesomeversion.AwesomeVersion(firmware) >= awesomeversion.AwesomeVersion(
             AIOPNSENSE_MIN_FIRMWARE
         ):
-            await probe_client.async_close()
+            await _close_client(probe_client)
             client = await _create_external_client(**kwargs)
             aiopnsense_version: str | None = await _get_external_aiopnsense_version()
             if aiopnsense_version:
@@ -640,4 +647,7 @@ async def create_opnsense_client(
         )
 
     _LOGGER.debug("Using bundled legacy pyopnsense backend")
+    if probe_kwargs["initial"] != kwargs["initial"]:
+        await _close_client(probe_client)
+        return LegacyOPNsenseClient(**kwargs)
     return probe_client

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -614,11 +614,14 @@ async def create_opnsense_client(
                 probe_error=err,
             )
         raise
-    except Exception:  # noqa: BLE001
-        try:
-            await _close_client(probe_client)
-        finally:
-            raise
+    except asyncio.CancelledError:
+        await _close_client(probe_client)
+        raise
+    except Exception:
+        await _close_client(probe_client)
+        if probe_timeout_fallback and not initial:
+            return LegacyOPNsenseClient(**kwargs)
+        raise
     # _LOGGER.debug("Client factory detected firmware: %s", firmware)
 
     try:
@@ -649,5 +652,7 @@ async def create_opnsense_client(
     _LOGGER.debug("Using bundled legacy pyopnsense backend")
     if probe_kwargs["initial"] != kwargs["initial"]:
         await _close_client(probe_client)
-        return LegacyOPNsenseClient(**kwargs)
+        legacy_client = LegacyOPNsenseClient(**kwargs)
+        object.__setattr__(legacy_client, "_firmware_version", firmware)
+        return legacy_client
     return probe_client

--- a/custom_components/opnsense/client_factory.py
+++ b/custom_components/opnsense/client_factory.py
@@ -491,12 +491,15 @@ async def _try_external_client_after_probe_timeout(
     *,
     kwargs: dict[str, Any],
     probe_error: TimeoutError | aiohttp.ServerTimeoutError,
+    initial: bool,
 ) -> OPNsenseClientProtocol:
     """Try external aiopnsense when the initial legacy firmware probe times out.
 
     Args:
         kwargs: Normalized constructor arguments for the external client.
         probe_error: Timeout raised by the bundled legacy firmware probe.
+        initial: Whether failed fallback validation should preserve strict initial
+            setup behavior.
 
     Returns:
         OPNsenseClientProtocol: External client when it confirms firmware supported by
@@ -518,13 +521,18 @@ async def _try_external_client_after_probe_timeout(
             "aiopnsense fallback unavailable after legacy firmware probe timeout",
             exc_info=True,
         )
-        raise probe_error from err
+        if initial:
+            raise probe_error from err
+        return LegacyOPNsenseClient(**kwargs)
 
     try:
         firmware = await client.get_host_firmware_version()
         supported_firmware = awesomeversion.AwesomeVersion(
             firmware
         ) >= awesomeversion.AwesomeVersion(AIOPNSENSE_MIN_FIRMWARE)
+    except asyncio.CancelledError:
+        await _close_client(client)
+        raise
     except (
         TimeoutError,
         aiohttp.ServerTimeoutError,
@@ -538,7 +546,9 @@ async def _try_external_client_after_probe_timeout(
             "aiopnsense fallback could not confirm supported firmware after legacy probe timeout",
             exc_info=True,
         )
-        raise probe_error from err
+        if initial:
+            raise probe_error from err
+        return LegacyOPNsenseClient(**kwargs)
 
     if supported_firmware:
         aiopnsense_version: str | None = await _get_external_aiopnsense_version()
@@ -556,7 +566,9 @@ async def _try_external_client_after_probe_timeout(
         return client
 
     await _close_client(client)
-    raise probe_error
+    if initial:
+        raise probe_error
+    return LegacyOPNsenseClient(**kwargs)
 
 
 async def create_opnsense_client(
@@ -612,6 +624,7 @@ async def create_opnsense_client(
             return await _try_external_client_after_probe_timeout(
                 kwargs=kwargs,
                 probe_error=err,
+                initial=initial,
             )
         raise
     except asyncio.CancelledError:

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -689,8 +689,130 @@ async def test_create_client_uses_external_probe_fallback_without_initial_client
     assert external_kwargs[0]["initial"] is False
 
 
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "dependency_missing",
+        "unsupported_firmware",
+        "fallback_timeout",
+        "non_comparable",
+    ],
+)
 @pytest.mark.asyncio
-async def test_create_client_uses_external_after_initial_timeout_without_version_log(
+async def test_create_client_falls_back_to_legacy_after_probe_timeout_when_fallback_cannot_validate(
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+) -> None:
+    """Non-initial fallback should return legacy when aiopnsense validation fails."""
+    legacy_kwargs: list[dict[str, Any]] = []
+    flags: dict[str, bool] = {"strict_closed": False, "fallback_closed": False}
+
+    class _LegacyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            """Track legacy construction for fallback assertions."""
+            legacy_kwargs.append(kwargs)
+
+        async def get_host_firmware_version(self) -> str:
+            """Simulate strict probe timeout."""
+            raise TimeoutError("legacy firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Track when strict probe client is closed."""
+            flags["strict_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> Any:
+            """Return or raise firmware values according to the failure scenario."""
+            if scenario == "fallback_timeout":
+                raise TimeoutError("fallback firmware status timed out")
+            if scenario == "non_comparable":
+                return {"version": "26.1.6"}
+            return "25.7"
+
+        async def async_close(self) -> None:
+            """Track that failed external fallback client is closed."""
+            flags["fallback_closed"] = True
+
+    async def _create_external_client(**kwargs: Any) -> _ExternalClient:
+        """Provide fallback external client or missing-dependency failures."""
+        if scenario == "dependency_missing":
+            raise factory_mod.MissingExternalAiopnsenseDependency("not found")
+        return _ExternalClient()
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _LegacyClient)
+    monkeypatch.setattr(factory_mod, "_create_external_client", _create_external_client)
+
+    if scenario == "non_comparable":
+
+        class _BrokenAwesomeVersion:
+            def __init__(self, value: Any) -> None:
+                """Mirror version wrapper for non-comparable fallback tests."""
+                self._value = value
+
+            def __ge__(self, other: Any) -> bool:
+                """Raise during comparison to force legacy fallback."""
+                raise ValueError("cannot compare")
+
+        monkeypatch.setattr(factory_mod.awesomeversion, "AwesomeVersion", _BrokenAwesomeVersion)
+
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        probe_timeout_fallback=True,
+    )
+
+    assert isinstance(client, _LegacyClient)
+    assert legacy_kwargs[0]["initial"] is True
+    assert legacy_kwargs[1]["initial"] is False
+    assert flags["strict_closed"] is True
+    if scenario != "dependency_missing":
+        assert flags["fallback_closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_try_external_client_after_probe_timeout_closes_external_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel during external firmware validation should close the external fallback client."""
+    closed = {"external": False}
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise cancellation while validating firmware."""
+            raise asyncio.CancelledError("fallback cancelled")
+
+        async def async_close(self) -> None:
+            """Record cleanup on cancellation."""
+            closed["external"] = True
+
+    async def _create_external_client(**kwargs: Any) -> _ExternalClient:
+        """Return a fallback client that cancels during firmware validation."""
+        return _ExternalClient()
+
+    monkeypatch.setattr(factory_mod, "_create_external_client", _create_external_client)
+
+    with pytest.raises(asyncio.CancelledError, match="fallback cancelled"):
+        await factory_mod._try_external_client_after_probe_timeout(
+            kwargs={
+                "url": "https://router",
+                "username": "u",
+                "password": TEST_PASSWORD,
+                "session": cast("aiohttp.ClientSession", SimpleNamespace()),
+                "opts": {"verify_ssl": True},
+                "initial": False,
+            },
+            probe_error=TimeoutError("legacy firmware status timed out"),
+            initial=False,
+        )
+
+    assert closed["external"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_client_uses_external_after_initial_legacy_probe_timeout_without_version_log(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Initial timeout fallback should work when aiopnsense package version is unknown."""

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -698,6 +698,123 @@ async def test_create_client_reraises_initial_legacy_probe_timeout_when_fallback
 
 
 @pytest.mark.asyncio
+async def test_create_client_reraises_initial_legacy_probe_timeout_when_fallback_times_out(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initial setup should preserve original timeout if aiopnsense also times out."""
+    created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung legacy firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("legacy firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung aiopnsense firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("fallback firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed aiopnsense fallback was closed."""
+            created["external_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+
+    caplog.set_level("DEBUG")
+    with pytest.raises(TimeoutError, match="legacy firmware status timed out") as exc_info:
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+            initial=True,
+        )
+
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+    assert str(exc_info.value.__cause__) == "fallback firmware status timed out"
+    assert created["legacy_closed"] is True
+    assert created["external_closed"] is True
+    assert (
+        "aiopnsense fallback could not confirm supported firmware after legacy probe timeout"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_client_reraises_initial_legacy_probe_timeout_when_fallback_client_errors(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initial setup should close fallback client and preserve original timeout on client errors."""
+    created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung legacy firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("legacy firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise client error to emulate failed aiopnsense fallback validation.
+
+            Raises:
+                aiohttp.ClientError: Always raised by this stub.
+            """
+            raise aiohttp.ClientError("fallback client failed")
+
+        async def async_close(self) -> None:
+            """Record that the failed aiopnsense fallback was closed."""
+            created["external_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+
+    caplog.set_level("DEBUG")
+    with pytest.raises(TimeoutError, match="legacy firmware status timed out") as exc_info:
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+            initial=True,
+        )
+
+    assert isinstance(exc_info.value.__cause__, aiohttp.ClientError)
+    assert created["legacy_closed"] is True
+    assert created["external_closed"] is True
+    assert (
+        "aiopnsense fallback could not confirm supported firmware after legacy probe timeout"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_client_logs_external_version_for_new_firmware(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -566,6 +566,8 @@ async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
 ) -> None:
     """Initial setup should try aiopnsense when the legacy firmware probe times out."""
     created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+    legacy_kwargs: list[dict[str, Any]] = []
+    external_kwargs: list[dict[str, Any]] = []
 
     class _LegacyClient:
         async def get_host_firmware_version(self) -> str:
@@ -589,10 +591,18 @@ async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
             """Record close calls for unsupported-firmware fallback paths."""
             created["external_closed"] = True
 
-    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
-    monkeypatch.setattr(
-        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
-    )
+    def _legacy_client(**kwargs: Any) -> _LegacyClient:
+        """Capture legacy constructor kwargs and return a timeout probe client."""
+        legacy_kwargs.append(kwargs)
+        return _LegacyClient()
+
+    async def _create_external_client(**kwargs: Any) -> _ExternalClient:
+        """Capture external constructor kwargs and return a supported fallback client."""
+        external_kwargs.append(kwargs)
+        return _ExternalClient()
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _legacy_client)
+    monkeypatch.setattr(factory_mod, "_create_external_client", _create_external_client)
     monkeypatch.setattr(
         factory_mod, "_get_external_aiopnsense_version", AsyncMock(return_value="1.0.14")
     )
@@ -608,6 +618,8 @@ async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
     )
 
     assert isinstance(client, _ExternalClient)
+    assert legacy_kwargs[0]["initial"] is True
+    assert external_kwargs[0]["initial"] is True
     assert created["legacy_closed"] is True
     assert created["external_closed"] is False
     assert (
@@ -618,6 +630,62 @@ async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
         "Using aiopnsense 1.0.14 after legacy firmware probe timeout for firmware 26.1.6_2"
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_create_client_uses_external_probe_fallback_without_initial_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe timeout fallback should not make the returned external client initial."""
+    legacy_kwargs: list[dict[str, Any]] = []
+    external_kwargs: list[dict[str, Any]] = []
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a suppressed non-initial legacy probe path.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Provide cleanup hook expected by factory timeout handling."""
+            return
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return new firmware value so fallback can select external backend."""
+            return "26.1.6_2"
+
+    def _legacy_client(**kwargs: Any) -> _LegacyClient:
+        """Capture strict probe kwargs and return a timeout probe client."""
+        legacy_kwargs.append(kwargs)
+        return _LegacyClient()
+
+    async def _create_external_client(**kwargs: Any) -> _ExternalClient:
+        """Capture returned-client kwargs and return an external fallback client."""
+        external_kwargs.append(kwargs)
+        return _ExternalClient()
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _legacy_client)
+    monkeypatch.setattr(factory_mod, "_create_external_client", _create_external_client)
+    monkeypatch.setattr(
+        factory_mod, "_get_external_aiopnsense_version", AsyncMock(return_value=None)
+    )
+
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        probe_timeout_fallback=True,
+    )
+
+    assert isinstance(client, _ExternalClient)
+    assert legacy_kwargs[0]["initial"] is True
+    assert external_kwargs[0]["initial"] is False
 
 
 @pytest.mark.asyncio
@@ -808,6 +876,54 @@ async def test_create_client_reraises_initial_legacy_probe_timeout_for_old_fallb
 
     assert created["legacy_closed"] is True
     assert created["external_closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_client_recreates_legacy_after_strict_probe_for_old_firmware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe fallback should not return a strict legacy probe for old firmware."""
+    legacy_kwargs: list[dict[str, Any]] = []
+    closed: list[bool] = []
+
+    class _LegacyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            """Store constructor kwargs for returned-client assertions.
+
+            Args:
+                **kwargs: Constructor kwargs passed by the factory.
+            """
+            self.kwargs = kwargs
+
+        async def get_host_firmware_version(self) -> str:
+            """Return old firmware so the factory keeps the legacy backend."""
+            return "25.7"
+
+        async def async_close(self) -> None:
+            """Record that the strict probe client was closed before recreation."""
+            closed.append(True)
+
+    def _legacy_client(**kwargs: Any) -> _LegacyClient:
+        """Capture each legacy construction and return a fake client."""
+        legacy_kwargs.append(kwargs)
+        return _LegacyClient(**kwargs)
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _legacy_client)
+
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        probe_timeout_fallback=True,
+    )
+
+    assert isinstance(client, _LegacyClient)
+    assert legacy_kwargs[0]["initial"] is True
+    assert legacy_kwargs[1]["initial"] is False
+    assert client.kwargs["initial"] is False
+    assert closed == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect as _inspect
 from types import SimpleNamespace
 from typing import Any, cast
@@ -924,6 +925,125 @@ async def test_create_client_recreates_legacy_after_strict_probe_for_old_firmwar
     assert legacy_kwargs[1]["initial"] is False
     assert client.kwargs["initial"] is False
     assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_create_client_closes_probe_on_cancelled_probe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during legacy probe should close probe client and re-raise."""
+    closed = {"value": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise cancellation to verify cleanup and cancellation propagation."""
+            raise asyncio.CancelledError("probe cancelled")
+
+        async def async_close(self) -> None:
+            """Record that probe cancellation cleanup ran."""
+            closed["value"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+
+    with pytest.raises(asyncio.CancelledError, match="probe cancelled"):
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+        )
+    assert closed["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_client_falls_back_to_legacy_on_non_timeout_probe_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-timeout probe failures with timeout fallback should continue with legacy."""
+    legacy_kwargs: list[dict[str, Any]] = []
+    closed: list[bool] = []
+
+    class _LegacyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            """Capture legacy constructor kwargs for strict and fallback clients."""
+            legacy_kwargs.append(kwargs)
+
+        async def get_host_firmware_version(self) -> str:
+            """Simulate non-timeout probe failure."""
+            raise aiohttp.ClientError("strict legacy probe failed")
+
+        async def async_close(self) -> None:
+            """Track cleanup call on failed strict probe."""
+            closed.append(True)
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _LegacyClient)
+
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        probe_timeout_fallback=True,
+    )
+
+    assert isinstance(client, _LegacyClient)
+    assert len(legacy_kwargs) == 2
+    assert legacy_kwargs[0]["initial"] is True
+    assert legacy_kwargs[1]["initial"] is False
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_create_client_preserves_old_firmware_on_recreated_legacy_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recreated legacy client should reuse probed firmware cache.
+
+    This avoids a second firmware request during setup initialization.
+    """
+    legacy_kwargs: list[dict[str, Any]] = []
+    firmware_requests: list[str] = []
+    closed: list[bool] = []
+
+    class _LegacyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            """Capture construction args and initialize lazy firmware cache."""
+            self._firmware_version: str | None = None
+            self.initial = kwargs.get("initial")
+            legacy_kwargs.append(kwargs)
+
+        async def get_host_firmware_version(self) -> str:
+            """Return cached firmware when available, otherwise emulate network call."""
+            if self._firmware_version is not None:
+                return self._firmware_version
+            firmware_requests.append("request")
+            return "25.7"
+
+        async def async_close(self) -> None:
+            """Track strict probe close to ensure fallback path closes it."""
+            closed.append(bool(self.initial))
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _LegacyClient)
+
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        probe_timeout_fallback=True,
+    )
+
+    assert isinstance(client, _LegacyClient)
+    assert len(legacy_kwargs) == 2
+    assert legacy_kwargs[0]["initial"] is True
+    assert legacy_kwargs[1]["initial"] is False
+    assert closed == [True]
+    assert firmware_requests == ["request"]
+    assert await client.get_host_firmware_version() == "25.7"
+    assert firmware_requests == ["request"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -551,6 +551,153 @@ async def test_create_client_uses_external_for_new_firmware(
 
 
 @pytest.mark.asyncio
+async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initial setup should try aiopnsense when the legacy firmware probe times out."""
+    created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung legacy firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return new firmware value so fallback can select external backend."""
+            return "26.1.6_2"
+
+        async def async_close(self) -> None:
+            """Record close calls for unsupported-firmware fallback paths."""
+            created["external_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+    monkeypatch.setattr(
+        factory_mod, "_get_external_aiopnsense_version", AsyncMock(return_value="1.0.14")
+    )
+
+    caplog.set_level("INFO")
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        initial=True,
+    )
+
+    assert isinstance(client, _ExternalClient)
+    assert created["legacy_closed"] is True
+    assert created["external_closed"] is False
+    assert (
+        "Legacy firmware probe timed out during initial setup; trying aiopnsense fallback"
+        in caplog.text
+    )
+    assert (
+        "Using aiopnsense 1.0.14 after legacy firmware probe timeout for firmware 26.1.6_2"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_client_reraises_non_initial_legacy_probe_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-initial legacy probe timeouts should preserve existing failure behavior."""
+    created: dict[str, Any] = {"legacy_closed": False}
+    create_external_client = AsyncMock()
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(factory_mod, "_create_external_client", create_external_client)
+
+    with pytest.raises(TimeoutError, match="firmware status timed out"):
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+            initial=False,
+        )
+
+    assert created["legacy_closed"] is True
+    create_external_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_client_reraises_initial_legacy_probe_timeout_when_fallback_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initial setup should preserve the original timeout if aiopnsense is unavailable."""
+    created: dict[str, Any] = {"legacy_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    async def _raise_missing_external_client(**kwargs: Any) -> Any:
+        """Raise missing-dependency error for the aiopnsense fallback path.
+
+        Args:
+            **kwargs: Constructor kwargs ignored by this stub.
+
+        Raises:
+            MissingExternalAiopnsenseDependency: Always raised by this stub.
+        """
+        raise factory_mod.MissingExternalAiopnsenseDependency("not found")
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(factory_mod, "_create_external_client", _raise_missing_external_client)
+
+    caplog.set_level("DEBUG")
+    with pytest.raises(TimeoutError, match="firmware status timed out"):
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+            initial=True,
+        )
+
+    assert created["legacy_closed"] is True
+    assert "aiopnsense fallback unavailable after legacy firmware probe timeout" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_create_client_logs_external_version_for_new_firmware(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -450,6 +450,16 @@ def test_add_query_count_compat_noop_without_query_methods() -> None:
 
 
 @pytest.mark.asyncio
+async def test_close_client_noops_without_async_close() -> None:
+    """Client close helper should ignore clients without an async close hook."""
+
+    class _Client:
+        pass
+
+    await factory_mod._close_client(cast("Any", _Client()))
+
+
+@pytest.mark.asyncio
 async def test_create_client_uses_legacy_for_old_firmware(monkeypatch: pytest.MonkeyPatch) -> None:
     """Factory should return the bundled legacy client for old firmware."""
 
@@ -611,6 +621,61 @@ async def test_create_client_uses_external_when_initial_legacy_probe_times_out(
 
 
 @pytest.mark.asyncio
+async def test_create_client_uses_external_after_initial_timeout_without_version_log(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Initial timeout fallback should work when aiopnsense package version is unknown."""
+    created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung legacy firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return new firmware value so fallback can select external backend."""
+            return "26.1.6_2"
+
+        async def async_close(self) -> None:
+            """Record close calls for unsupported-firmware fallback paths."""
+            created["external_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+    monkeypatch.setattr(
+        factory_mod, "_get_external_aiopnsense_version", AsyncMock(return_value=None)
+    )
+
+    caplog.set_level("INFO")
+    client = await factory_mod.create_opnsense_client(
+        url="https://router",
+        username="u",
+        password=TEST_PASSWORD,
+        session=cast("aiohttp.ClientSession", SimpleNamespace()),
+        opts={"verify_ssl": True},
+        initial=True,
+    )
+
+    assert isinstance(client, _ExternalClient)
+    assert created["legacy_closed"] is True
+    assert created["external_closed"] is False
+    assert (
+        "Using aiopnsense after legacy firmware probe timeout for firmware 26.1.6_2" in caplog.text
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_client_reraises_non_initial_legacy_probe_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -695,6 +760,54 @@ async def test_create_client_reraises_initial_legacy_probe_timeout_when_fallback
 
     assert created["legacy_closed"] is True
     assert "aiopnsense fallback unavailable after legacy firmware probe timeout" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_create_client_reraises_initial_legacy_probe_timeout_for_old_fallback_firmware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial setup should preserve original timeout if fallback detects old firmware."""
+    created: dict[str, Any] = {"legacy_closed": False, "external_closed": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Raise timeout to emulate a hung legacy firmware status request.
+
+            Raises:
+                TimeoutError: Always raised by this stub.
+            """
+            raise TimeoutError("legacy firmware status timed out")
+
+        async def async_close(self) -> None:
+            """Record that the failed legacy probe was closed."""
+            created["legacy_closed"] = True
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return old firmware so fallback cannot select external backend."""
+            return "25.7"
+
+        async def async_close(self) -> None:
+            """Record that the unsupported aiopnsense fallback was closed."""
+            created["external_closed"] = True
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod, "_create_external_client", AsyncMock(return_value=_ExternalClient())
+    )
+
+    with pytest.raises(TimeoutError, match="legacy firmware status timed out"):
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+            initial=True,
+        )
+
+    assert created["legacy_closed"] is True
+    assert created["external_closed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -812,6 +812,54 @@ async def test_try_external_client_after_probe_timeout_closes_external_on_cancel
 
 
 @pytest.mark.asyncio
+async def test_try_external_client_after_probe_timeout_closes_external_on_version_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel during external version resolution should close the fallback client."""
+    closed = {"external": False}
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return supported firmware for the post-timeout branch."""
+            return "26.1.6_2"
+
+        async def async_close(self) -> None:
+            """Record close calls when cancellation occurs."""
+            closed["external"] = True
+
+    async def _create_external_client(**kwargs: Any) -> _ExternalClient:
+        """Return an external client that will be cancelled during version check."""
+        return _ExternalClient()
+
+    async def _get_external_aiopnsense_version() -> str | None:
+        """Cancel when reading package version metadata."""
+        raise asyncio.CancelledError("version cancelled")
+
+    monkeypatch.setattr(factory_mod, "_create_external_client", _create_external_client)
+    monkeypatch.setattr(
+        factory_mod,
+        "_get_external_aiopnsense_version",
+        _get_external_aiopnsense_version,
+    )
+
+    with pytest.raises(asyncio.CancelledError, match="version cancelled"):
+        await factory_mod._try_external_client_after_probe_timeout(
+            kwargs={
+                "url": "https://router",
+                "username": "u",
+                "password": TEST_PASSWORD,
+                "session": cast("aiohttp.ClientSession", SimpleNamespace()),
+                "opts": {"verify_ssl": True},
+                "initial": False,
+            },
+            probe_error=TimeoutError("legacy firmware status timed out"),
+            initial=False,
+        )
+
+    assert closed["external"] is True
+
+
+@pytest.mark.asyncio
 async def test_try_external_client_after_probe_timeout_preserves_firmware_on_unsupported_old_firmware(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -925,6 +973,56 @@ async def test_create_client_uses_external_after_initial_legacy_probe_timeout_wi
     assert (
         "Using aiopnsense after legacy firmware probe timeout for firmware 26.1.6_2" in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_create_client_closes_external_on_version_cancel_after_supported_firmware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancel while resolving aiopnsense version should close both clients and re-raise."""
+    closed: dict[str, bool] = {"probe": False, "external": False}
+
+    class _LegacyClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return supported firmware to force external path."""
+            return "26.1.6_2"
+
+        async def async_close(self) -> None:
+            """Track closure of the strict probe client."""
+            closed["probe"] = True
+
+    class _ExternalClient:
+        async def async_close(self) -> None:
+            """Track closure of external aiopnsense client."""
+            closed["external"] = True
+
+    async def _get_external_aiopnsense_version() -> str | None:
+        """Cancel while looking up package version."""
+        raise asyncio.CancelledError("version cancelled")
+
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", lambda **kwargs: _LegacyClient())
+    monkeypatch.setattr(
+        factory_mod,
+        "_create_external_client",
+        AsyncMock(return_value=_ExternalClient()),
+    )
+    monkeypatch.setattr(
+        factory_mod,
+        "_get_external_aiopnsense_version",
+        _get_external_aiopnsense_version,
+    )
+
+    with pytest.raises(asyncio.CancelledError, match="version cancelled"):
+        await factory_mod.create_opnsense_client(
+            url="https://router",
+            username="u",
+            password=TEST_PASSWORD,
+            session=cast("aiohttp.ClientSession", SimpleNamespace()),
+            opts={"verify_ssl": True},
+        )
+
+    assert closed["probe"] is True
+    assert closed["external"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_factory.py
+++ b/tests/test_client_factory.py
@@ -812,6 +812,67 @@ async def test_try_external_client_after_probe_timeout_closes_external_on_cancel
 
 
 @pytest.mark.asyncio
+async def test_try_external_client_after_probe_timeout_preserves_firmware_on_unsupported_old_firmware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unsupported aiopnsense firmware should seed legacy fallback firmware cache."""
+    created: dict[str, Any] = {"external_closed": False}
+    legacy_client: dict[str, Any] = {}
+    firmware_requests: list[str] = []
+
+    class _ExternalClient:
+        async def get_host_firmware_version(self) -> str:
+            """Return legacy firmware to force legacy fallback."""
+            return "25.7"
+
+        async def async_close(self) -> None:
+            """Record external client cleanup after unsupported firmware detection."""
+            created["external_closed"] = True
+
+    class _LegacyClient:
+        def __init__(self, **kwargs: Any) -> None:
+            """Capture kwargs and initialize firmware cache."""
+            self.kwargs = kwargs
+            self._firmware_version: str | None = None
+            legacy_client["instance"] = self
+
+        async def get_host_firmware_version(self) -> str:
+            """Return cached firmware when factory pre-populates it."""
+            if self._firmware_version is not None:
+                return self._firmware_version
+            firmware_requests.append("request")
+            return "unknown"
+
+    monkeypatch.setattr(
+        factory_mod,
+        "_create_external_client",
+        AsyncMock(return_value=_ExternalClient()),
+    )
+    monkeypatch.setattr(factory_mod, "LegacyOPNsenseClient", _LegacyClient)
+
+    client = await factory_mod._try_external_client_after_probe_timeout(
+        kwargs={
+            "url": "https://router",
+            "username": "u",
+            "password": TEST_PASSWORD,
+            "session": cast("aiohttp.ClientSession", SimpleNamespace()),
+            "opts": {"verify_ssl": True},
+            "initial": False,
+        },
+        probe_error=TimeoutError("legacy firmware status timed out"),
+        initial=False,
+    )
+
+    assert created["external_closed"] is True
+    assert isinstance(client, _LegacyClient)
+    assert client.kwargs["initial"] is False
+    assert getattr(client, "_firmware_version", None) == "25.7"
+    assert await client.get_host_firmware_version() == "25.7"
+    assert firmware_requests == []
+    assert legacy_client["instance"] is client
+
+
+@pytest.mark.asyncio
 async def test_create_client_uses_external_after_initial_legacy_probe_timeout_without_version_log(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -181,6 +181,59 @@ async def test_async_setup_entry_success(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_uses_probe_timeout_fallback_without_initial_client(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator_capture: Any,
+    fake_client: Any,
+    fake_coordinator: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """async_setup_entry should request probe fallback without initial client behavior."""
+    create_calls: list[dict[str, Any]] = []
+    client_ctor: Any = fake_client()
+
+    async def _create_opnsense_client(**kwargs: Any) -> Any:
+        """Record setup-time client constructor arguments for a focused regression check."""
+        create_calls.append(kwargs)
+        return client_ctor(
+            url=kwargs["url"],
+            username=kwargs["username"],
+            password=kwargs["password"],
+            session=kwargs["session"],
+            opts=kwargs["opts"],
+            initial=kwargs.get("initial", False),
+            name=kwargs["name"],
+        )
+
+    monkeypatch.setattr(init_mod, "create_opnsense_client", _create_opnsense_client)
+    monkeypatch.setattr(
+        init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
+    )
+
+    entry = make_config_entry(
+        data={
+            init_mod.CONF_URL: "http://1.2.3.4",
+            init_mod.CONF_USERNAME: "u",
+            init_mod.CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={},
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = AsyncMock()
+    hass.data = {}
+
+    res = await init_mod.async_setup_entry(hass, entry)
+    assert res is True
+    assert create_calls
+    assert create_calls[0].get("initial", False) is False
+    assert create_calls[0]["probe_timeout_fallback"] is True
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_device_id_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -35,6 +35,7 @@ def patch_client_factory(monkeypatch: pytest.MonkeyPatch, module: Any, client_ct
         session: aiohttp.ClientSession,
         opts: MutableMapping[str, Any] | None = None,
         initial: bool = False,
+        probe_timeout_fallback: bool = False,
         name: str | None = None,
     ) -> Any:
         """Create a fake OPNsense client using the provided constructor.
@@ -46,11 +47,13 @@ def patch_client_factory(monkeypatch: pytest.MonkeyPatch, module: Any, client_ct
             session: aiohttp session passed by caller.
             opts: Optional connection options passed by caller.
             initial: Whether the caller marks this as initial setup.
+            probe_timeout_fallback: Whether caller requests factory-level fallback behavior.
             name: Optional client display name passed by caller.
 
         Returns:
             Any: Fake client instance returned by `client_ctor`.
         """
+        _ = probe_timeout_fallback
         return client_ctor(
             url=url,
             username=username,


### PR DESCRIPTION
## Summary
Adds a guarded initial-setup fallback so client creation can try external `aiopnsense` when the bundled legacy firmware probe times out. This keeps existing routing behavior intact while allowing new-firmware setups to recover when the legacy probe cannot confirm the firmware version.

## What Changed
- Added a shared async client close helper for probe cleanup.
- Added an initial-setup-only `aiopnsense` fallback after legacy firmware probe timeouts.
- Kept non-initial timeout behavior unchanged.
- Preserved the original timeout when `aiopnsense` is unavailable or cannot confirm supported firmware.
- Added regression coverage for fallback success, non-initial timeout preservation, and fallback-unavailable behavior.

## Why
Firmware-based backend selection currently depends on the legacy client successfully reading the firmware version before the integration can switch to `aiopnsense`. If that legacy probe times out during setup, new-firmware installs can fail before the intended backend gets a chance to validate the device. The fallback is intentionally narrow: it runs only during initial setup and only returns the external backend after confirming firmware supported by `aiopnsense`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend client cleanup during probe and connection errors.
  * Added a firmware-probe timeout fallback that can switch to an alternate backend when the initial probe times out.
  * Preserved the original error behavior when fallback cannot confirm supported firmware.
  * Safely handles clients that don’t provide an explicit close method.
* **Tests**
  * Expanded async test coverage for fallback routing, cancellation/error paths, cleanup order, and related logging.
  * Added an integration setup test to ensure the fallback is enabled during entry setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->