### PR TITLE
Align entity names with has_entity_name

### DIFF
--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -296,7 +296,6 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         """
         super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_vendor: str | None = mac_vendor
-        self._tracker_device_name: str | None = hostname or mac
         self._attr_name: str | None = None
         self._last_known_ip: str | None = None
         self._last_known_hostname: str | None = None
@@ -471,7 +470,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         return DeviceInfo(
             connections=connections,
             default_manufacturer=self._mac_vendor or "",
-            default_name=self._tracker_device_name or "",
+            default_name=self.hostname or self.mac_address or "",
             via_device=(DOMAIN, self._device_unique_id),
         )
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -296,7 +296,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         """
         super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_vendor: str | None = mac_vendor
-        self._attr_name: str | None = f"{self.opnsense_device_name} {hostname or mac}"
+        self._attr_name: str | None = hostname or mac
         self._last_known_ip: str | None = None
         self._last_known_hostname: str | None = None
         self._is_connected: bool = False

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -346,6 +346,23 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         return self._attr_unique_id
 
     @property
+    def suggested_object_id(self) -> str | None:
+        """Return a stable object-id hint when linking to an existing device.
+
+        Returns:
+            Hostname when available, otherwise MAC, but only for the
+            auto-link path (enabled matching MAC + new-entity preference disabled).
+        """
+        if (
+            self._has_matching_enabled_mac_device()
+            and not self.config_entry.pref_disable_new_entities
+        ):
+            if self._attr_hostname is not None:
+                return self._attr_hostname
+            return self._attr_mac_address
+        return None
+
+    @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity registry is enabled by default.
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -296,7 +296,8 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         """
         super().__init__(config_entry, coordinator, unique_id_suffix=f"mac_{mac}")
         self._mac_vendor: str | None = mac_vendor
-        self._attr_name: str | None = hostname or mac
+        self._tracker_device_name: str | None = hostname or mac
+        self._attr_name: str | None = None
         self._last_known_ip: str | None = None
         self._last_known_hostname: str | None = None
         self._is_connected: bool = False
@@ -470,7 +471,7 @@ class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):
         return DeviceInfo(
             connections=connections,
             default_manufacturer=self._mac_vendor or "",
-            default_name=self.name if isinstance(self.name, str) else "",
+            default_name=self._tracker_device_name or "",
             via_device=(DOMAIN, self._device_unique_id),
         )
 

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -22,6 +22,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
     """Base entity for OPNsense."""
 
+    _attr_has_entity_name = True
+
     @staticmethod
     def payload_display_name(
         payload: Mapping[str, Any],
@@ -87,7 +89,7 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         if unique_id_suffix:
             self._attr_unique_id: str = slugify(f"{self._device_unique_id}_{unique_id_suffix}")
         if name_suffix:
-            self._attr_name: str | None = f"{self.opnsense_device_name or 'OPNsense'} {name_suffix}"
+            self._attr_name: str | None = name_suffix
         self._client: OPNsenseClient | None = None
         self._attr_extra_state_attributes: dict[str, Any] = {}
         self._available: bool = False
@@ -102,8 +104,7 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         """
         return self._available
 
-    @property
-    def opnsense_device_name(self) -> str | None:
+    def _device_name(self) -> str | None:
         """Return the display name for the parent OPNsense device.
 
         Returns:
@@ -209,7 +210,7 @@ class OPNsenseEntity(OPNsenseBaseEntity):
 
         device_info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._device_unique_id)},
-            "name": self.opnsense_device_name,
+            "name": self._device_name(),
             "configuration_url": self.config_entry.data.get("url", None),
         }
 

--- a/custom_components/opnsense/entity.py
+++ b/custom_components/opnsense/entity.py
@@ -104,16 +104,6 @@ class OPNsenseBaseEntity(CoordinatorEntity[OPNsenseDataUpdateCoordinator]):
         """
         return self._available
 
-    def _device_name(self) -> str | None:
-        """Return the display name for the parent OPNsense device.
-
-        Returns:
-            str | None: Config entry title when present, otherwise the runtime device name.
-        """
-        if self.config_entry.title and len(self.config_entry.title) > 0:
-            return self.config_entry.title
-        return self._get_opnsense_state_value("system_info.name")
-
     def _get_opnsense_state_value(self, path: str) -> Any | None:
         """Read a nested value from coordinator state data.
 
@@ -210,7 +200,7 @@ class OPNsenseEntity(OPNsenseBaseEntity):
 
         device_info: DeviceInfo = {
             "identifiers": {(DOMAIN, self._device_unique_id)},
-            "name": self._device_name(),
+            "name": self.config_entry.title or self._get_opnsense_state_value("system_info.name"),
             "configuration_url": self.config_entry.data.get("url", None),
         }
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -634,6 +634,8 @@ async def test_restore_last_state_and_device_info(
         mac_vendor="mfg",
         hostname="dev",
     )
+    assert ent.name == "dev"
+    assert ent.unique_id == "dev1_mac_aa_bb_cc"
     ent._attr_extra_state_attributes = {}
     last_known_connected_time = datetime.now(UTC)
 
@@ -662,11 +664,14 @@ async def test_restore_last_state_and_device_info(
     if isinstance(devinfo, MutableMapping):
         connections = devinfo.get("connections", [])
         via = devinfo.get("via_device")
+        default_name = devinfo.get("default_name")
     else:
         connections = getattr(devinfo, "connections", [])
         via = getattr(devinfo, "via_device", None)
+        default_name = getattr(devinfo, "default_name", None)
 
     assert any(t[1] == "aa:bb:cc" for t in connections)
+    assert default_name == "dev"
     assert via is not None
     assert via[0] == dt_mod.DOMAIN
     assert via[1] == entry.data[pkg.CONF_DEVICE_UNIQUE_ID]

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -634,8 +634,9 @@ async def test_restore_last_state_and_device_info(
         mac_vendor="mfg",
         hostname="dev",
     )
-    assert ent.name == "dev"
+    assert ent.name is None
     assert ent.unique_id == "dev1_mac_aa_bb_cc"
+    assert ent._attr_has_entity_name is True
     ent._attr_extra_state_attributes = {}
     last_known_connected_time = datetime.now(UTC)
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -636,7 +636,7 @@ async def test_restore_last_state_and_device_info(
     )
     assert ent.name is None
     assert ent.unique_id == "dev1_mac_aa_bb_cc"
-    assert ent._attr_has_entity_name is True
+    assert ent.has_entity_name is True
     ent._attr_extra_state_attributes = {}
     last_known_connected_time = datetime.now(UTC)
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -314,6 +314,54 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
     assert ent.device_info is None
 
 
+def test_suggested_object_id_prefers_hostname_when_matching_enabled_mac_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Hostnames should drive suggested_object_id for existing enabled MAC matches."""
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}),
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname="MyDevice",
+    )
+    ent.hass = ph_hass
+    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
+
+    assert ent.device_info is None
+    assert ent.suggested_object_id == "MyDevice"
+
+
+def test_suggested_object_id_falls_back_to_mac_for_existing_enabled_mac_match(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Use MAC as suggested_object_id when hostname is unavailable."""
+    ent = dt_mod.OPNsenseScannerEntity(
+        config_entry=make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}),
+        coordinator=coordinator,
+        enabled_default=False,
+        mac="aa:bb:cc",
+        mac_vendor=None,
+        hostname=None,
+    )
+    ent.hass = ph_hass
+    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
+
+    assert ent.device_info is None
+    assert ent.suggested_object_id == "aa:bb:cc"
+
+
 def test_entity_registry_enabled_default_respects_configured_enabled_default(
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -101,7 +101,7 @@ def test_init_sets_unique_and_name_suffixes(
     assert ent.unique_id.startswith(f"{expected_prefix}_")
     assert ent.unique_id.endswith("_suf")
     assert ent.unique_id == "dev_123_suf"
-    assert ent._attr_has_entity_name is True
+    assert ent.has_entity_name is True
     assert hasattr(ent, "name")
     assert ent.name == "Name"
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -85,7 +85,7 @@ def test_payload_display_name_skips_get_and_str_failures() -> None:
 def test_init_sets_unique_and_name_suffixes(
     make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
 ) -> None:
-    """Verify unique_id and name suffix handling for base entities."""
+    """Verify unique_id and suffix-only name handling for base entities."""
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev-123", "url": "http://x"}, title="MyBox")
     coord = dummy_coordinator
     ent = OPNsenseBaseEntity(
@@ -100,8 +100,10 @@ def test_init_sets_unique_and_name_suffixes(
     assert ent.unique_id is not None
     assert ent.unique_id.startswith(f"{expected_prefix}_")
     assert ent.unique_id.endswith("_suf")
+    assert ent.unique_id == "dev_123_suf"
+    assert ent._attr_has_entity_name is True
     assert hasattr(ent, "name")
-    assert ent.name == "MyBox Name"
+    assert ent.name == "Name"
 
 
 def test_available_property_toggle(
@@ -116,24 +118,28 @@ def test_available_property_toggle(
     assert ent.available is True
 
 
-def test_opnsense_device_name_prefers_title_and_fallback_to_state(
+def test_device_info_name_prefers_title_and_fallback_to_state(
     make_config_entry: Callable[..., MockConfigEntry], dummy_coordinator: MagicMock
 ) -> None:
-    """Device name prefers config entry title and falls back to state name."""
+    """Device info name prefers config entry title and falls back to state name."""
     # when title present
     entry = make_config_entry(
         {CONF_DEVICE_UNIQUE_ID: "dev-123", "url": "http://x"}, title="BoxTitle"
     )
     coord = dummy_coordinator
-    ent = OPNsenseBaseEntity(config_entry=entry, coordinator=coord, unique_id_suffix="test")
-    assert ent.opnsense_device_name == "BoxTitle"
+    ent = OPNsenseEntity(config_entry=entry, coordinator=coord, unique_id_suffix="test")
+    info = ent.device_info
+    assert info is not None
+    assert info["name"] == "BoxTitle"
 
     # when title empty -> falls back to coordinator.data system_info.name
     entry2 = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev-123", "url": "http://x"}, title="")
     coord2 = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coord2.data = {"system_info": {"name": "FromState"}}
-    ent2 = OPNsenseBaseEntity(config_entry=entry2, coordinator=coord2, unique_id_suffix="test")
-    assert ent2.opnsense_device_name == "FromState"
+    ent2 = OPNsenseEntity(config_entry=entry2, coordinator=coord2, unique_id_suffix="test")
+    info2 = ent2.device_info
+    assert info2 is not None
+    assert info2["name"] == "FromState"
 
 
 def test_get_opnsense_state_value_nested_lookup(

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable, Iterator, Mapping
 from unittest.mock import MagicMock
 
-from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -92,17 +91,9 @@ def test_init_sets_unique_and_name_suffixes(
         config_entry=entry, coordinator=coord, unique_id_suffix="suf", name_suffix="Name"
     )
 
-    assert hasattr(ent, "unique_id")
-    # deterministically compute expected slug from device_unique_id and assert
-    device_unique = entry.data.get(CONF_DEVICE_UNIQUE_ID)
-    expected_prefix = slugify(device_unique)
-    # entity unique id is slugified(device_unique_id) + '_' + suffix
     assert ent.unique_id is not None
-    assert ent.unique_id.startswith(f"{expected_prefix}_")
-    assert ent.unique_id.endswith("_suf")
     assert ent.unique_id == "dev_123_suf"
     assert ent.has_entity_name is True
-    assert hasattr(ent, "name")
     assert ent.name == "Name"
 
 


### PR DESCRIPTION
## Summary
Aligns hass-opnsense entity naming with Home Assistant's `has_entity_name` model. Entity display names now omit the parent OPNsense device name while preserving all existing unique ID construction.

## What Changed
- Set `_attr_has_entity_name = True` on the shared OPNsense base entity.
- Changed shared entity name suffix handling so platform entities expose suffix-only names.
- Removed the public `opnsense_device_name` helper and kept parent device naming internal to `device_info`.
- Updated scanner entities to use hostname/MAC names without prefixing the firewall device name.
- Added tests for suffix-only names, `has_entity_name`, device-info naming, and unchanged unique IDs.

## Why
Home Assistant requires new integrations to use `has_entity_name = True`, where the entity name represents only the data point and Home Assistant combines it with the device name. This keeps hass-opnsense aligned with current entity naming expectations without changing entity unique IDs.

## Testing
- `./.venv/bin/pytest`
- `./.venv/bin/prek run -a`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity names now display more cleanly, using the device hostname or MAC address instead of a longer prefixed format.
  * Added a stable suggestion for automatically linking matching devices, helping devices appear more consistently.

* **Bug Fixes**
  * Improved fallback naming so device details use the most relevant available name.
  * Restored entities now keep a more predictable name and identifier display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->