### PR TITLE
Preserve shared devices during tracker cleanup

### DIFF
--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -158,20 +158,25 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 None,
             )
 
-            tracker_device_ids: set[str] = {
-                ent.device_id
+            tracker_entries = [
+                ent
                 for ent in entity_entries
-                if ent.domain == Platform.DEVICE_TRACKER and ent.device_id is not None
+                if getattr(ent, "domain", str(ent.entity_id).split(".", 1)[0])
+                == Platform.DEVICE_TRACKER
+            ]
+            tracker_device_ids: set[str] = {
+                device_id
+                for ent in tracker_entries
+                if (device_id := getattr(ent, "device_id", None)) is not None
             }
-            for ent in entity_entries:
-                if ent.domain == Platform.DEVICE_TRACKER:
-                    _LOGGER.debug(
-                        "[async_update_listener] dissociating "
-                        "device_tracker entity %s from config entry %s",
-                        ent.entity_id,
-                        entry.entry_id,
-                    )
-                    entity_registry.async_remove(ent.entity_id)
+            for ent in tracker_entries:
+                _LOGGER.debug(
+                    "[async_update_listener] dissociating "
+                    "device_tracker entity %s from config entry %s",
+                    ent.entity_id,
+                    entry.entry_id,
+                )
+                entity_registry.async_remove(ent.entity_id)
 
             for device in devices:
                 if device.id not in tracker_device_ids:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -50,7 +50,7 @@ from .const import (
     VERSION,
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
-from .helpers import create_opnsense_client_from_config_entry, find_replacement_router_device_id
+from .helpers import create_opnsense_client_from_config_entry, detach_shared_router_parent
 from .migrate import (
     _is_firewall_sync_enabled,
     _migrate_1_to_2,
@@ -176,18 +176,13 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             for device in devices:
                 if device.id not in tracker_device_ids:
                     continue
-                replacement_router_id = None
-                if (
-                    device.via_device_id is not None
-                    and router_device_id is not None
-                    and device.via_device_id == router_device_id
-                ):
-                    replacement_router_id = find_replacement_router_device_id(
-                        shared_config_entry_id=entry.entry_id,
-                        shared_device_entry=device,
-                        config_entries=hass.config_entries,
-                        device_registry=device_registry,
-                    )
+                from_current_router, replacement_router_id = detach_shared_router_parent(
+                    shared_config_entry_id=entry.entry_id,
+                    shared_device_entry=device,
+                    router_device_id=router_device_id,
+                    config_entries=hass.config_entries,
+                    device_registry=device_registry,
+                )
                 if replacement_router_id is not None:
                     _LOGGER.debug(
                         "[async_update_listener] reparenting shared "
@@ -196,22 +191,12 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                         router_device_id,
                         replacement_router_id,
                     )
-                    device_registry.async_update_device(
-                        device.id,
-                        remove_config_entry_id=entry.entry_id,
-                        via_device_id=replacement_router_id,
-                    )
-                elif device.via_device_id is not None and device.via_device_id == router_device_id:
+                elif from_current_router:
                     _LOGGER.debug(
                         "[async_update_listener] dissociating shared "
                         "tracker device %s from router %s",
                         device.id,
                         config_device_id,
-                    )
-                    device_registry.async_update_device(
-                        device.id,
-                        remove_config_entry_id=entry.entry_id,
-                        via_device_id=None,
                     )
                 else:
                     _LOGGER.debug(
@@ -219,10 +204,6 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                         "tracker device %s from config entry %s",
                         device.id,
                         entry.entry_id,
-                    )
-                    device_registry.async_update_device(
-                        device.id,
-                        remove_config_entry_id=entry.entry_id,
                     )
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
     else:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -179,7 +179,10 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 entity_registry.async_remove(ent.entity_id)
 
             for device in devices:
-                if device.id not in tracker_device_ids:
+                is_current_router_child = (
+                    router_device_id is not None and device.via_device_id == router_device_id
+                )
+                if device.id not in tracker_device_ids and not is_current_router_child:
                     continue
                 from_current_router, replacement_router_id = detach_shared_router_parent(
                     shared_config_entry_id=entry.entry_id,

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -107,6 +107,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             _LOGGER.debug("[async_update_listener] Skipping entity cleanup; empty entry uid prefix")
             uid_prefix = None
         sync_firewall_and_nat_enabled = _is_firewall_sync_enabled(entry)
+        config_device_id: str = entry.data[CONF_DEVICE_UNIQUE_ID]
         # _LOGGER.debug("[async_update_listener] uid_prefix: %s", uid_prefix)
         removal_prefixes: list[str] = []
         for item, prefix in GRANULAR_SYNC_PREFIX.items():
@@ -150,13 +151,51 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             devices = dr.async_entries_for_config_entry(
                 registry=device_registry, config_entry_id=entry.entry_id
             )
-            # _LOGGER.debug("[async_update_listener] devices: %s", devices)
+
+            router_device_id: str | None = None
+            for dev in devices:
+                if (DOMAIN, config_device_id) in dev.identifiers:
+                    router_device_id = dev.id
+                    break
+
+            for ent in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
+                entity_domain = getattr(ent, "domain", None)
+                if entity_domain is None and getattr(ent, "entity_id", None):
+                    entity_domain = str(ent.entity_id).split(".", 1)[0]
+                if entity_domain == Platform.DEVICE_TRACKER:
+                    _LOGGER.debug(
+                        "[async_update_listener] dissociating "
+                        "device_tracker entity %s from config entry %s",
+                        ent.entity_id,
+                        entry.entry_id,
+                    )
+                    entity_registry.async_remove(ent.entity_id)
+
             for device in devices:
                 if device.via_device_id:
-                    _LOGGER.debug("[async_update_listener] removing device: %s", device.name)
-                    device_registry.async_update_device(
-                        device.id, remove_config_entry_id=entry.entry_id
-                    )
+                    if device.via_device_id == router_device_id:
+                        _LOGGER.debug(
+                            "[async_update_listener] dissociating shared "
+                            "tracker device %s from router %s",
+                            device.id,
+                            config_device_id,
+                        )
+                        device_registry.async_update_device(
+                            device.id,
+                            remove_config_entry_id=entry.entry_id,
+                            via_device_id=None,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "[async_update_listener] dissociating "
+                            "tracker device %s from config entry %s",
+                            device.id,
+                            entry.entry_id,
+                        )
+                        device_registry.async_update_device(
+                            device.id,
+                            remove_config_entry_id=entry.entry_id,
+                        )
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
     else:
         _LOGGER.info("[async_update_listener] Not Reloading")

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -182,12 +182,27 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 is_current_router_child = (
                     router_device_id is not None and device.via_device_id == router_device_id
                 )
-                if device.id not in tracker_device_ids and not is_current_router_child:
+                is_orphaned_mac_tracker = (
+                    router_device_id is None
+                    and device.via_device_id is not None
+                    and any(
+                        connection_type == dr.CONNECTION_NETWORK_MAC
+                        for connection_type, _connection_value in device.connections
+                    )
+                )
+                if (
+                    device.id not in tracker_device_ids
+                    and not is_current_router_child
+                    and not is_orphaned_mac_tracker
+                ):
                     continue
+                effective_router_device_id = (
+                    device.via_device_id if is_orphaned_mac_tracker else router_device_id
+                )
                 from_current_router, replacement_router_id = detach_shared_router_parent(
                     shared_config_entry_id=entry.entry_id,
                     shared_device_entry=device,
-                    router_device_id=router_device_id,
+                    router_device_id=effective_router_device_id,
                     config_entries=hass.config_entries,
                     device_registry=device_registry,
                 )
@@ -196,7 +211,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                         "[async_update_listener] reparenting shared "
                         "tracker device %s from %s to %s",
                         device.id,
-                        router_device_id,
+                        effective_router_device_id,
                         replacement_router_id,
                     )
                 elif from_current_router:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -50,7 +50,7 @@ from .const import (
     VERSION,
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
-from .helpers import create_opnsense_client_from_config_entry
+from .helpers import create_opnsense_client_from_config_entry, find_replacement_router_device_id
 from .migrate import (
     _is_firewall_sync_enabled,
     _migrate_1_to_2,
@@ -170,7 +170,28 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
             for device in devices:
                 if device.via_device_id:
-                    if device.via_device_id == router_device_id:
+                    replacement_router_id = None
+                    if router_device_id is not None and device.via_device_id == router_device_id:
+                        replacement_router_id = find_replacement_router_device_id(
+                            shared_config_entry_id=entry.entry_id,
+                            shared_device_entry=device,
+                            config_entries=hass.config_entries,
+                            device_registry=device_registry,
+                        )
+                    if replacement_router_id is not None:
+                        _LOGGER.debug(
+                            "[async_update_listener] reparenting shared "
+                            "tracker device %s from %s to %s",
+                            device.id,
+                            router_device_id,
+                            replacement_router_id,
+                        )
+                        device_registry.async_update_device(
+                            device.id,
+                            remove_config_entry_id=entry.entry_id,
+                            via_device_id=replacement_router_id,
+                        )
+                    elif device.via_device_id == router_device_id:
                         _LOGGER.debug(
                             "[async_update_listener] dissociating shared "
                             "tracker device %s from router %s",

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -154,7 +154,9 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             for device in devices:
                 if device.via_device_id:
                     _LOGGER.debug("[async_update_listener] removing device: %s", device.name)
-                    device_registry.async_remove_device(device.id)
+                    device_registry.async_update_device(
+                        device.id, remove_config_entry_id=entry.entry_id
+                    )
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
     else:
         _LOGGER.info("[async_update_listener] Not Reloading")

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -158,6 +158,11 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 None,
             )
 
+            tracker_device_ids: set[str] = {
+                ent.device_id
+                for ent in entity_entries
+                if ent.domain == Platform.DEVICE_TRACKER and ent.device_id is not None
+            }
             for ent in entity_entries:
                 if ent.domain == Platform.DEVICE_TRACKER:
                     _LOGGER.debug(
@@ -169,51 +174,56 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                     entity_registry.async_remove(ent.entity_id)
 
             for device in devices:
-                if device.via_device_id:
-                    replacement_router_id = None
-                    if router_device_id is not None and device.via_device_id == router_device_id:
-                        replacement_router_id = find_replacement_router_device_id(
-                            shared_config_entry_id=entry.entry_id,
-                            shared_device_entry=device,
-                            config_entries=hass.config_entries,
-                            device_registry=device_registry,
-                        )
-                    if replacement_router_id is not None:
-                        _LOGGER.debug(
-                            "[async_update_listener] reparenting shared "
-                            "tracker device %s from %s to %s",
-                            device.id,
-                            router_device_id,
-                            replacement_router_id,
-                        )
-                        device_registry.async_update_device(
-                            device.id,
-                            remove_config_entry_id=entry.entry_id,
-                            via_device_id=replacement_router_id,
-                        )
-                    elif device.via_device_id == router_device_id:
-                        _LOGGER.debug(
-                            "[async_update_listener] dissociating shared "
-                            "tracker device %s from router %s",
-                            device.id,
-                            config_device_id,
-                        )
-                        device_registry.async_update_device(
-                            device.id,
-                            remove_config_entry_id=entry.entry_id,
-                            via_device_id=None,
-                        )
-                    else:
-                        _LOGGER.debug(
-                            "[async_update_listener] dissociating "
-                            "tracker device %s from config entry %s",
-                            device.id,
-                            entry.entry_id,
-                        )
-                        device_registry.async_update_device(
-                            device.id,
-                            remove_config_entry_id=entry.entry_id,
-                        )
+                if device.id not in tracker_device_ids:
+                    continue
+                replacement_router_id = None
+                if (
+                    device.via_device_id is not None
+                    and router_device_id is not None
+                    and device.via_device_id == router_device_id
+                ):
+                    replacement_router_id = find_replacement_router_device_id(
+                        shared_config_entry_id=entry.entry_id,
+                        shared_device_entry=device,
+                        config_entries=hass.config_entries,
+                        device_registry=device_registry,
+                    )
+                if replacement_router_id is not None:
+                    _LOGGER.debug(
+                        "[async_update_listener] reparenting shared "
+                        "tracker device %s from %s to %s",
+                        device.id,
+                        router_device_id,
+                        replacement_router_id,
+                    )
+                    device_registry.async_update_device(
+                        device.id,
+                        remove_config_entry_id=entry.entry_id,
+                        via_device_id=replacement_router_id,
+                    )
+                elif device.via_device_id is not None and device.via_device_id == router_device_id:
+                    _LOGGER.debug(
+                        "[async_update_listener] dissociating shared "
+                        "tracker device %s from router %s",
+                        device.id,
+                        config_device_id,
+                    )
+                    device_registry.async_update_device(
+                        device.id,
+                        remove_config_entry_id=entry.entry_id,
+                        via_device_id=None,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "[async_update_listener] dissociating "
+                        "tracker device %s from config entry %s",
+                        device.id,
+                        entry.entry_id,
+                    )
+                    device_registry.async_update_device(
+                        device.id,
+                        remove_config_entry_id=entry.entry_id,
+                    )
         hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
     else:
         _LOGGER.info("[async_update_listener] Not Reloading")

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -116,9 +116,10 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
         _LOGGER.debug("[async_update_listener] removal_prefixes: %s", removal_prefixes)
 
         entity_registry = er.async_get(hass)
-        for ent in er.async_entries_for_config_entry(
+        entity_entries = er.async_entries_for_config_entry(
             registry=entity_registry, config_entry_id=entry.entry_id
-        ):
+        )
+        for ent in entity_entries:
             if uid_prefix is None or not ent.unique_id.startswith(f"{uid_prefix}_"):
                 continue
             # _LOGGER.debug("[async_update_listener] ent: %s", ent)
@@ -152,17 +153,13 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 registry=device_registry, config_entry_id=entry.entry_id
             )
 
-            router_device_id: str | None = None
-            for dev in devices:
-                if (DOMAIN, config_device_id) in dev.identifiers:
-                    router_device_id = dev.id
-                    break
+            router_device_id: str | None = next(
+                (dev.id for dev in devices if (DOMAIN, config_device_id) in dev.identifiers),
+                None,
+            )
 
-            for ent in er.async_entries_for_config_entry(entity_registry, entry.entry_id):
-                entity_domain = getattr(ent, "domain", None)
-                if entity_domain is None and getattr(ent, "entity_id", None):
-                    entity_domain = str(ent.entity_id).split(".", 1)[0]
-                if entity_domain == Platform.DEVICE_TRACKER:
+            for ent in entity_entries:
+                if ent.domain == Platform.DEVICE_TRACKER:
                     _LOGGER.debug(
                         "[async_update_listener] dissociating "
                         "device_tracker entity %s from config entry %s",

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -182,9 +182,15 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
                 is_current_router_child = (
                     router_device_id is not None and device.via_device_id == router_device_id
                 )
+                via_parent: object | None = (
+                    device_registry.async_get(device.via_device_id)
+                    if isinstance(device.via_device_id, str)
+                    else None
+                )
                 is_orphaned_mac_tracker = (
                     router_device_id is None
-                    and device.via_device_id is not None
+                    and isinstance(device.via_device_id, str)
+                    and via_parent is None
                     and any(
                         connection_type == dr.CONNECTION_NETWORK_MAC
                         for connection_type, _connection_value in device.connections

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -281,49 +281,44 @@ async def async_setup_entry(
             hostname=device.get("hostname", None),
         )
         entities.append(entity)
-    # _LOGGER.debug(
-    #     "[device_tracker async_setup_entry] mac_addresses: %s, previous_mac_addresses: %s",
-    #     mac_addresses,
-    #     previous_mac_addresses,
-    # )
-    # Get the MACs that need to be removed and remove their devices
-    router_device_id = None
-    if router_device := dev_reg.async_get_device(
-        identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
-    ):
-        router_device_id = router_device.id
-
-    for mac_address in list(set(previous_mac_addresses) - set(mac_addresses)):
-        rem_device = dev_reg.async_get_device(connections={(CONNECTION_NETWORK_MAC, mac_address)})
-        expected_unique_id = slugify(
-            f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
-        )
+    stale_mac_addresses = set(previous_mac_addresses) - set(mac_addresses)
+    if stale_mac_addresses:
         entity_registry = er.async_get(hass)
-        for ent in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
-            entity_domain = getattr(ent, "domain", None)
-            if entity_domain is None and getattr(ent, "entity_id", None):
-                entity_domain = str(ent.entity_id).split(".", 1)[0]
-            if entity_domain == Platform.DEVICE_TRACKER and ent.unique_id == expected_unique_id:
+        router_device = dev_reg.async_get_device(
+            identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
+        )
+        router_device_id = router_device.id if router_device else None
+
+        for mac_address in stale_mac_addresses:
+            rem_device = dev_reg.async_get_device(
+                connections={(CONNECTION_NETWORK_MAC, mac_address)}
+            )
+            expected_unique_id = slugify(
+                f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
+            )
+            if entity_id := entity_registry.async_get_entity_id(
+                Platform.DEVICE_TRACKER, DOMAIN, expected_unique_id
+            ):
                 _LOGGER.debug(
                     "[device_tracker async_setup_entry] "
                     "removing tracker entity_id %s for stale MAC %s",
-                    ent.entity_id,
+                    entity_id,
                     mac_address,
                 )
-                entity_registry.async_remove(ent.entity_id)
-        if rem_device:
-            rem_device_via_id = getattr(rem_device, "via_device_id", None)
-            if rem_device_via_id is not None and rem_device_via_id == router_device_id:
-                dev_reg.async_update_device(
-                    rem_device.id,
-                    remove_config_entry_id=config_entry.entry_id,
-                    via_device_id=None,
-                )
-            else:
-                dev_reg.async_update_device(
-                    rem_device.id,
-                    remove_config_entry_id=config_entry.entry_id,
-                )
+                entity_registry.async_remove(entity_id)
+
+            if rem_device:
+                if router_device_id is not None and rem_device.via_device_id == router_device_id:
+                    dev_reg.async_update_device(
+                        rem_device.id,
+                        remove_config_entry_id=config_entry.entry_id,
+                        via_device_id=None,
+                    )
+                else:
+                    dev_reg.async_update_device(
+                        rem_device.id,
+                        remove_config_entry_id=config_entry.entry_id,
+                    )
 
     if set(mac_addresses) != set(previous_mac_addresses):
         setattr(config_entry.runtime_data, SHOULD_RELOAD, False)

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -36,7 +36,7 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseBaseEntity
-from .helpers import dict_get
+from .helpers import dict_get, find_replacement_router_device_id
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -308,7 +308,28 @@ async def async_setup_entry(
                 entity_registry.async_remove(entity_id)
 
             if rem_device:
+                replacement_router_id = None
                 if router_device_id is not None and rem_device.via_device_id == router_device_id:
+                    replacement_router_id = find_replacement_router_device_id(
+                        shared_config_entry_id=config_entry.entry_id,
+                        shared_device_entry=rem_device,
+                        config_entries=hass.config_entries,
+                        device_registry=dev_reg,
+                    )
+                if replacement_router_id is not None:
+                    _LOGGER.debug(
+                        "[device_tracker async_setup_entry] reparenting shared tracker "
+                        "device %s from %s to %s",
+                        rem_device.id,
+                        router_device_id,
+                        replacement_router_id,
+                    )
+                    dev_reg.async_update_device(
+                        rem_device.id,
+                        remove_config_entry_id=config_entry.entry_id,
+                        via_device_id=replacement_router_id,
+                    )
+                elif router_device_id is not None and rem_device.via_device_id == router_device_id:
                     dev_reg.async_update_device(
                         rem_device.id,
                         remove_config_entry_id=config_entry.entry_id,

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -9,7 +9,9 @@ from typing import Any
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import ScannerEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     async_get as async_get_dev_reg,
@@ -17,11 +19,13 @@ from homeassistant.helpers.device_registry import (
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import slugify
 
 from .config_flow import normalize_mac_address
 from .const import (
     CONF_DEVICE_TRACKER_CONSIDER_HOME,
     CONF_DEVICE_TRACKER_ENABLED,
+    CONF_DEVICE_UNIQUE_ID,
     CONF_DEVICES,
     DEFAULT_DEVICE_TRACKER_CONSIDER_HOME,
     DEFAULT_DEVICE_TRACKER_ENABLED,
@@ -277,11 +281,49 @@ async def async_setup_entry(
             hostname=device.get("hostname", None),
         )
         entities.append(entity)
+    # _LOGGER.debug(
+    #     "[device_tracker async_setup_entry] mac_addresses: %s, previous_mac_addresses: %s",
+    #     mac_addresses,
+    #     previous_mac_addresses,
+    # )
+    # Get the MACs that need to be removed and remove their devices
+    router_device_id = None
+    if router_device := dev_reg.async_get_device(
+        identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
+    ):
+        router_device_id = router_device.id
 
     for mac_address in list(set(previous_mac_addresses) - set(mac_addresses)):
         rem_device = dev_reg.async_get_device(connections={(CONNECTION_NETWORK_MAC, mac_address)})
+        expected_unique_id = slugify(
+            f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
+        )
+        entity_registry = er.async_get(hass)
+        for ent in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
+            entity_domain = getattr(ent, "domain", None)
+            if entity_domain is None and getattr(ent, "entity_id", None):
+                entity_domain = str(ent.entity_id).split(".", 1)[0]
+            if entity_domain == Platform.DEVICE_TRACKER and ent.unique_id == expected_unique_id:
+                _LOGGER.debug(
+                    "[device_tracker async_setup_entry] "
+                    "removing tracker entity_id %s for stale MAC %s",
+                    ent.entity_id,
+                    mac_address,
+                )
+                entity_registry.async_remove(ent.entity_id)
         if rem_device:
-            dev_reg.async_update_device(rem_device.id, remove_config_entry_id=config_entry.entry_id)
+            rem_device_via_id = getattr(rem_device, "via_device_id", None)
+            if rem_device_via_id is not None and rem_device_via_id == router_device_id:
+                dev_reg.async_update_device(
+                    rem_device.id,
+                    remove_config_entry_id=config_entry.entry_id,
+                    via_device_id=None,
+                )
+            else:
+                dev_reg.async_update_device(
+                    rem_device.id,
+                    remove_config_entry_id=config_entry.entry_id,
+                )
 
     if set(mac_addresses) != set(previous_mac_addresses):
         setattr(config_entry.runtime_data, SHOULD_RELOAD, False)

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -1,6 +1,6 @@
 """Support for tracking for OPNsense devices."""
 
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping
 import contextlib
 from datetime import datetime, timedelta, timezone
 import logging
@@ -304,8 +304,8 @@ def _cleanup_stale_tracked_devices(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     device_registry: DeviceRegistry,
-    previous_mac_addresses: Sequence[Any],
-    current_mac_addresses: Sequence[str],
+    previous_mac_addresses: list[Any],
+    current_mac_addresses: list[str],
 ) -> None:
     """Remove stale tracker entities and reparent shared tracker devices.
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -1,6 +1,6 @@
 """Support for tracking for OPNsense devices."""
 
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, Sequence
 import contextlib
 from datetime import datetime, timedelta, timezone
 import logging
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
+    DeviceRegistry,
     async_get as async_get_dev_reg,
 )
 from homeassistant.helpers.entity import DeviceInfo
@@ -281,48 +282,13 @@ async def async_setup_entry(
             hostname=device.get("hostname", None),
         )
         entities.append(entity)
-    stale_mac_addresses = set(previous_mac_addresses) - set(mac_addresses)
-    if stale_mac_addresses:
-        entity_registry = er.async_get(hass)
-        router_device = dev_reg.async_get_device(
-            identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
-        )
-        router_device_id = router_device.id if router_device else None
-
-        for mac_address in stale_mac_addresses:
-            rem_device = dev_reg.async_get_device(
-                connections={(CONNECTION_NETWORK_MAC, mac_address)}
-            )
-            expected_unique_id = slugify(
-                f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
-            )
-            if entity_id := entity_registry.async_get_entity_id(
-                Platform.DEVICE_TRACKER, DOMAIN, expected_unique_id
-            ):
-                _LOGGER.debug(
-                    "[device_tracker async_setup_entry] "
-                    "removing tracker entity_id %s for stale MAC %s",
-                    entity_id,
-                    mac_address,
-                )
-                entity_registry.async_remove(entity_id)
-
-            if rem_device:
-                _from_current_router, replacement_router_id = detach_shared_router_parent(
-                    shared_config_entry_id=config_entry.entry_id,
-                    shared_device_entry=rem_device,
-                    router_device_id=router_device_id,
-                    config_entries=hass.config_entries,
-                    device_registry=dev_reg,
-                )
-                if replacement_router_id is not None:
-                    _LOGGER.debug(
-                        "[device_tracker async_setup_entry] reparenting shared tracker "
-                        "device %s from %s to %s",
-                        rem_device.id,
-                        router_device_id,
-                        replacement_router_id,
-                    )
+    _cleanup_stale_tracked_devices(
+        hass=hass,
+        config_entry=config_entry,
+        device_registry=dev_reg,
+        previous_mac_addresses=previous_mac_addresses,
+        current_mac_addresses=mac_addresses,
+    )
 
     if set(mac_addresses) != set(previous_mac_addresses):
         setattr(config_entry.runtime_data, SHOULD_RELOAD, False)
@@ -332,6 +298,67 @@ async def async_setup_entry(
 
     _LOGGER.debug("[device_tracker async_setup_entry] entities: %s", len(entities))
     async_add_entities(entities)
+
+
+def _cleanup_stale_tracked_devices(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    device_registry: DeviceRegistry,
+    previous_mac_addresses: Sequence[Any],
+    current_mac_addresses: Sequence[str],
+) -> None:
+    """Remove stale tracker entities and reparent shared tracker devices.
+
+    Args:
+        hass: Home Assistant runtime object.
+        config_entry: Active integration config entry for this setup run.
+        device_registry: Device registry used to query and mutate tracked devices.
+        previous_mac_addresses: Previously persisted MAC addresses from config entry data.
+        current_mac_addresses: MAC addresses currently discovered during setup.
+    """
+    stale_mac_addresses = set(previous_mac_addresses) - set(current_mac_addresses)
+    if not stale_mac_addresses:
+        return
+
+    entity_registry = er.async_get(hass)
+    router_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, config_entry.data[CONF_DEVICE_UNIQUE_ID])}
+    )
+    router_device_id = router_device.id if router_device else None
+
+    for mac_address in stale_mac_addresses:
+        rem_device = device_registry.async_get_device(
+            connections={(CONNECTION_NETWORK_MAC, mac_address)}
+        )
+        expected_unique_id = slugify(
+            f"{config_entry.data[CONF_DEVICE_UNIQUE_ID]}_mac_{mac_address}"
+        )
+        if entity_id := entity_registry.async_get_entity_id(
+            Platform.DEVICE_TRACKER, DOMAIN, expected_unique_id
+        ):
+            _LOGGER.debug(
+                "[device_tracker async_setup_entry] removing tracker entity_id %s for stale MAC %s",
+                entity_id,
+                mac_address,
+            )
+            entity_registry.async_remove(entity_id)
+
+        if rem_device:
+            _from_current_router, replacement_router_id = detach_shared_router_parent(
+                shared_config_entry_id=config_entry.entry_id,
+                shared_device_entry=rem_device,
+                router_device_id=router_device_id,
+                config_entries=hass.config_entries,
+                device_registry=device_registry,
+            )
+            if replacement_router_id is not None:
+                _LOGGER.debug(
+                    "[device_tracker async_setup_entry] reparenting shared tracker "
+                    "device %s from %s to %s",
+                    rem_device.id,
+                    router_device_id,
+                    replacement_router_id,
+                )
 
 
 class OPNsenseScannerEntity(OPNsenseBaseEntity, ScannerEntity, RestoreEntity):

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -281,7 +281,7 @@ async def async_setup_entry(
     for mac_address in list(set(previous_mac_addresses) - set(mac_addresses)):
         rem_device = dev_reg.async_get_device(connections={(CONNECTION_NETWORK_MAC, mac_address)})
         if rem_device:
-            dev_reg.async_remove_device(rem_device.id)
+            dev_reg.async_update_device(rem_device.id, remove_config_entry_id=config_entry.entry_id)
 
     if set(mac_addresses) != set(previous_mac_addresses):
         setattr(config_entry.runtime_data, SHOULD_RELOAD, False)

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -344,10 +344,17 @@ def _cleanup_stale_tracked_devices(
             entity_registry.async_remove(entity_id)
 
         if rem_device:
+            effective_router_device_id: str | None = router_device_id
+            if (
+                effective_router_device_id is None
+                and isinstance(rem_device.via_device_id, str)
+                and device_registry.async_get(rem_device.via_device_id) is None
+            ):
+                effective_router_device_id = rem_device.via_device_id
             _from_current_router, replacement_router_id = detach_shared_router_parent(
                 shared_config_entry_id=config_entry.entry_id,
                 shared_device_entry=rem_device,
-                router_device_id=router_device_id,
+                router_device_id=effective_router_device_id,
                 config_entries=hass.config_entries,
                 device_registry=device_registry,
             )

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -36,7 +36,7 @@ from .const import (
 )
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseBaseEntity
-from .helpers import dict_get, find_replacement_router_device_id
+from .helpers import detach_shared_router_parent, dict_get
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -308,14 +308,13 @@ async def async_setup_entry(
                 entity_registry.async_remove(entity_id)
 
             if rem_device:
-                replacement_router_id = None
-                if router_device_id is not None and rem_device.via_device_id == router_device_id:
-                    replacement_router_id = find_replacement_router_device_id(
-                        shared_config_entry_id=config_entry.entry_id,
-                        shared_device_entry=rem_device,
-                        config_entries=hass.config_entries,
-                        device_registry=dev_reg,
-                    )
+                _from_current_router, replacement_router_id = detach_shared_router_parent(
+                    shared_config_entry_id=config_entry.entry_id,
+                    shared_device_entry=rem_device,
+                    router_device_id=router_device_id,
+                    config_entries=hass.config_entries,
+                    device_registry=dev_reg,
+                )
                 if replacement_router_id is not None:
                     _LOGGER.debug(
                         "[device_tracker async_setup_entry] reparenting shared tracker "
@@ -323,22 +322,6 @@ async def async_setup_entry(
                         rem_device.id,
                         router_device_id,
                         replacement_router_id,
-                    )
-                    dev_reg.async_update_device(
-                        rem_device.id,
-                        remove_config_entry_id=config_entry.entry_id,
-                        via_device_id=replacement_router_id,
-                    )
-                elif router_device_id is not None and rem_device.via_device_id == router_device_id:
-                    dev_reg.async_update_device(
-                        rem_device.id,
-                        remove_config_entry_id=config_entry.entry_id,
-                        via_device_id=None,
-                    )
-                else:
-                    dev_reg.async_update_device(
-                        rem_device.id,
-                        remove_config_entry_id=config_entry.entry_id,
                     )
 
     if set(mac_addresses) != set(previous_mac_addresses):

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -11,8 +11,8 @@ from aiopnsense import OPNsenseClient
 from homeassistant.config_entries import ConfigEntries, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 from homeassistant.util import slugify
 
 from .const import CONF_DEVICE_UNIQUE_ID, DEFAULT_VERIFY_SSL, DOMAIN

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -8,13 +8,14 @@ from urllib.parse import urlparse
 
 import aiohttp
 from aiopnsense import OPNsenseClient
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntries, ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceRegistry
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.util import slugify
 
-from .const import DEFAULT_VERIFY_SSL
+from .const import CONF_DEVICE_UNIQUE_ID, DEFAULT_VERIFY_SSL, DOMAIN
 
 
 def dict_get(data: MutableMapping[str, Any], path: str, default: Any | None = None) -> Any | None:
@@ -191,6 +192,42 @@ def create_opnsense_client_from_config_entry(
         throw_errors=throw_errors,
         name=config_entry.title,
     )
+
+
+def find_replacement_router_device_id(
+    shared_config_entry_id: str,
+    shared_device_entry: DeviceEntry,
+    config_entries: ConfigEntries,
+    device_registry: DeviceRegistry,
+) -> str | None:
+    """Find a replacement OPNsense router device id for a shared tracked device.
+
+    Args:
+        shared_config_entry_id: The config entry currently being detached.
+        shared_device_entry: Device registry entry shared by multiple integrations.
+        config_entries: HA config-entry registry object.
+        device_registry: HA device registry for router lookup by identifier.
+
+    Returns:
+        str | None: Replacement router ``device_id`` if a surviving OPNsense entry
+            can be resolved, otherwise ``None``.
+    """
+    remaining_config_entries = sorted(shared_device_entry.config_entries)
+    for owner_entry_id in remaining_config_entries:
+        if owner_entry_id == shared_config_entry_id:
+            continue
+        owner_entry = config_entries.async_get_entry(owner_entry_id)
+        if owner_entry is None or owner_entry.domain != DOMAIN:
+            continue
+        owner_device_unique_id = owner_entry.data.get(CONF_DEVICE_UNIQUE_ID)
+        if not isinstance(owner_device_unique_id, str):
+            continue
+        owner_router = device_registry.async_get_device(
+            identifiers={(DOMAIN, owner_device_unique_id)}
+        )
+        if owner_router is not None:
+            return owner_router.id
+    return None
 
 
 def coerce_bool(value: Any) -> bool | None:

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -230,6 +230,65 @@ def find_replacement_router_device_id(
     return None
 
 
+def detach_shared_router_parent(
+    *,
+    shared_config_entry_id: str,
+    shared_device_entry: DeviceEntry,
+    router_device_id: str | None,
+    config_entries: ConfigEntries,
+    device_registry: DeviceRegistry,
+) -> tuple[bool, str | None]:
+    """Detach a shared tracker device from a removed router config entry.
+
+    Args:
+        shared_config_entry_id: The config entry being detached from the shared device.
+        shared_device_entry: Shared device entry associated with one or more OPNsense
+            integrations.
+        router_device_id: The current router device ID for the detaching integration.
+        config_entries: HA config-entry registry used for surviving router lookup.
+        device_registry: HA device registry used for updating tracker relationships.
+
+    Returns:
+        tuple[bool, str | None]: ``True`` when device was parented through the
+        current router, with optional replacement router id for reparenting.
+    """
+    is_device_from_router: bool = (
+        shared_device_entry.via_device_id is not None
+        and router_device_id is not None
+        and shared_device_entry.via_device_id == router_device_id
+    )
+    replacement_router_id: str | None = None
+    if is_device_from_router:
+        replacement_router_id = find_replacement_router_device_id(
+            shared_config_entry_id=shared_config_entry_id,
+            shared_device_entry=shared_device_entry,
+            config_entries=config_entries,
+            device_registry=device_registry,
+        )
+
+    if replacement_router_id is not None:
+        device_registry.async_update_device(
+            shared_device_entry.id,
+            remove_config_entry_id=shared_config_entry_id,
+            via_device_id=replacement_router_id,
+        )
+        return is_device_from_router, replacement_router_id
+
+    if is_device_from_router:
+        device_registry.async_update_device(
+            shared_device_entry.id,
+            remove_config_entry_id=shared_config_entry_id,
+            via_device_id=None,
+        )
+        return is_device_from_router, None
+
+    device_registry.async_update_device(
+        shared_device_entry.id,
+        remove_config_entry_id=shared_config_entry_id,
+    )
+    return is_device_from_router, None
+
+
 def coerce_bool(value: Any) -> bool | None:
     """Normalize values that may represent booleans.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,7 +380,6 @@ def fake_reg_factory() -> Any:
     def _make(
         device_exists: bool = False,
         device_id: str = "dev",
-        remove_result: Any | None = None,
         config_entries: set[str] | None = None,
         disabled_by: str | None = None,
     ) -> Any:
@@ -389,7 +388,6 @@ def fake_reg_factory() -> Any:
         Args:
             device_exists: Whether ``async_get_device`` should return a device record.
             device_id: Device identifier returned when ``device_exists`` is true.
-            remove_result: Value returned by ``async_remove_device``.
             config_entries: Config entries already linked to the fake device.
             disabled_by: Disable source reported by the fake device entry.
         """
@@ -404,7 +402,6 @@ def fake_reg_factory() -> Any:
                 disabled_by=disabled_by,
             )
         )
-        registry.async_remove_device.return_value = remove_result
         return registry
 
     return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,6 +405,13 @@ def fake_reg_factory() -> Any:
                 self._config_entries = config_entries or set()
                 self._disabled_by = disabled_by
 
+            class _FakeDevice:
+                def __init__(self, device_id: str, via_device_id: str | None = None) -> None:
+                    self.id = device_id
+                    self.via_device_id = via_device_id
+                    self.config_entries = config_entries or set()
+                    self.disabled_by = disabled_by
+
             def async_get_device(self, *args, **kwargs) -> Any:
                 """Return a fake device entry when the fixture is configured to find one.
 
@@ -412,15 +419,13 @@ def fake_reg_factory() -> Any:
                     *args: Positional lookup arguments accepted for API compatibility.
                     **kwargs: Keyword lookup arguments accepted for API compatibility.
                 """
-                if self._device_exists:
+                if not self._device_exists:
+                    return None
 
-                    class _D:
-                        id = self._device_id
-                        config_entries = self._config_entries
-                        disabled_by = self._disabled_by
-
-                    return _D()
-                return None
+                if "identifiers" in kwargs:
+                    # Router-aware lookup is handled by test-specific fakes.
+                    return None
+                return self._FakeDevice(device_id=self._device_id)
 
             def async_update_device(self, device_id: str, **kwargs: Any) -> None:
                 """Record device updates for assertions.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,9 +373,8 @@ def fake_client() -> Any:
 def fake_reg_factory() -> Any:
     """Provide a factory that builds configurable fake device registries.
 
-    The returned registry object exposes ``async_get_device()``,
-    ``async_remove_device()``, and a ``removed`` flag so tests can assert how
-    registry cleanup behaves.
+    The returned registry object exposes device lookup, update, and removal
+    methods so tests can assert how registry cleanup behaves.
     """
 
     def _make(
@@ -442,6 +441,15 @@ def fake_reg_factory() -> Any:
                 """
                 self.removed = True
                 return self._remove_result
+
+            def async_update_device(self, *args: Any, **kwargs: Any) -> None:
+                """Record a device registry update.
+
+                Args:
+                    *args: Positional update arguments.
+                    **kwargs: Keyword update arguments.
+                """
+                self.updated = (args, kwargs)
 
         return _FakeReg()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,8 +373,8 @@ def fake_client() -> Any:
 def fake_reg_factory() -> Any:
     """Provide a factory that builds configurable fake device registries.
 
-    The returned registry object exposes device lookup, update, and removal
-    methods so tests can assert how registry cleanup behaves.
+    The returned registry object exposes configurable lookup, update, and
+    removal methods so tests can assert registry cleanup behavior.
     """
 
     def _make(
@@ -393,70 +393,19 @@ def fake_reg_factory() -> Any:
             config_entries: Config entries already linked to the fake device.
             disabled_by: Disable source reported by the fake device entry.
         """
-
-        class _FakeReg:
-            def __init__(self) -> None:
-                """Initialize _FakeReg."""
-                self.removed = False
-                self.updated_devices: list[tuple[str, dict[str, Any]]] = []
-                self._device_exists = device_exists
-                self._device_id = device_id
-                self._remove_result = remove_result
-                self._config_entries = config_entries or set()
-                self._disabled_by = disabled_by
-
-            class _FakeDevice:
-                def __init__(self, device_id: str, via_device_id: str | None = None) -> None:
-                    self.id = device_id
-                    self.via_device_id = via_device_id
-                    self.config_entries = config_entries or set()
-                    self.disabled_by = disabled_by
-
-            def async_get_device(self, *args, **kwargs) -> Any:
-                """Return a fake device entry when the fixture is configured to find one.
-
-                Args:
-                    *args: Positional lookup arguments accepted for API compatibility.
-                    **kwargs: Keyword lookup arguments accepted for API compatibility.
-                """
-                if not self._device_exists:
-                    return None
-
-                if "identifiers" in kwargs:
-                    # Router-aware lookup is handled by test-specific fakes.
-                    return None
-                return self._FakeDevice(device_id=self._device_id)
-
-            def async_update_device(self, device_id: str, **kwargs: Any) -> None:
-                """Record device updates for assertions.
-
-                Args:
-                    device_id: Device identifier being updated.
-                    **kwargs: Device update keyword arguments.
-                """
-                self.updated_devices.append((device_id, kwargs))
-
-            def async_remove_device(self, *args, **kwargs) -> Any:
-                # mirror previous tests which sometimes inspect a `removed` flag
-                """Record device removal and return the configured removal result.
-
-                Args:
-                    *args: Positional removal arguments accepted for API compatibility.
-                    **kwargs: Keyword removal arguments accepted for API compatibility.
-                """
-                self.removed = True
-                return self._remove_result
-
-            def async_update_device(self, *args: Any, **kwargs: Any) -> None:
-                """Record a device registry update.
-
-                Args:
-                    *args: Positional update arguments.
-                    **kwargs: Keyword update arguments.
-                """
-                self.updated = (args, kwargs)
-
-        return _FakeReg()
+        registry = MagicMock()
+        registry.async_get_device.side_effect = lambda *args, **kwargs: (
+            None
+            if not device_exists or "identifiers" in kwargs
+            else MagicMock(
+                id=device_id,
+                via_device_id=None,
+                config_entries=config_entries or set(),
+                disabled_by=disabled_by,
+            )
+        )
+        registry.async_remove_device.return_value = remove_result
+        return registry
 
     return _make
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1455,3 +1455,65 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
     assert call(
         "stale-other-device", remove_config_entry_id=entry.entry_id, via_device_id=None
     ) not in (device_registry.async_update_device.call_args_list)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_removes_stale_tracker_entities_clears_missing_parent(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Clear stale tracker parent assignment when router lookup is no longer available."""
+    coordinator.data = {"arp_table": [{"mac": "keep:mac"}]}
+    stale_router_mac = "stale:mac:router"
+    entry = make_config_entry(
+        data={
+            dt_mod.TRACKED_MACS: [stale_router_mac, "keep:mac"],
+            pkg.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        entry_id="entity-rm-missing-parent",
+    )
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    entity_registry = MagicMock()
+    entity_registry.async_get_entity_id = MagicMock(return_value=None)
+    monkeypatch.setattr(dt_mod.er, "async_get", MagicMock(return_value=entity_registry))
+
+    missing_parent_id = "missing-router-device-id"
+    stale_device = MagicMock(
+        id="stale-router-device",
+        via_device_id=missing_parent_id,
+        config_entries={entry.entry_id},
+    )
+    devices = {
+        stale_router_mac: stale_device,
+    }
+
+    def get_device(
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        connections: set[tuple[str, str]] | None = None,
+    ) -> Any:
+        """Return fake stale tracker devices and missing router lookup results."""
+        if identifiers is not None:
+            return None
+        if connections is not None:
+            return devices[next(iter(connections))[1]]
+        return None
+
+    device_registry = MagicMock()
+    device_registry.async_get_device = MagicMock(side_effect=get_device)
+    device_registry.async_get = MagicMock(return_value=None)
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", MagicMock(return_value=device_registry))
+
+    ph_hass.config_entries.async_update_entry = MagicMock()
+    await dt_mod.async_setup_entry(ph_hass, entry, MagicMock())
+
+    device_registry.async_get.assert_called_once_with(missing_parent_id)
+    device_registry.async_update_device.assert_called_once_with(
+        stale_device.id,
+        remove_config_entry_id=entry.entry_id,
+        via_device_id=None,
+    )

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1302,19 +1302,25 @@ async def test_async_setup_entry_from_arp_entries(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
+async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_shared_router(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Stale MAC removal should clear via-links and remove matching tracker entities."""
+    """Stale MAC cleanup reassigns shared parents to surviving OPNsense routers."""
     coordinator.data = {"arp_table": [{"mac": "keep:mac"}]}
     stale_router_mac = "stale:mac:router"
     stale_other_mac = "stale:mac:other"
+    stale_non_opnsense_mac = "stale:mac:nonopnsense"
     entry = make_config_entry(
         data={
-            dt_mod.TRACKED_MACS: [stale_router_mac, stale_other_mac, "keep:mac"],
+            dt_mod.TRACKED_MACS: [
+                stale_router_mac,
+                stale_other_mac,
+                stale_non_opnsense_mac,
+                "keep:mac",
+            ],
             pkg.CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
@@ -1326,6 +1332,7 @@ async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
     entity_ids = {
         "dev1_mac_stale_mac_router": "device_tracker.device_stale_router",
         "dev1_mac_stale_mac_other": "device_tracker.device_stale_other",
+        "dev1_mac_stale_mac_nonopnsense": "device_tracker.device_stale_nonopnsense_router",
     }
 
     def get_entity_id(domain: str, platform: str, unique_id: str) -> str | None:
@@ -1335,10 +1342,60 @@ async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
     entity_registry.async_get_entity_id.side_effect = get_entity_id
     monkeypatch.setattr(dt_mod.er, "async_get", MagicMock(return_value=entity_registry))
 
-    router_device = MagicMock(id="router-device-id")
+    router_device = MagicMock(
+        id="router-device-id",
+        identifiers={(dt_mod.DOMAIN, entry.data[dt_mod.CONF_DEVICE_UNIQUE_ID])},
+    )
+    surviving_entry_a = MagicMock(
+        entry_id="survive-entry-b",
+        domain=dt_mod.DOMAIN,
+        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "survive-b"},
+    )
+    surviving_entry_b = MagicMock(
+        entry_id="survive-entry-a",
+        domain=dt_mod.DOMAIN,
+        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "survive-a"},
+    )
+    non_opnsense_entry = MagicMock(
+        entry_id="non-opnsense-entry",
+        domain="other",
+        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
+    )
+    async_get_entry_map = {
+        entry.entry_id: entry,
+        surviving_entry_a.entry_id: surviving_entry_a,
+        surviving_entry_b.entry_id: surviving_entry_b,
+        non_opnsense_entry.entry_id: non_opnsense_entry,
+    }
+    ph_hass.config_entries.async_get_entry = MagicMock(side_effect=async_get_entry_map.get)
+    surviving_router_a = MagicMock(id="survivor-a-router")
+    surviving_router_b = MagicMock(id="survivor-b-router")
+    identifier_router_map = {
+        (dt_mod.DOMAIN, entry.data[dt_mod.CONF_DEVICE_UNIQUE_ID]): router_device,
+        (dt_mod.DOMAIN, "survive-b"): surviving_router_b,
+        (dt_mod.DOMAIN, "survive-a"): surviving_router_a,
+    }
     devices = {
-        stale_router_mac: MagicMock(id="stale-router-device", via_device_id="router-device-id"),
-        stale_other_mac: MagicMock(id="stale-other-device", via_device_id="other-device-id"),
+        stale_router_mac: MagicMock(
+            id="stale-router-device",
+            via_device_id="router-device-id",
+            config_entries={
+                entry.entry_id,
+                surviving_entry_a.entry_id,
+                surviving_entry_b.entry_id,
+                non_opnsense_entry.entry_id,
+            },
+        ),
+        stale_other_mac: MagicMock(
+            id="stale-other-device",
+            via_device_id="other-device-id",
+            config_entries={entry.entry_id, non_opnsense_entry.entry_id},
+        ),
+        stale_non_opnsense_mac: MagicMock(
+            id="stale-nonopnsense-device",
+            via_device_id="router-device-id",
+            config_entries={entry.entry_id, non_opnsense_entry.entry_id},
+        ),
     }
 
     def get_device(
@@ -1348,7 +1405,8 @@ async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
     ) -> Any:
         """Return the fake router or stale device for the requested lookup."""
         if identifiers is not None:
-            return router_device
+            key = next(iter(identifiers))
+            return identifier_router_map.get(key)
         if connections is not None:
             return devices[next(iter(connections))[1]]
         return None
@@ -1364,19 +1422,30 @@ async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
         [
             call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_router"),
             call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_other"),
+            call(
+                dt_mod.Platform.DEVICE_TRACKER,
+                dt_mod.DOMAIN,
+                "dev1_mac_stale_mac_nonopnsense",
+            ),
         ],
         any_order=True,
     )
-    assert entity_registry.async_get_entity_id.call_count == 2
+    assert entity_registry.async_get_entity_id.call_count == 3
     removed_ids = {item.args[0] for item in entity_registry.async_remove.call_args_list}
     assert removed_ids == {
         "device_tracker.device_stale_router",
         "device_tracker.device_stale_other",
+        "device_tracker.device_stale_nonopnsense_router",
     }
     device_registry.async_update_device.assert_has_calls(
         [
             call(
                 "stale-router-device",
+                remove_config_entry_id=entry.entry_id,
+                via_device_id="survivor-a-router",
+            ),
+            call(
+                "stale-nonopnsense-device",
                 remove_config_entry_id=entry.entry_id,
                 via_device_id=None,
             ),

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1298,3 +1298,110 @@ async def test_async_setup_entry_from_arp_entries(
     assert len(added) == 2
     assert all(isinstance(e, dt_mod.OPNsenseScannerEntity) for e in added)
     assert {e.unique_id for e in added} == {"dev1_mac_m1", "dev1_mac_m2"}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Stale MAC removal should clear via-links and remove matching tracker entities."""
+    coordinator.data = {"arp_table": [{"mac": "keep:mac"}]}
+    stale_router_mac = "stale:mac:router"
+    stale_other_mac = "stale:mac:other"
+    entry = make_config_entry(
+        data={
+            dt_mod.TRACKED_MACS: [stale_router_mac, stale_other_mac, "keep:mac"],
+            pkg.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        entry_id="entity-rm",
+    )
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    stale_router_ent = MagicMock()
+    stale_router_ent.entity_id = "device_tracker.device_stale_router"
+    stale_router_ent.unique_id = "dev1_mac_stale_mac_router"
+    stale_router_ent.domain = "device_tracker"
+
+    stale_other_ent = MagicMock()
+    stale_other_ent.entity_id = "device_tracker.device_stale_other"
+    stale_other_ent.unique_id = "dev1_mac_stale_mac_other"
+    stale_other_ent.domain = "device_tracker"
+
+    other_ent = MagicMock()
+    other_ent.entity_id = "sensor.other"
+    other_ent.unique_id = "dev1_sensor_other"
+    other_ent.domain = "sensor"
+
+    class _FakeEntityReg:
+        def __init__(self) -> None:
+            """Track removed entity IDs."""
+            self.removed: list[str] = []
+            self.updated: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+            self._router_device = MagicMock()
+            self._router_device.id = "router-device-id"
+            self._router_device.identifiers = {(dt_mod.DOMAIN, "dev1")}
+            self._mac_devices: dict[frozenset[Any], MagicMock] = {
+                frozenset({(dt_mod.CONNECTION_NETWORK_MAC, stale_router_mac)}): MagicMock(
+                    id="stale-router-device", via_device_id="router-device-id"
+                ),
+                frozenset({(dt_mod.CONNECTION_NETWORK_MAC, stale_other_mac)}): MagicMock(
+                    id="stale-other-device", via_device_id="other-device-id"
+                ),
+            }
+
+        def async_entries_for_config_entry(self, registry: Any, config_entry_id: str) -> list[Any]:
+            """Return registry entries for this config entry."""
+            return [stale_router_ent, stale_other_ent, other_ent]
+
+        def async_remove(self, entity_id: str) -> None:
+            """Record removed entity identifiers."""
+            self.removed.append(entity_id)
+
+        def async_get_device(self, *args: Any, **kwargs: Any) -> Any:
+            """Return configured stale router or stale tracker devices by lookup.
+
+            Returns the router device by identifiers and stale devices by connection.
+            """
+            if "identifiers" in kwargs:
+                identifiers = kwargs["identifiers"]
+                if identifiers == self._router_device.identifiers:
+                    return self._router_device
+                return None
+            if "connections" in kwargs:
+                return self._mac_devices.get(frozenset(kwargs["connections"]))
+            return None
+
+        def async_update_device(self, *args: Any, **kwargs: Any) -> None:
+            """Record a cleanup update to the device registry."""
+            self.updated.append((args, kwargs))
+
+    entity_registry = _FakeEntityReg()
+    monkeypatch.setattr(dt_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        dt_mod.er,
+        "async_entries_for_config_entry",
+        entity_registry.async_entries_for_config_entry,
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_update_entry = MagicMock()
+
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: entity_registry)
+
+    await dt_mod.async_setup_entry(hass, entry, lambda x: None)
+    assert set(entity_registry.removed) == {
+        "device_tracker.device_stale_router",
+        "device_tracker.device_stale_other",
+    }
+    assert (
+        ("stale-router-device",),
+        {"remove_config_entry_id": entry.entry_id, "via_device_id": None},
+    ) in entity_registry.updated
+    assert (
+        ("stale-other-device",),
+        {"remove_config_entry_id": entry.entry_id},
+    ) in entity_registry.updated

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1137,7 +1137,10 @@ async def test_async_setup_entry_removes_previous_mac(
     hass.config_entries.async_update_entry = MagicMock()
 
     await dt_mod.async_setup_entry(hass, entry, cast("AddEntitiesCallback", lambda _x: None))
-    assert fake.removed is True
+    assert fake.removed is False
+    assert fake.updated_devices == [
+        ("dev_to_remove", {"remove_config_entry_id": entry.entry_id})
+    ]
     assert hass.config_entries.async_update_entry.called
 
 

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -6,7 +6,6 @@ and device info formatting for the integration's device tracker entities.
 
 from collections.abc import Callable, Iterable, MutableMapping
 from datetime import UTC, datetime, timedelta
-import importlib
 from types import MappingProxyType
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -6,9 +6,10 @@ and device info formatting for the integration's device tracker entities.
 
 from collections.abc import Callable, Iterable, MutableMapping
 from datetime import UTC, datetime, timedelta
+import importlib
 from types import MappingProxyType
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -1137,10 +1138,10 @@ async def test_async_setup_entry_removes_previous_mac(
     hass.config_entries.async_update_entry = MagicMock()
 
     await dt_mod.async_setup_entry(hass, entry, cast("AddEntitiesCallback", lambda _x: None))
-    assert fake.removed is False
-    assert fake.updated_devices == [
-        ("dev_to_remove", {"remove_config_entry_id": entry.entry_id})
-    ]
+    fake.async_remove_device.assert_not_called()
+    fake.async_update_device.assert_called_once_with(
+        "dev_to_remove", remove_config_entry_id=entry.entry_id
+    )
     assert hass.config_entries.async_update_entry.called
 
 
@@ -1321,87 +1322,68 @@ async def test_async_setup_entry_removes_stale_tracker_entities_before_detach(
     )
     setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    stale_router_ent = MagicMock()
-    stale_router_ent.entity_id = "device_tracker.device_stale_router"
-    stale_router_ent.unique_id = "dev1_mac_stale_mac_router"
-    stale_router_ent.domain = "device_tracker"
+    entity_registry = MagicMock()
+    entity_ids = {
+        "dev1_mac_stale_mac_router": "device_tracker.device_stale_router",
+        "dev1_mac_stale_mac_other": "device_tracker.device_stale_other",
+    }
 
-    stale_other_ent = MagicMock()
-    stale_other_ent.entity_id = "device_tracker.device_stale_other"
-    stale_other_ent.unique_id = "dev1_mac_stale_mac_other"
-    stale_other_ent.domain = "device_tracker"
+    def get_entity_id(domain: str, platform: str, unique_id: str) -> str | None:
+        """Return the registered tracker entity for a stale unique ID."""
+        return entity_ids.get(unique_id)
 
-    other_ent = MagicMock()
-    other_ent.entity_id = "sensor.other"
-    other_ent.unique_id = "dev1_sensor_other"
-    other_ent.domain = "sensor"
+    entity_registry.async_get_entity_id.side_effect = get_entity_id
+    monkeypatch.setattr(dt_mod.er, "async_get", MagicMock(return_value=entity_registry))
 
-    class _FakeEntityReg:
-        def __init__(self) -> None:
-            """Track removed entity IDs."""
-            self.removed: list[str] = []
-            self.updated: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
-            self._router_device = MagicMock()
-            self._router_device.id = "router-device-id"
-            self._router_device.identifiers = {(dt_mod.DOMAIN, "dev1")}
-            self._mac_devices: dict[frozenset[Any], MagicMock] = {
-                frozenset({(dt_mod.CONNECTION_NETWORK_MAC, stale_router_mac)}): MagicMock(
-                    id="stale-router-device", via_device_id="router-device-id"
-                ),
-                frozenset({(dt_mod.CONNECTION_NETWORK_MAC, stale_other_mac)}): MagicMock(
-                    id="stale-other-device", via_device_id="other-device-id"
-                ),
-            }
+    router_device = MagicMock(id="router-device-id")
+    devices = {
+        stale_router_mac: MagicMock(id="stale-router-device", via_device_id="router-device-id"),
+        stale_other_mac: MagicMock(id="stale-other-device", via_device_id="other-device-id"),
+    }
 
-        def async_entries_for_config_entry(self, registry: Any, config_entry_id: str) -> list[Any]:
-            """Return registry entries for this config entry."""
-            return [stale_router_ent, stale_other_ent, other_ent]
+    def get_device(
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        connections: set[tuple[str, str]] | None = None,
+    ) -> Any:
+        """Return the fake router or stale device for the requested lookup."""
+        if identifiers is not None:
+            return router_device
+        if connections is not None:
+            return devices[next(iter(connections))[1]]
+        return None
 
-        def async_remove(self, entity_id: str) -> None:
-            """Record removed entity identifiers."""
-            self.removed.append(entity_id)
+    device_registry = MagicMock()
+    device_registry.async_get_device.side_effect = get_device
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", MagicMock(return_value=device_registry))
 
-        def async_get_device(self, *args: Any, **kwargs: Any) -> Any:
-            """Return configured stale router or stale tracker devices by lookup.
+    ph_hass.config_entries.async_update_entry = MagicMock()
+    await dt_mod.async_setup_entry(ph_hass, entry, MagicMock())
 
-            Returns the router device by identifiers and stale devices by connection.
-            """
-            if "identifiers" in kwargs:
-                identifiers = kwargs["identifiers"]
-                if identifiers == self._router_device.identifiers:
-                    return self._router_device
-                return None
-            if "connections" in kwargs:
-                return self._mac_devices.get(frozenset(kwargs["connections"]))
-            return None
-
-        def async_update_device(self, *args: Any, **kwargs: Any) -> None:
-            """Record a cleanup update to the device registry."""
-            self.updated.append((args, kwargs))
-
-    entity_registry = _FakeEntityReg()
-    monkeypatch.setattr(dt_mod.er, "async_get", lambda hass: entity_registry)
-    monkeypatch.setattr(
-        dt_mod.er,
-        "async_entries_for_config_entry",
-        entity_registry.async_entries_for_config_entry,
+    entity_registry.async_get_entity_id.assert_has_calls(
+        [
+            call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_router"),
+            call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_other"),
+        ],
+        any_order=True,
     )
-
-    hass = ph_hass
-    hass.config_entries.async_update_entry = MagicMock()
-
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda hass: entity_registry)
-
-    await dt_mod.async_setup_entry(hass, entry, lambda x: None)
-    assert set(entity_registry.removed) == {
+    assert entity_registry.async_get_entity_id.call_count == 2
+    removed_ids = {item.args[0] for item in entity_registry.async_remove.call_args_list}
+    assert removed_ids == {
         "device_tracker.device_stale_router",
         "device_tracker.device_stale_other",
     }
-    assert (
-        ("stale-router-device",),
-        {"remove_config_entry_id": entry.entry_id, "via_device_id": None},
-    ) in entity_registry.updated
-    assert (
-        ("stale-other-device",),
-        {"remove_config_entry_id": entry.entry_id},
-    ) in entity_registry.updated
+    device_registry.async_update_device.assert_has_calls(
+        [
+            call(
+                "stale-router-device",
+                remove_config_entry_id=entry.entry_id,
+                via_device_id=None,
+            ),
+            call("stale-other-device", remove_config_entry_id=entry.entry_id),
+        ],
+        any_order=True,
+    )
+    assert call(
+        "stale-other-device", remove_config_entry_id=entry.entry_id, via_device_id=None
+    ) not in (device_registry.async_update_device.call_args_list)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1661,7 +1661,7 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("dt_enabled", "via_device_id", "expect_removed"),
+    ("dt_enabled", "via_device_id", "expect_updated"),
     [
         (False, True, True),
         (False, False, False),
@@ -1674,9 +1674,9 @@ async def test_async_update_listener_device_removal_param(
     make_config_entry: Callable[..., MockConfigEntry],
     dt_enabled: Any,
     via_device_id: Any,
-    expect_removed: Any,
+    expect_updated: Any,
 ) -> None:
-    """Parameterized: ensure devices are removed only when device tracker disabled and via_device_id is True."""
+    """Remove only this config entry from tracked devices when tracking is disabled."""
     # create an entry with the device tracker option set per parameter
     entry = make_config_entry(
         data={init_mod.CONF_DEVICE_UNIQUE_ID: "dev1"},
@@ -1696,6 +1696,7 @@ async def test_async_update_listener_device_removal_param(
 
     dr_reg = MagicMock()
     dr_reg.async_remove_device = MagicMock()
+    dr_reg.async_update_device = MagicMock()
     monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
     monkeypatch.setattr(
         init_mod.dr,
@@ -1713,10 +1714,13 @@ async def test_async_update_listener_device_removal_param(
 
     await init_mod._async_update_listener(hass, entry)
 
-    if expect_removed:
-        dr_reg.async_remove_device.assert_called_once_with(device.id)
+    dr_reg.async_remove_device.assert_not_called()
+    if expect_updated:
+        dr_reg.async_update_device.assert_called_once_with(
+            device.id, remove_config_entry_id=entry.entry_id
+        )
     else:
-        dr_reg.async_remove_device.assert_not_called()
+        dr_reg.async_update_device.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1725,12 +1725,12 @@ async def test_async_update_listener_device_removal_param(
 
 
 @pytest.mark.asyncio
-async def test_async_update_listener_disassociates_tracker_entities_and_router_links(
+async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsense_router(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Disabling tracking removes tracker entities and only matching parent links."""
+    """Disabling tracking reassigns shared tracker parent to surviving OPNsense router."""
     entry = make_config_entry(
         data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
         options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
@@ -1765,16 +1765,77 @@ async def test_async_update_listener_disassociates_tracker_entities_and_router_l
         identifiers={(init_mod.DOMAIN, "router-mac")},
         via_device_id=None,
     )
-    linked_to_router = MagicMock(id="shared-device", via_device_id=router_device.id)
+    surviving_opnsense_a = MagicMock(
+        entry_id="survive-entry-b",
+        domain=init_mod.DOMAIN,
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "survive-b"},
+    )
+    surviving_opnsense_b = MagicMock(
+        entry_id="survive-entry-a",
+        domain=init_mod.DOMAIN,
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "survive-a"},
+    )
+    non_opnsense_entry = MagicMock(
+        entry_id="non-opnsense-entry",
+        domain="other",
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
+    )
+    shared_router_b = MagicMock(id="survivor-b-router")
+    shared_router_a = MagicMock(id="survivor-a-router")
+    linked_to_router = MagicMock(
+        id="shared-device",
+        via_device_id=router_device.id,
+        config_entries={
+            entry.entry_id,
+            surviving_opnsense_a.entry_id,
+            surviving_opnsense_b.entry_id,
+            non_opnsense_entry.entry_id,
+        },
+    )
+    linked_to_router_non_opnsense_only = MagicMock(
+        id="nonopnsense-device",
+        via_device_id=router_device.id,
+        config_entries={entry.entry_id, non_opnsense_entry.entry_id},
+    )
     linked_to_other_router = MagicMock(id="other-device", via_device_id="other-device-id")
     no_parent = MagicMock(id="noparent-device", via_device_id=None)
+    async_get_entry_map = {
+        entry.entry_id: entry,
+        surviving_opnsense_a.entry_id: surviving_opnsense_a,
+        surviving_opnsense_b.entry_id: surviving_opnsense_b,
+        non_opnsense_entry.entry_id: non_opnsense_entry,
+    }
+    ph_hass.config_entries.async_get_entry = MagicMock(side_effect=async_get_entry_map.get)
+    identifier_router_map = {
+        (init_mod.DOMAIN, "router-mac"): router_device,
+        (init_mod.DOMAIN, "survive-b"): shared_router_b,
+        (init_mod.DOMAIN, "survive-a"): shared_router_a,
+    }
     dr_reg = MagicMock()
+
+    def get_device(
+        *,
+        identifiers: set[tuple[str, str]] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        if identifiers is None:
+            return None
+        key = next(iter(identifiers))
+        return identifier_router_map.get(key)
+
+    dr_reg.async_get_device = MagicMock(side_effect=get_device)
     monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
         init_mod.dr,
         "async_entries_for_config_entry",
         MagicMock(
-            return_value=[router_device, linked_to_router, linked_to_other_router, no_parent]
+            return_value=[
+                router_device,
+                linked_to_router,
+                linked_to_router_non_opnsense_only,
+                linked_to_other_router,
+                no_parent,
+            ]
         ),
     )
 
@@ -1782,10 +1843,23 @@ async def test_async_update_listener_disassociates_tracker_entities_and_router_l
 
     er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
     assert call(sensor_ent.entity_id) not in er_reg.async_remove.mock_calls
+    assert (
+        call(
+            linked_to_other_router.id,
+            remove_config_entry_id=entry.entry_id,
+            via_device_id=None,
+        )
+        not in dr_reg.async_update_device.mock_calls
+    )
     dr_reg.async_update_device.assert_has_calls(
         [
             call(
                 linked_to_router.id,
+                remove_config_entry_id=entry.entry_id,
+                via_device_id="survivor-a-router",
+            ),
+            call(
+                linked_to_router_non_opnsense_only.id,
                 remove_config_entry_id=entry.entry_id,
                 via_device_id=None,
             ),
@@ -1801,7 +1875,7 @@ async def test_async_update_listener_disassociates_tracker_entities_and_router_l
         )
         not in dr_reg.async_update_device.mock_calls
     )
-    assert dr_reg.async_update_device.call_count == 2
+    assert dr_reg.async_update_device.call_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1662,11 +1662,12 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("dt_enabled", "via_device_id", "expect_updated"),
+    ("dt_enabled", "via_device_id", "tracker_device_id", "expect_updated"),
     [
-        (False, True, True),
-        (False, False, False),
-        (True, True, False),
+        (False, True, "tracked-device", True),
+        (False, False, "tracked-device", True),
+        (True, True, "tracked-device", False),
+        (False, True, None, False),
     ],
 )
 async def test_async_update_listener_device_removal_param(
@@ -1675,6 +1676,7 @@ async def test_async_update_listener_device_removal_param(
     make_config_entry: Callable[..., MockConfigEntry],
     dt_enabled: Any,
     via_device_id: Any,
+    tracker_device_id: Any,
     expect_updated: Any,
 ) -> None:
     """Remove only this config entry from tracked devices when tracking is disabled."""
@@ -1689,10 +1691,23 @@ async def test_async_update_listener_device_removal_param(
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
 
+    # ensure hass.async_create_task exists for scheduling reload
+    if not hasattr(hass, "async_create_task"):
+        hass.async_create_task = MagicMock()
+
+    dt_ent = None
+    if tracker_device_id is not None:
+        dt_ent = MagicMock(
+            entity_id=f"device_tracker.{tracker_device_id}",
+            domain=init_mod.Platform.DEVICE_TRACKER,
+            unique_id=f"{entry.unique_id}_{tracker_device_id}",
+            device_id=tracker_device_id,
+        )
+
     # prepare a single device entry returned by the device registry
     device = MagicMock()
     device.via_device_id = via_device_id
-    device.id = "d_device"
+    device.id = tracker_device_id or "d_device"
     device.name = "devname"
 
     dr_reg = MagicMock()
@@ -1706,22 +1721,95 @@ async def test_async_update_listener_device_removal_param(
     )
 
     # ensure no entity registry removals interfere
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
+    er_reg = MagicMock()
+    er_reg.async_remove = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
         init_mod.er,
         "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [],
+        lambda registry, config_entry_id: [dt_ent] if dt_ent is not None else [],
     )
 
     await init_mod._async_update_listener(hass, entry)
 
     dr_reg.async_remove_device.assert_not_called()
+    if tracker_device_id is None:
+        er_reg.async_remove.assert_not_called()
     if expect_updated:
         dr_reg.async_update_device.assert_called_once_with(
             device.id, remove_config_entry_id=entry.entry_id
         )
     else:
         dr_reg.async_update_device.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_update_listener_detaches_no_parent_tracker_device(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Trackers with no parent remain detached from removed config entry."""
+    entry = make_config_entry(
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.data = {}
+    if not hasattr(ph_hass, "async_create_task"):
+        ph_hass.async_create_task = MagicMock()
+
+    dt_ent = MagicMock(
+        entity_id="device_tracker.tracked_device",
+        domain=init_mod.Platform.DEVICE_TRACKER,
+        unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
+        device_id="tracker-device-no-parent",
+    )
+    sensor_ent = MagicMock(
+        entity_id="sensor.system_uptime",
+        domain=init_mod.Platform.SENSOR,
+        unique_id=f"{entry.unique_id}_system_uptime",
+    )
+    er_reg = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[dt_ent, sensor_ent]),
+    )
+
+    tracker_without_parent = MagicMock(id="tracker-device-no-parent", via_device_id=None)
+    non_tracker_no_parent = MagicMock(id="nontracker-no-parent-device", via_device_id=None)
+    dr_reg = MagicMock()
+    dr_reg.async_update_device = MagicMock()
+    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(
+        init_mod.dr,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[tracker_without_parent, non_tracker_no_parent]),
+    )
+
+    await init_mod._async_update_listener(ph_hass, entry)
+
+    er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
+    assert (
+        call(tracker_without_parent.id, remove_config_entry_id=entry.entry_id)
+        in dr_reg.async_update_device.mock_calls
+    )
+    assert (
+        call(
+            non_tracker_no_parent.id,
+            remove_config_entry_id=entry.entry_id,
+        )
+        not in dr_reg.async_update_device.mock_calls
+    )
+    assert (
+        call(non_tracker_no_parent.id, remove_config_entry_id=entry.entry_id, via_device_id=None)
+        not in dr_reg.async_update_device.mock_calls
+    )
+    assert dr_reg.async_update_device.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -1746,6 +1834,13 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
         entity_id="device_tracker.living_room_device",
         domain=init_mod.Platform.DEVICE_TRACKER,
         unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
+        device_id="shared-device",
+    )
+    dt_ent_non_router = MagicMock(
+        entity_id="device_tracker.kitchen_device",
+        domain=init_mod.Platform.DEVICE_TRACKER,
+        unique_id=f"{entry.unique_id}_mac_cdddeeff0011",
+        device_id="nonopnsense-device",
     )
     sensor_ent = MagicMock(
         entity_id="sensor.system_uptime",
@@ -1757,7 +1852,7 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
     monkeypatch.setattr(
         init_mod.er,
         "async_entries_for_config_entry",
-        MagicMock(return_value=[dt_ent, sensor_ent]),
+        MagicMock(return_value=[dt_ent, dt_ent_non_router, sensor_ent]),
     )
 
     router_device = MagicMock(
@@ -1841,16 +1936,11 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
 
     await init_mod._async_update_listener(ph_hass, entry)
 
-    er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
-    assert call(sensor_ent.entity_id) not in er_reg.async_remove.mock_calls
-    assert (
-        call(
-            linked_to_other_router.id,
-            remove_config_entry_id=entry.entry_id,
-            via_device_id=None,
-        )
-        not in dr_reg.async_update_device.mock_calls
+    er_reg.async_remove.assert_has_calls(
+        [call(dt_ent.entity_id), call(dt_ent_non_router.entity_id)],
+        any_order=True,
     )
+    assert call(sensor_ent.entity_id) not in er_reg.async_remove.mock_calls
     dr_reg.async_update_device.assert_has_calls(
         [
             call(
@@ -1863,19 +1953,25 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
                 remove_config_entry_id=entry.entry_id,
                 via_device_id=None,
             ),
-            call(linked_to_other_router.id, remove_config_entry_id=entry.entry_id),
         ],
         any_order=True,
     )
     assert (
         call(
             linked_to_other_router.id,
-            remove_config_entry_id=entry.entry_id,
             via_device_id=None,
         )
         not in dr_reg.async_update_device.mock_calls
     )
-    assert dr_reg.async_update_device.call_count == 3
+    assert (
+        call(no_parent.id, remove_config_entry_id=entry.entry_id)
+        not in dr_reg.async_update_device.mock_calls
+    )
+    assert (
+        call(no_parent.id, remove_config_entry_id=entry.entry_id, via_device_id=None)
+        not in dr_reg.async_update_device.mock_calls
+    )
+    assert dr_reg.async_update_device.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1909,6 +1909,7 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
         config_entries={entry.entry_id},
     )
     dr_reg = MagicMock()
+    dr_reg.async_get = MagicMock(return_value=None)
     monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
         init_mod.dr,
@@ -1922,6 +1923,68 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
         tracker_without_router_or_entity.id,
         remove_config_entry_id=entry.entry_id,
         via_device_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_listener_preserves_existing_tracker_parent_when_parent_device_exists(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Keep a shared tracker parent when disabling tracking if that parent still exists."""
+    entry = make_config_entry(
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.data = {}
+    if not hasattr(ph_hass, "async_create_task"):
+        ph_hass.async_create_task = MagicMock()
+
+    dt_ent = MagicMock(
+        entity_id="device_tracker.shared_tracker",
+        domain=init_mod.Platform.DEVICE_TRACKER,
+        unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
+        device_id="shared-device",
+    )
+    er_reg = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[dt_ent]),
+    )
+
+    shared_parent = MagicMock(id="shared-router-device-id")
+    shared_tracker = MagicMock(
+        id="shared-device",
+        identifiers=set(),
+        via_device_id=shared_parent.id,
+        config_entries={entry.entry_id},
+    )
+    dr_reg = MagicMock()
+    dr_reg.async_update_device = MagicMock()
+    dr_reg.async_get = MagicMock(return_value=shared_parent)
+    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(
+        init_mod.dr,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[shared_tracker]),
+    )
+
+    await init_mod._async_update_listener(ph_hass, entry)
+
+    er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
+    dr_reg.async_get.assert_called_once_with(shared_parent.id)
+    dr_reg.async_update_device.assert_called_once_with(
+        shared_tracker.id, remove_config_entry_id=entry.entry_id
+    )
+    assert (
+        call(shared_tracker.id, remove_config_entry_id=entry.entry_id, via_device_id=None)
+        not in dr_reg.async_update_device.mock_calls
     )
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1724,6 +1724,94 @@ async def test_async_update_listener_device_removal_param(
 
 
 @pytest.mark.asyncio
+async def test_async_update_listener_disassociates_tracker_entities_and_router_links(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Disabling device tracker should remove tracker entities and clear only matching router parent links."""
+    entry = make_config_entry(
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+
+    hass = ph_hass
+    hass.config_entries.async_reload = AsyncMock()
+    hass.data = {}
+    if not hasattr(hass, "async_create_task"):
+        hass.async_create_task = MagicMock()
+
+    dt_ent = MagicMock()
+    dt_ent.entity_id = "device_tracker.living_room_device"
+    dt_ent.domain = "device_tracker"
+    dt_ent.unique_id = f"{entry.unique_id}_mac_aabbccddeeff"
+
+    sensor_ent = MagicMock()
+    sensor_ent.entity_id = "sensor.system_uptime"
+    sensor_ent.domain = "sensor"
+    sensor_ent.unique_id = f"{entry.unique_id}_system_uptime"
+
+    er_reg = MagicMock()
+    er_reg.async_remove = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [dt_ent, sensor_ent],
+    )
+
+    router_device = MagicMock()
+    router_device.id = "router-device-id"
+    router_device.identifiers = {(init_mod.DOMAIN, "router-mac")}
+    router_device.via_device_id = None
+
+    linked_to_router = MagicMock()
+    linked_to_router.id = "shared-device"
+    linked_to_router.via_device_id = "router-device-id"
+
+    linked_to_other_router = MagicMock()
+    linked_to_other_router.id = "other-device"
+    linked_to_other_router.via_device_id = "other-device-id"
+
+    no_parent = MagicMock()
+    no_parent.id = "noparent-device"
+    no_parent.via_device_id = None
+
+    dr_reg = MagicMock()
+    dr_reg.async_update_device = MagicMock()
+    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(
+        init_mod.dr,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [
+            router_device,
+            linked_to_router,
+            linked_to_other_router,
+            no_parent,
+        ],
+    )
+
+    await init_mod._async_update_listener(hass, entry)
+
+    er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
+    assert sensor_ent.entity_id not in [c.args[0] for c in er_reg.async_remove.mock_calls]
+    assert dr_reg.async_update_device.call_count == 2
+    assert (
+        call(
+            linked_to_router.id,
+            remove_config_entry_id=entry.entry_id,
+            via_device_id=None,
+        )
+        in dr_reg.async_update_device.mock_calls
+    )
+    assert (
+        call(linked_to_other_router.id, remove_config_entry_id=entry.entry_id)
+        in dr_reg.async_update_device.mock_calls
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_firmware_below_min(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1465,6 +1465,7 @@ async def test_async_update_listener_reload_and_remove(
             """Store the entity and unique IDs used by the update-listener test."""
             self.entity_id = entity_id
             self.unique_id = unique_id
+            self.domain = init_mod.Platform.SENSOR
 
     # explicitly use the 'sync_telemetry' prefix so the test targets the intended sync item
     prefix = list(init_mod.GRANULAR_SYNC_PREFIX["sync_telemetry"])
@@ -1729,86 +1730,78 @@ async def test_async_update_listener_disassociates_tracker_entities_and_router_l
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Disabling device tracker should remove tracker entities and clear only matching router parent links."""
+    """Disabling tracking removes tracker entities and only matching parent links."""
     entry = make_config_entry(
         data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
         options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
     )
     setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
 
-    hass = ph_hass
-    hass.config_entries.async_reload = AsyncMock()
-    hass.data = {}
-    if not hasattr(hass, "async_create_task"):
-        hass.async_create_task = MagicMock()
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.data = {}
+    if not hasattr(ph_hass, "async_create_task"):
+        ph_hass.async_create_task = MagicMock()
 
-    dt_ent = MagicMock()
-    dt_ent.entity_id = "device_tracker.living_room_device"
-    dt_ent.domain = "device_tracker"
-    dt_ent.unique_id = f"{entry.unique_id}_mac_aabbccddeeff"
-
-    sensor_ent = MagicMock()
-    sensor_ent.entity_id = "sensor.system_uptime"
-    sensor_ent.domain = "sensor"
-    sensor_ent.unique_id = f"{entry.unique_id}_system_uptime"
-
+    dt_ent = MagicMock(
+        entity_id="device_tracker.living_room_device",
+        domain=init_mod.Platform.DEVICE_TRACKER,
+        unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
+    )
+    sensor_ent = MagicMock(
+        entity_id="sensor.system_uptime",
+        domain=init_mod.Platform.SENSOR,
+        unique_id=f"{entry.unique_id}_system_uptime",
+    )
     er_reg = MagicMock()
-    er_reg.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
         init_mod.er,
         "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [dt_ent, sensor_ent],
+        MagicMock(return_value=[dt_ent, sensor_ent]),
     )
 
-    router_device = MagicMock()
-    router_device.id = "router-device-id"
-    router_device.identifiers = {(init_mod.DOMAIN, "router-mac")}
-    router_device.via_device_id = None
-
-    linked_to_router = MagicMock()
-    linked_to_router.id = "shared-device"
-    linked_to_router.via_device_id = "router-device-id"
-
-    linked_to_other_router = MagicMock()
-    linked_to_other_router.id = "other-device"
-    linked_to_other_router.via_device_id = "other-device-id"
-
-    no_parent = MagicMock()
-    no_parent.id = "noparent-device"
-    no_parent.via_device_id = None
-
+    router_device = MagicMock(
+        id="router-device-id",
+        identifiers={(init_mod.DOMAIN, "router-mac")},
+        via_device_id=None,
+    )
+    linked_to_router = MagicMock(id="shared-device", via_device_id=router_device.id)
+    linked_to_other_router = MagicMock(id="other-device", via_device_id="other-device-id")
+    no_parent = MagicMock(id="noparent-device", via_device_id=None)
     dr_reg = MagicMock()
-    dr_reg.async_update_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
         init_mod.dr,
         "async_entries_for_config_entry",
-        lambda registry, config_entry_id: [
-            router_device,
-            linked_to_router,
-            linked_to_other_router,
-            no_parent,
-        ],
+        MagicMock(
+            return_value=[router_device, linked_to_router, linked_to_other_router, no_parent]
+        ),
     )
 
-    await init_mod._async_update_listener(hass, entry)
+    await init_mod._async_update_listener(ph_hass, entry)
 
     er_reg.async_remove.assert_called_once_with(dt_ent.entity_id)
-    assert sensor_ent.entity_id not in [c.args[0] for c in er_reg.async_remove.mock_calls]
-    assert dr_reg.async_update_device.call_count == 2
+    assert call(sensor_ent.entity_id) not in er_reg.async_remove.mock_calls
+    dr_reg.async_update_device.assert_has_calls(
+        [
+            call(
+                linked_to_router.id,
+                remove_config_entry_id=entry.entry_id,
+                via_device_id=None,
+            ),
+            call(linked_to_other_router.id, remove_config_entry_id=entry.entry_id),
+        ],
+        any_order=True,
+    )
     assert (
         call(
-            linked_to_router.id,
+            linked_to_other_router.id,
             remove_config_entry_id=entry.entry_id,
             via_device_id=None,
         )
-        in dr_reg.async_update_device.mock_calls
+        not in dr_reg.async_update_device.mock_calls
     )
-    assert (
-        call(linked_to_other_router.id, remove_config_entry_id=entry.entry_id)
-        in dr_reg.async_update_device.mock_calls
-    )
+    assert dr_reg.async_update_device.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1813,6 +1813,64 @@ async def test_async_update_listener_detaches_no_parent_tracker_device(
 
 
 @pytest.mark.asyncio
+async def test_async_update_listener_detaches_tracker_device_without_entity(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Detach a router-linked tracker device after its entity was already removed."""
+    entry = make_config_entry(
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.data = {}
+
+    er_reg = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[]),
+    )
+
+    router_device = MagicMock(
+        id="router-device-id",
+        identifiers={(init_mod.DOMAIN, "router-mac")},
+        via_device_id=None,
+    )
+    tracker_without_entity = MagicMock(
+        id="tracker-without-entity",
+        identifiers=set(),
+        via_device_id=router_device.id,
+        config_entries={entry.entry_id},
+    )
+    unrelated_device = MagicMock(
+        id="unrelated-device",
+        identifiers=set(),
+        via_device_id="other-router-id",
+        config_entries={entry.entry_id},
+    )
+    dr_reg = MagicMock()
+    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(
+        init_mod.dr,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[router_device, tracker_without_entity, unrelated_device]),
+    )
+
+    await init_mod._async_update_listener(ph_hass, entry)
+
+    dr_reg.async_update_device.assert_called_once_with(
+        tracker_without_entity.id,
+        remove_config_entry_id=entry.entry_id,
+        via_device_id=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsense_router(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1871,6 +1871,61 @@ async def test_async_update_listener_detaches_tracker_device_without_entity(
 
 
 @pytest.mark.asyncio
+async def test_async_update_listener_detaches_tracker_when_router_and_entity_are_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Detach a MAC tracker whose removed router remains as a stale parent."""
+    entry = make_config_entry(
+        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.data = {}
+
+    er_reg = MagicMock()
+    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(
+        init_mod.er,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[]),
+    )
+
+    tracker_without_router_or_entity = MagicMock(
+        id="tracker-without-router-or-entity",
+        identifiers=set(),
+        connections={(init_mod.dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")},
+        via_device_id="removed-router-device-id",
+        config_entries={entry.entry_id},
+    )
+    unrelated_device = MagicMock(
+        id="unrelated-device",
+        identifiers=set(),
+        connections=set(),
+        via_device_id="unrelated-parent-id",
+        config_entries={entry.entry_id},
+    )
+    dr_reg = MagicMock()
+    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(
+        init_mod.dr,
+        "async_entries_for_config_entry",
+        MagicMock(return_value=[tracker_without_router_or_entity, unrelated_device]),
+    )
+
+    await init_mod._async_update_listener(ph_hass, entry)
+
+    dr_reg.async_update_device.assert_called_once_with(
+        tracker_without_router_or_entity.id,
+        remove_config_entry_id=entry.entry_id,
+        via_device_id=None,
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsense_router(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,


### PR DESCRIPTION
## Summary

Prevents OPNsense device-tracker cleanup from deleting an entire Home Assistant device when that device is shared with another integration.

## What Changed

- Remove only the OPNsense config-entry association when a previously tracked MAC disappears.
- Apply the same scoped cleanup when device tracking is disabled.
- Add regression coverage confirming shared devices are updated instead of deleted.

## Why

Home Assistant can merge devices from multiple integrations using a common MAC address. Removing the complete registry device during OPNsense cleanup also removes unrelated integrations' device ownership and entities. Config-entry-specific removal preserves those shared resources while still detaching OPNsense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when device tracking is disabled or configuration entries are removed.
  * Stale device-tracker entities are now removed correctly.
  * Shared devices remain connected to surviving routers when applicable, or are safely detached when no replacement exists.
  * Prevented unnecessary device deletion during tracker cleanup.

* **Tests**
  * Added coverage for stale trackers, shared-router reassignment, detached devices, and removed parent routers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes OPNsense tracker cleanup to preserve shared Home Assistant devices. The main changes are:

- Scoped stale tracker cleanup to the OPNsense config entry.
- Removed stale OPNsense tracker entities before updating tracked MAC state.
- Reparented shared tracker devices to surviving OPNsense routers when possible.
- Added tests for shared devices, missing parents, and disabled tracker cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/opnsense/__init__.py | Updates disabled tracker cleanup to remove tracker entities and detach or reparent device entries instead of deleting devices. |
| custom_components/opnsense/device_tracker.py | Adds stale MAC cleanup that removes the tracker entity and detaches only this config entry from the matched device. |
| custom_components/opnsense/helpers.py | Adds shared-device helper logic for finding a replacement OPNsense router and updating parent links. |
| tests/test_device_tracker.py | Adds tests for stale tracker entity removal, shared-device reparenting, and missing parent cleanup. |
| tests/test_init.py | Adds tests for disabled tracker cleanup across tracker entities, missing entities, missing parents, and surviving router parents. |

</details>

<sub>Reviews (12): Last reviewed commit: ["Validate tracker parent devices during c..."](https://github.com/snuffy2/hass-opnsense/commit/5077719b3c44a4c99039adc70751e168c0f4c36e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43578165)</sub>

**Context used:**

- Rule used - In Python 3.14+, `except ExcTypeA, ExcTypeB:` (com... ([source](https://app.greptile.com/snuffy2/github/Snuffy2/carrier_api/-/custom-context?memory=0402128e-91c3-4dd3-a9a0-49f92b3531f7))
- Rule used - Always check the project's minimum Python version ... ([source](https://app.greptile.com/snuffy2/github/Snuffy2/places/-/custom-context?memory=442bbe98-87a9-414c-a77c-6465ceee15f9))

<!-- /greptile_comment -->