### PR TITLE
Add device-id replacement repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A Discord server to discuss the integration is available. Click the Discord badg
 * [Actions](#actions-services)
 
 * [Known Issues](#known-issues)
-  * [Hardware Changes](#hardware-changes)
+  * [Replacing OPNsense Hardware](#replacing-opnsense-hardware)
 
 ## Installation
 
@@ -200,9 +200,13 @@ See [Device Tracker Guide](docs/device_tracker.md) for setup details, ARP behavi
 
 ## Known Issues
 
-### Hardware Changes
+### Replacing OPNsense Hardware
 
-If you partially or fully change the <ins>OPNsense</ins> hardware, it will require a removal and reinstall of this integration. This is to ensure changed interfaces, services, gateways, etc. are accounted for and don't leave duplicate or non-functioning entities. 
+Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same. Keeping stale disabled entities is dangerous because they can look valid while referring to hardware that no longer exists.
+
+When an OPNsense device entry reports a device-ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair unloads the entry, removes all current entities and devices for it (including disabled entities), updates the device ID, and schedules a reload to rebuild entities.
+
+The repair preserves the URL, credentials, and options. It discards entity registry names, enabled/disabled selections, areas, and other customizations. Recreated entity IDs may differ, so dashboards and automations that reference those IDs may need updates.
 
 [commits-shield]: https://img.shields.io/github/last-commit/travisghansen/hass-opnsense?style=for-the-badge
 [commits]: https://github.com/travisghansen/hass-opnsense/commits/main

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -52,6 +52,7 @@ from .migrate import (
     _migrate_3_to_4,
     _migrate_4_to_5,
 )
+from .repairs import async_create_device_id_mismatch_issue
 from .services import async_setup_services
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -220,19 +221,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             router_device_id,
         )
         if router_device_id != config_device_id and router_device_id:
-            ir.async_create_issue(
-                hass=hass,
-                domain=DOMAIN,
-                issue_id=f"{config_device_id}_device_id_mismatched",
-                is_fixable=False,
-                is_persistent=False,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="device_id_mismatched",
-            )
+            async_create_device_id_mismatch_issue(hass, entry, router_device_id)
             _LOGGER.error(
                 "OPNsense Device ID has changed which indicates new or changed hardware. "
-                "In order to accommodate this, hass-opnsense needs to be removed "
-                "and reinstalled for this router. "
+                "A fixable repair issue is available to rebuild entities for this "
+                "OPNsense device. "
                 "hass-opnsense is shutting down."
             )
             return False

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -52,7 +52,7 @@ from .migrate import (
     _migrate_3_to_4,
     _migrate_4_to_5,
 )
-from .repairs import async_create_device_id_mismatch_issue
+from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 from .services import async_setup_services
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -220,7 +220,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_device_id,
             router_device_id,
         )
-        if router_device_id != config_device_id and router_device_id:
+        if (
+            is_valid_device_id(config_device_id)
+            and is_valid_device_id(router_device_id)
+            and router_device_id != config_device_id
+        ):
             async_create_device_id_mismatch_issue(hass, entry, router_device_id)
             _LOGGER.error(
                 "OPNsense Device ID has changed which indicates new or changed hardware. "

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -253,20 +253,21 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         Returns:
             bool: `True` when IDs match; otherwise `False` after mismatch handling.
         """
-        if self._state.get("device_unique_id") is None:
+        runtime_device_id = self._state.get("device_unique_id")
+        if not isinstance(runtime_device_id, str) or not runtime_device_id:
             _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0
             return False
-        if self._state.get("device_unique_id") != self._device_unique_id:
+        if runtime_device_id != self._device_unique_id:
             _LOGGER.debug(
                 "[Coordinator async_update_data]: config device id: %s, router device id: %s",
                 self._device_unique_id,
-                self._state.get("device_unique_id"),
+                runtime_device_id,
             )
             _LOGGER.error(
                 "Coordinator error. "
                 "OPNsense Router Device ID (%s) differs from the one saved in hass-opnsense (%s)",
-                self._state.get("device_unique_id"),
+                runtime_device_id,
                 self._device_unique_id,
             )
             self._mismatched_count += 1
@@ -276,7 +277,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     async_create_device_id_mismatch_issue(
                         self.hass,
                         self.config_entry,
-                        self._state["device_unique_id"],
+                        runtime_device_id,
                     )
                 _LOGGER.error(
                     "OPNsense Device ID has changed which indicates new or changed hardware. "

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -31,7 +31,7 @@ from .const import (
     DEFAULT_SYNC_OPTION_VALUE,
 )
 from .helpers import dict_get
-from .repairs import async_create_device_id_mismatch_issue
+from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -254,8 +254,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             bool: `True` when IDs match; otherwise `False` after mismatch handling.
         """
         runtime_device_id = self._state.get("device_unique_id")
-        if not isinstance(runtime_device_id, str) or not runtime_device_id:
-            _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
+        if not is_valid_device_id(runtime_device_id):
+            _LOGGER.warning("Coordinator received malformed OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0
             return False
         if runtime_device_id != self._device_unique_id:

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -30,9 +29,9 @@ from .const import (
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     DEFAULT_SYNC_OPTION_VALUE,
-    DOMAIN,
 )
 from .helpers import dict_get
+from .repairs import async_create_device_id_mismatch_issue
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -273,19 +272,16 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             self._mismatched_count += 1
             # Trigger repair task and shutdown if this happens 3 times in a row
             if self._mismatched_count == 3:
-                ir.async_create_issue(
-                    hass=self.hass,
-                    domain=DOMAIN,
-                    issue_id=f"{self._device_unique_id}_device_id_mismatched",
-                    is_fixable=False,
-                    is_persistent=False,
-                    severity=ir.IssueSeverity.ERROR,
-                    translation_key="device_id_mismatched",
-                )
+                if self.config_entry is not None:
+                    async_create_device_id_mismatch_issue(
+                        self.hass,
+                        self.config_entry,
+                        self._state["device_unique_id"],
+                    )
                 _LOGGER.error(
                     "OPNsense Device ID has changed which indicates new or changed hardware. "
-                    "In order to accommodate this, hass-opnsense needs to be removed and "
-                    "reinstalled for this router. "
+                    "A fixable repair issue is available to rebuild entities for this "
+                    "OPNsense device. "
                     "hass-opnsense is shutting down."
                 )
                 await self.async_shutdown()

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -1,0 +1,528 @@
+"""Repair flows for the OPNsense integration."""
+
+from copy import deepcopy
+import logging
+
+import aiohttp
+from aiopnsense.exceptions import OPNsenseError
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
+import voluptuous as vol
+
+from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from .helpers import create_opnsense_client_from_config_entry
+
+_ISSUE_SUFFIX = "_device_id_mismatched"
+_LOGGER = logging.getLogger(__name__)
+
+
+def _entry_matches_snapshot(
+    entry: ConfigEntry | None,
+    entry_id: str,
+    data_snapshot: dict[str, object],
+    options_snapshot: dict[str, object],
+    unique_id_snapshot: str | None,
+) -> bool:
+    """Return whether a re-fetched entry still matches the repair snapshot.
+
+    Args:
+        entry: Current config entry, if it still exists.
+        entry_id: Entry ID captured when the repair started.
+        data_snapshot: Original config-entry data mapping.
+        options_snapshot: Original config-entry options mapping.
+        unique_id_snapshot: Original config-entry unique ID.
+
+    Returns:
+        bool: ``True`` when the entry identity and persisted values are unchanged.
+    """
+    return bool(
+        entry is not None
+        and entry.entry_id == entry_id
+        and dict(entry.data) == data_snapshot
+        and dict(entry.options) == options_snapshot
+        and entry.unique_id == unique_id_snapshot
+    )
+
+
+def _get_entry_matching_snapshot(
+    hass: HomeAssistant,
+    entry_id: str,
+    data_snapshot: dict[str, object],
+    options_snapshot: dict[str, object],
+    unique_id_snapshot: str | None,
+) -> ConfigEntry | None:
+    """Return the current entry only when it still matches the repair snapshot.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        entry_id: Entry ID captured when the repair started.
+        data_snapshot: Original config-entry data mapping.
+        options_snapshot: Original config-entry options mapping.
+        unique_id_snapshot: Original config-entry unique ID.
+
+    Returns:
+        ConfigEntry | None: Matching current entry, if it is still owned.
+    """
+    current_entry = hass.config_entries.async_get_entry(entry_id)
+    if not _entry_matches_snapshot(
+        current_entry,
+        entry_id,
+        data_snapshot,
+        options_snapshot,
+        unique_id_snapshot,
+    ):
+        return None
+    return current_entry
+
+
+async def _async_validate_and_probe_device_id(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> str | None:
+    """Validate an OPNsense client and probe the current device identifier.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        config_entry: OPNsense config entry used to build the client.
+
+    Returns:
+        str | None: Device identifier returned by OPNsense.
+
+    Raises:
+        OPNsenseError: If validation or the device-ID probe fails.
+        aiohttp.ClientError: If the client encounters a transport failure.
+        TimeoutError: If the client request times out.
+    """
+    client = create_opnsense_client_from_config_entry(
+        hass=hass,
+        config_entry=config_entry,
+        throw_errors=True,
+    )
+    try:
+        await client.validate()
+        return await client.get_device_unique_id()
+    finally:
+        await client.async_close()
+
+
+async def _async_prepare_entry_for_repair(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> tuple[bool, bool]:
+    """Check whether an entry can be safely unloaded before repair mutation.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        config_entry: OPNsense config entry being repaired.
+
+    Returns:
+        tuple[bool, bool]: Whether the entry is ready and whether it was loaded.
+    """
+    entry_was_loaded = config_entry.state is ConfigEntryState.LOADED
+    if not config_entry.state.recoverable:
+        return False, entry_was_loaded
+    if entry_was_loaded and not await hass.config_entries.async_unload(config_entry.entry_id):
+        return False, entry_was_loaded
+    return True, entry_was_loaded
+
+
+def _device_id_repair_abort_reason(
+    observed_device_id: object,
+    expected_device_id: str,
+    current_device_id: object,
+) -> str | None:
+    """Return the abort reason for an invalid replacement device ID.
+
+    Args:
+        observed_device_id: Device identifier returned by the firewall.
+        expected_device_id: Replacement identifier stored in the repair issue.
+        current_device_id: Identifier currently stored on the config entry.
+
+    Returns:
+        str | None: Repair abort reason, or ``None`` when the replacement is valid.
+    """
+    if not isinstance(observed_device_id, str) or not observed_device_id:
+        return "cannot_connect"
+    if observed_device_id != expected_device_id or observed_device_id == current_device_id:
+        return "entry_changed"
+    return None
+
+
+def async_create_device_id_mismatch_issue(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    observed_device_id: str,
+) -> None:
+    """Create a fixable hardware-replacement issue for a normal device entry.
+
+    Args:
+        hass: Home Assistant instance that owns the issue registry.
+        config_entry: Device config entry with the stale identifier.
+        observed_device_id: Replacement device identifier observed at runtime.
+    """
+    old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+    ir.async_create_issue(
+        hass=hass,
+        domain=DOMAIN,
+        issue_id=f"{config_entry.entry_id}{_ISSUE_SUFFIX}",
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="device_id_mismatched",
+        translation_placeholders={
+            "entry_title": config_entry.title,
+            "old_device_id": old_device_id,
+            "new_device_id": observed_device_id,
+        },
+        data={
+            "entry_id": config_entry.entry_id,
+            "old_device_id": old_device_id,
+            "new_device_id": observed_device_id,
+        },
+    )
+
+
+class DeviceIDMismatchRepairFlow(RepairsFlow):
+    """Rebuild one OPNsense config entry after confirmed hardware replacement."""
+
+    def __init__(self, entry_id: str, old_device_id: str, new_device_id: str) -> None:
+        """Initialize a repair flow from issue data.
+
+        Args:
+            entry_id: Config-entry ID associated with the repair issue.
+            old_device_id: Device identifier stored before the repair.
+            new_device_id: Replacement identifier expected by the issue.
+        """
+        self._entry_id = entry_id
+        self._old_device_id = old_device_id
+        self._expected_device_id = new_device_id
+        self._description_placeholders: dict[str, str] = {
+            "entry_title": "",
+            "old_device_id": old_device_id,
+            "new_device_id": new_device_id,
+        }
+
+    async def async_step_init(self, user_input: dict[str, str] | None = None) -> RepairsFlowResult:
+        """Load issue placeholders and display the confirmation step.
+
+        Args:
+            user_input: Ignored initialization payload.
+
+        Returns:
+            RepairsFlowResult: Confirmation form result.
+        """
+        del user_input
+        issue_registry = ir.async_get(self.hass)
+        issue = issue_registry.async_get_issue(self.handler, self.issue_id)
+        if issue is not None and issue.translation_placeholders is not None:
+            self._description_placeholders = dict(issue.translation_placeholders)
+        return await self.async_step_confirm()
+
+    async def _async_reload_with_recovery(
+        self,
+        entry: ConfigEntry,
+        *,
+        data_snapshot: dict[str, object],
+        options_snapshot: dict[str, object],
+        unique_id_snapshot: str | None,
+    ) -> RepairsFlowResult:
+        """Reload an updated entry and schedule guarded recovery on any reload failure.
+
+        Args:
+            entry: Updated OPNsense config entry to reload.
+            data_snapshot: Persisted data expected before repair completion.
+            options_snapshot: Persisted options expected before repair completion.
+            unique_id_snapshot: Persisted unique ID expected before repair completion.
+
+        Returns:
+            RepairsFlowResult: Successful completion or a retryable repair failure.
+        """
+        try:
+            if await self.hass.config_entries.async_reload(entry.entry_id):
+                return self.async_create_entry(data={})
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot reload entry",
+                entry.title,
+            )
+        self._schedule_recovery_reload(
+            data_snapshot=data_snapshot,
+            options_snapshot=options_snapshot,
+            unique_id_snapshot=unique_id_snapshot,
+            entry_id=entry.entry_id,
+            entry_title=entry.title,
+        )
+        return self.async_abort(reason="repair_failed")
+
+    def _schedule_recovery_reload(
+        self,
+        *,
+        data_snapshot: dict[str, object],
+        options_snapshot: dict[str, object],
+        unique_id_snapshot: str | None,
+        entry_id: str,
+        entry_title: str,
+    ) -> None:
+        """Schedule a recovery reload without mutating an untouched repair entry.
+
+        Args:
+            data_snapshot: Snapshot of the entry data used to detect changes.
+            options_snapshot: Snapshot of entry options used to detect changes.
+            unique_id_snapshot: Snapshot of the entry unique ID used to detect changes.
+            entry_id: Config entry ID used to resolve the entry for reload.
+            entry_title: Human-readable entry title for log context.
+        """
+        current_entry = self.hass.config_entries.async_get_entry(entry_id)
+        if not _entry_matches_snapshot(
+            current_entry,
+            entry_id,
+            data_snapshot,
+            options_snapshot,
+            unique_id_snapshot,
+        ):
+            return
+        try:
+            self.hass.config_entries.async_schedule_reload(entry_id)
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot schedule recovery "
+                "reload after a non-mutating failure",
+                entry_title,
+            )
+
+    def _cleanup_entry_registries(self, entry: ConfigEntry) -> bool:
+        """Remove the entry's entities and device associations from the registries.
+
+        Args:
+            entry: Config entry whose old registry data should be removed.
+
+        Returns:
+            bool: ``True`` when all registry cleanup operations succeeded.
+        """
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        entities_to_cleanup = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        devices_to_cleanup = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+        failed_cleanup = False
+        for entity in entities_to_cleanup:
+            try:
+                entity_registry.async_remove(entity.entity_id)
+            except HomeAssistantError, KeyError:
+                failed_cleanup = True
+                _LOGGER.exception(
+                    "Device-ID repair did not finish for %s; cannot remove entity %s",
+                    entry.title,
+                    entity.entity_id,
+                )
+
+        for device in devices_to_cleanup:
+            try:
+                device_registry.async_update_device(
+                    device.id,
+                    remove_config_entry_id=entry.entry_id,
+                )
+            except HomeAssistantError, KeyError:
+                failed_cleanup = True
+                _LOGGER.exception(
+                    "Device-ID repair did not finish for %s; cannot update device %s",
+                    entry.title,
+                    device.id,
+                )
+        return not failed_cleanup
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Confirm and perform the ordered registry rebuild.
+
+        Args:
+            user_input: Confirmation payload, or ``None`` to render the form.
+
+        Returns:
+            RepairsFlowResult: Confirmation form, abort result, or successful completion.
+        """
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm",
+                data_schema=vol.Schema({}),
+                description_placeholders=self._description_placeholders,
+            )
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return self.async_abort(reason="entry_not_found")
+        entry_data_snapshot = deepcopy(dict(entry.data))
+        entry_options_snapshot = deepcopy(dict(entry.options))
+        entry_unique_id_snapshot = entry.unique_id
+        stored_device_id = entry.data.get(CONF_DEVICE_UNIQUE_ID)
+        if stored_device_id == self._expected_device_id:
+            entry_ready, _ = await _async_prepare_entry_for_repair(self.hass, entry)
+            if not entry_ready:
+                return self.async_abort(reason="cannot_unload")
+            current_entry = _get_entry_matching_snapshot(
+                self.hass,
+                self._entry_id,
+                entry_data_snapshot,
+                entry_options_snapshot,
+                entry_unique_id_snapshot,
+            )
+            if current_entry is None:
+                return self.async_abort(reason="entry_changed")
+            if not self._cleanup_entry_registries(current_entry):
+                return self.async_abort(reason="repair_failed")
+            return await self._async_reload_with_recovery(
+                current_entry,
+                data_snapshot=entry_data_snapshot,
+                options_snapshot=entry_options_snapshot,
+                unique_id_snapshot=entry_unique_id_snapshot,
+            )
+        if stored_device_id != self._old_device_id:
+            return self.async_abort(reason="entry_changed")
+
+        try:
+            observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
+        except OPNsenseError, aiohttp.ClientError, TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+
+        current_entry = _get_entry_matching_snapshot(
+            self.hass,
+            self._entry_id,
+            entry_data_snapshot,
+            entry_options_snapshot,
+            entry_unique_id_snapshot,
+        )
+        if current_entry is None:
+            return self.async_abort(reason="entry_changed")
+        entry = current_entry
+
+        if abort_reason := _device_id_repair_abort_reason(
+            observed_device_id,
+            self._expected_device_id,
+            entry.data.get(CONF_DEVICE_UNIQUE_ID),
+        ):
+            return self.async_abort(reason=abort_reason)
+
+        duplicate = next(
+            (
+                candidate
+                for candidate in self.hass.config_entries.async_entries(DOMAIN)
+                if candidate.entry_id != entry.entry_id
+                and candidate.unique_id == observed_device_id
+            ),
+            None,
+        )
+        if duplicate is not None:
+            return self.async_abort(reason="already_configured")
+
+        entry_ready, entry_was_loaded = await _async_prepare_entry_for_repair(self.hass, entry)
+        if not entry_ready:
+            return self.async_abort(reason="cannot_unload")
+
+        current_entry = _get_entry_matching_snapshot(
+            self.hass,
+            self._entry_id,
+            entry_data_snapshot,
+            entry_options_snapshot,
+            entry_unique_id_snapshot,
+        )
+        if current_entry is None:
+            return self.async_abort(reason="entry_changed")
+        entry = current_entry
+
+        new_data = {**entry.data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+
+        try:
+            updated = self.hass.config_entries.async_update_entry(
+                entry,
+                data=new_data,
+                unique_id=observed_device_id,
+            )
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot update config entry",
+                entry.title,
+            )
+            if entry_was_loaded:
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=entry.entry_id,
+                    entry_title=entry.title,
+                )
+            return self.async_abort(reason="repair_failed")
+
+        if not updated:
+            _LOGGER.error(
+                "Device-ID repair did not finish for %s; config-entry update made no changes",
+                entry.title,
+            )
+            if entry_was_loaded:
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=entry.entry_id,
+                    entry_title=entry.title,
+                )
+            return self.async_abort(reason="repair_failed")
+
+        post_update_entry_data_snapshot: dict[str, object] = {
+            **entry_data_snapshot,
+            CONF_DEVICE_UNIQUE_ID: observed_device_id,
+        }
+        post_update_entry_unique_id_snapshot = observed_device_id
+
+        if not self._cleanup_entry_registries(entry):
+            return self.async_abort(reason="repair_failed")
+
+        return await self._async_reload_with_recovery(
+            entry,
+            data_snapshot=post_update_entry_data_snapshot,
+            options_snapshot=entry_options_snapshot,
+            unique_id_snapshot=post_update_entry_unique_id_snapshot,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a device-ID replacement flow for a well-formed issue.
+
+    Args:
+        hass: Home Assistant instance that owns the repair flow.
+        issue_id: Issue identifier used to select the repair type.
+        data: Issue data containing the entry and device identifiers.
+
+    Returns:
+        RepairsFlow: Device-ID repair flow or a generic confirmation flow.
+    """
+    del hass
+    if not issue_id.endswith(_ISSUE_SUFFIX) or data is None:
+        return ConfirmRepairFlow()
+
+    entry_id = data.get("entry_id")
+    old_device_id = data.get("old_device_id")
+    new_device_id = data.get("new_device_id")
+    if not (
+        isinstance(entry_id, str)
+        and entry_id
+        and isinstance(old_device_id, str)
+        and old_device_id
+        and isinstance(new_device_id, str)
+        and new_device_id
+        and issue_id == f"{entry_id}{_ISSUE_SUFFIX}"
+    ):
+        return ConfirmRepairFlow()
+
+    return DeviceIDMismatchRepairFlow(
+        entry_id=entry_id,
+        old_device_id=old_device_id,
+        new_device_id=new_device_id,
+    )

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import logging
+from typing import TypeGuard
 
 import aiohttp
 from aiopnsense.exceptions import OPNsenseError
@@ -17,6 +18,11 @@ from .helpers import create_opnsense_client_from_config_entry
 
 _ISSUE_SUFFIX = "_device_id_mismatched"
 _LOGGER = logging.getLogger(__name__)
+
+
+def is_valid_device_id(device_id: object) -> TypeGuard[str]:
+    """Return whether a device ID is a usable string identifier."""
+    return isinstance(device_id, str) and bool(device_id.strip())
 
 
 def _entry_matches_snapshot(
@@ -144,7 +150,7 @@ def _device_id_repair_abort_reason(
     Returns:
         str | None: Repair abort reason, or ``None`` when the replacement is valid.
     """
-    if not isinstance(observed_device_id, str) or not observed_device_id:
+    if not is_valid_device_id(observed_device_id):
         return "cannot_connect"
     if observed_device_id != expected_device_id or observed_device_id == current_device_id:
         return "entry_changed"
@@ -154,7 +160,7 @@ def _device_id_repair_abort_reason(
 def async_create_device_id_mismatch_issue(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    observed_device_id: str,
+    observed_device_id: object,
 ) -> None:
     """Create a fixable hardware-replacement issue for a normal device entry.
 
@@ -164,6 +170,8 @@ def async_create_device_id_mismatch_issue(
         observed_device_id: Replacement device identifier observed at runtime.
     """
     old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+    if not is_valid_device_id(old_device_id) or not is_valid_device_id(observed_device_id):
+        return
     ir.async_create_issue(
         hass=hass,
         domain=DOMAIN,
@@ -527,10 +535,8 @@ async def async_create_fix_flow(
     if not (
         isinstance(entry_id, str)
         and entry_id
-        and isinstance(old_device_id, str)
-        and old_device_id
-        and isinstance(new_device_id, str)
-        and new_device_id
+        and is_valid_device_id(old_device_id)
+        and is_valid_device_id(new_device_id)
         and issue_id == f"{entry_id}{_ISSUE_SUFFIX}"
     ):
         return ConfirmRepairFlow()

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -311,7 +311,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         for entity in entities_to_cleanup:
             try:
                 entity_registry.async_remove(entity.entity_id)
-            except HomeAssistantError, KeyError:
+            except HomeAssistantError, KeyError, ValueError:
                 failed_cleanup = True
                 _LOGGER.exception(
                     "Device-ID repair did not finish for %s; cannot remove entity %s",
@@ -325,7 +325,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                     device.id,
                     remove_config_entry_id=entry.entry_id,
                 )
-            except HomeAssistantError, KeyError:
+            except HomeAssistantError, KeyError, ValueError:
                 failed_cleanup = True
                 _LOGGER.exception(
                     "Device-ID repair did not finish for %s; cannot update device %s",

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -266,7 +266,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry_id: str,
         entry_title: str,
     ) -> None:
-        """Schedule a recovery reload without mutating an untouched repair entry.
+        """Schedule a guarded recovery reload when the repair may have mutated state.
 
         Args:
             data_snapshot: Snapshot of the entry data used to detect changes.
@@ -289,7 +289,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
                 "Device-ID repair did not finish for %s; cannot schedule recovery "
-                "reload after a non-mutating failure",
+                "reload after an interrupted repair mutation",
                 entry_title,
             )
 
@@ -373,6 +373,13 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             if current_entry is None:
                 return self.async_abort(reason="entry_changed")
             if not self._cleanup_entry_registries(current_entry):
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=current_entry.entry_id,
+                    entry_title=current_entry.title,
+                )
                 return self.async_abort(reason="repair_failed")
             return await self._async_reload_with_recovery(
                 current_entry,
@@ -478,6 +485,13 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         post_update_entry_unique_id_snapshot = observed_device_id
 
         if not self._cleanup_entry_registries(entry):
+            self._schedule_recovery_reload(
+                data_snapshot=post_update_entry_data_snapshot,
+                options_snapshot=entry_options_snapshot,
+                unique_id_snapshot=post_update_entry_unique_id_snapshot,
+                entry_id=entry.entry_id,
+                entry_title=entry.title,
+            )
             return self.async_abort(reason="repair_failed")
 
         return await self._async_reload_with_recovery(

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -122,8 +122,23 @@
       "description": "Some hass-opnsense {version} functions require OPNsense firmware {ltd_firmware} or later. With firmware {firmware}, some functions may not work and there may be errors in the logs."
     },
     "device_id_mismatched": {
-      "title": "OPNsense Hardware Has Changed",
-      "description": "OPNsense Device ID has changed which indicates new or changed hardware. In order to accommodate this, hass-opnsense needs to be removed and reinstalled for this router. hass-opnsense is shutting down."
+      "title": "Replacement hardware detected",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Rebuild entities for replacement hardware",
+            "description": "This destructive repair will remove all current entities and devices for {entry_title}, including disabled entities, then rebuild entities from device ID {new_device_id}. The URL, credentials, and options will be preserved. Entity registry names, enabled/disabled selections, areas, and other customizations will be discarded. Recreated entity IDs may differ, so dashboards and automations may need updates. The previous device ID was {old_device_id}."
+          }
+        },
+        "abort": {
+          "entry_not_found": "The OPNsense device entry no longer exists.",
+          "entry_changed": "The OPNsense device entry changed while the repair was running. No registry changes were made.",
+          "cannot_connect": "The replacement hardware could not be confirmed. No changes were made.",
+          "already_configured": "Another OPNsense device entry already uses the replacement device ID. No changes were made.",
+          "cannot_unload": "The OPNsense device entry could not be unloaded safely. No registry changes were made.",
+          "repair_failed": "The replacement hardware repair did not finish. Some registry cleanup may already have occurred; review entities before retrying."
+        }
+      }
     }
   },
   "exceptions": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import coordinator as coordinator_module
+from custom_components.opnsense import coordinator as coordinator_module, repairs as repairs_module
 from custom_components.opnsense.const import (
     ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
@@ -336,8 +336,10 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Mismatched device_unique_id should create an issue and shutdown after threshold."""
+    caplog.set_level(logging.ERROR, logger=coordinator_module.__name__)
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
     client = fake_client()()
     coord = OPNsenseDataUpdateCoordinator(
@@ -374,7 +376,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
         called["issue"] += 1
         called["issue_kwargs"] = kwargs
 
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
 
     # call 3 times -> should call issue once and shutdown once
@@ -386,10 +388,21 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     assert called["shutdown"] == 1
     # validate the issue was created for the integration domain and expected id
     assert isinstance(called["issue_kwargs"], MutableMapping)
-    assert called["issue_kwargs"].get("domain") == coordinator_module.DOMAIN
-    assert (
-        called["issue_kwargs"].get("issue_id") == f"{coord._device_unique_id}_device_id_mismatched"
-    )
+    assert called["issue_kwargs"].get("domain") == repairs_module.DOMAIN
+    assert called["issue_kwargs"].get("issue_id") == f"{entry.entry_id}_device_id_mismatched"
+    assert called["issue_kwargs"].get("is_fixable") is True
+    assert called["issue_kwargs"].get("data") == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "expected",
+        "new_device_id": "other",
+    }
+    assert called["issue_kwargs"].get("translation_placeholders") == {
+        "entry_title": entry.title,
+        "old_device_id": "expected",
+        "new_device_id": "other",
+    }
+    assert "fixable repair issue" in caplog.text
+    assert "rebuild entities" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1475,7 +1488,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
             "arp_table": [],
         }
 
-    called: dict[str, Any] = {"issue": 0, "shutdown": 0}
+    called: dict[str, Any] = {"issue": 0, "shutdown": 0, "issue_kwargs": None}
 
     async def fake_shutdown() -> None:
         """Record coordinator shutdown requests."""
@@ -1484,9 +1497,10 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
     def fake_async_create_issue(**kwargs: Any) -> None:
         """Record repair issue creation requests."""
         called["issue"] += 1
+        called["issue_kwargs"] = kwargs
 
     monkeypatch.setattr(coord, "_get_states", fake_get_states)
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     object.__setattr__(client, "get_query_counts", AsyncMock(return_value=3))
 
@@ -1495,5 +1509,18 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
     assert await coord._async_update_dt_data() == {}
 
     assert coord._mismatched_count == 3
-    assert called == {"issue": 1, "shutdown": 1}
+    assert called["issue"] == 1
+    assert called["shutdown"] == 1
+    assert called["issue_kwargs"]["is_fixable"] is True
+    assert called["issue_kwargs"]["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert called["issue_kwargs"]["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "id",
+        "new_device_id": "other",
+    }
+    assert called["issue_kwargs"]["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "id",
+        "new_device_id": "other",
+    }
     client.get_query_counts.assert_not_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1404,6 +1404,7 @@ async def test_calculate_entity_speeds_returns_early_when_missing(
     [
         (None, False),
         ("other", False),
+        (" ", False),
         ("id", True),
     ],
 )
@@ -1534,6 +1535,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         pytest.param({"device_unique_id": ""}, id="blank"),
         pytest.param({"device_unique_id": None}, id="none"),
         pytest.param({"device_unique_id": 123}, id="number"),
+        pytest.param({"device_unique_id": "   "}, id="whitespace"),
     ],
 )
 async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1524,3 +1524,54 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         "new_device_id": "other",
     }
     client.get_query_counts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        pytest.param({}, id="missing"),
+        pytest.param({"device_unique_id": ""}, id="blank"),
+        pytest.param({"device_unique_id": None}, id="none"),
+        pytest.param({"device_unique_id": 123}, id="number"),
+    ],
+)
+async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+    state: dict[str, object],
+) -> None:
+    """Non-string and blank runtime IDs should reset mismatch count and fail fast."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=fake_client()(),
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="expected",
+        config_entry=entry,
+    )
+
+    called: dict[str, int] = {"issue": 0, "shutdown": 0}
+    coord._mismatched_count = 2
+
+    async def fake_shutdown() -> None:
+        """Record shutdown calls for invalid runtime IDs."""
+        called["shutdown"] += 1
+
+    def fake_async_create_issue(**kwargs: Any) -> None:
+        """Record issue creation calls."""
+        del kwargs
+        called["issue"] += 1
+
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    object.__setattr__(coord, "async_shutdown", fake_shutdown)
+    coord._state = state
+
+    result = await coord._check_device_unique_id()
+
+    assert result is False
+    assert coord._mismatched_count == 0
+    assert called["issue"] == 0
+    assert called["shutdown"] == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -394,8 +394,10 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_client: Any,
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """async_setup_entry should fail when client reports mismatched device id."""
+    caplog.set_level(logging.ERROR, logger=init_mod.__name__)
     patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id="other"))
     # use shared coordinator capture fixture
     monkeypatch.setattr(
@@ -417,12 +419,35 @@ async def test_async_setup_entry_device_id_mismatch(
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     hass.config_entries.async_reload = AsyncMock()
 
+    issue_kwargs: dict[str, Any] = {}
+
+    def _capture_issue(**kwargs: Any) -> None:
+        """Capture the startup device-ID repair issue payload."""
+        issue_kwargs.update(kwargs)
+
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
+
     # should return False because router id mismatches and coordinator.shutdown called
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is False
 
     # ensure coordinator shutdown was invoked
     assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
+    assert hass.config_entries.async_forward_entry_setups.await_count == 0
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    assert issue_kwargs["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    assert "fixable repair issue" in caplog.text
+    assert "rebuild entities" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -387,6 +387,16 @@ async def test_async_setup_entry_continues_after_firmware_validation_error(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("router_device_id", "should_create_issue"),
+    [
+        ("other", True),
+        (None, False),
+        ("", False),
+        ("   ", False),
+        (123, False),
+    ],
+)
 async def test_async_setup_entry_device_id_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
@@ -395,10 +405,12 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
     caplog: pytest.LogCaptureFixture,
+    router_device_id: Any,
+    should_create_issue: bool,
 ) -> None:
     """async_setup_entry should fail when client reports mismatched device id."""
     caplog.set_level(logging.ERROR, logger=init_mod.__name__)
-    patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id="other"))
+    patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id=router_device_id))
     # use shared coordinator capture fixture
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -427,27 +439,31 @@ async def test_async_setup_entry_device_id_mismatch(
 
     monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
 
-    # should return False because router id mismatches and coordinator.shutdown called
     res = await init_mod.async_setup_entry(hass, entry)
-    assert res is False
-
-    # ensure coordinator shutdown was invoked
-    assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
-    assert hass.config_entries.async_forward_entry_setups.await_count == 0
-    assert issue_kwargs["is_fixable"] is True
-    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
-    assert issue_kwargs["data"] == {
-        "entry_id": entry.entry_id,
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-    assert issue_kwargs["translation_placeholders"] == {
-        "entry_title": entry.title,
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-    assert "fixable repair issue" in caplog.text
-    assert "rebuild entities" in caplog.text
+    if should_create_issue:
+        # should return False because router id mismatches and coordinator.shutdown called
+        assert res is False
+        assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
+        assert hass.config_entries.async_forward_entry_setups.await_count == 0
+        assert issue_kwargs["is_fixable"] is True
+        assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+        assert issue_kwargs["data"] == {
+            "entry_id": entry.entry_id,
+            "old_device_id": "dev1",
+            "new_device_id": router_device_id,
+        }
+        assert issue_kwargs["translation_placeholders"] == {
+            "entry_title": entry.title,
+            "old_device_id": "dev1",
+            "new_device_id": router_device_id,
+        }
+        assert "fixable repair issue" in caplog.text
+        assert "rebuild entities" in caplog.text
+    else:
+        assert res is True
+        assert not issue_kwargs
+        assert hass.config_entries.async_forward_entry_setups.await_count == 1
+        assert not any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -911,7 +911,7 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
 async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Loaded retry cleanup failures should stay available without scheduling reload."""
+    """Loaded retry cleanup failures should schedule a guarded recovery reload."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
     _configure_hass(hass, entry)
@@ -944,6 +944,13 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "repair_failed"
     assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.data == {
+        "url": "https://router.example",
+        "username": "api-user",
+        "password": "api-password",
+        CONF_DEVICE_UNIQUE_ID: "other",
+    }
+    assert entry.unique_id == "other"
     hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
     entity_registry.async_remove.assert_called_once_with("sensor.old")
     device_registry.async_update_device.assert_called_once_with(
@@ -951,8 +958,21 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     )
     hass.config_entries.async_update_entry.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
     issue_delete.assert_not_called()
+
+    entity_registry.async_remove.side_effect = None
+    device_registry.async_update_device.side_effect = None
+    hass.config_entries.async_schedule_reload.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entity_registry.async_remove.call_count == 2
+    assert device_registry.async_update_device.call_count == 2
+    assert hass.config_entries.async_reload.await_count == 1
+    hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1028,12 +1048,13 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     assert len(hass.config_entries.async_update_entry.call_args_list) == 1
     issue_delete.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
 
     hass.config_entries.async_reload.reset_mock()
     entity_registry.async_remove.side_effect = None
     device_registry.async_update_device.side_effect = None
     client.get_device_unique_id.reset_mock()
+    hass.config_entries.async_schedule_reload.reset_mock()
 
     retry_result = await flow.async_step_confirm({})
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -413,12 +413,14 @@ async def test_loaded_entry_unloads_before_registry_cleanup(
         pytest.param(TimeoutError("timeout"), None, id="timeout-error"),
         pytest.param(None, None, id="missing-device-id"),
         pytest.param(None, "", id="blank-device-id"),
+        pytest.param(None, "   ", id="whitespace-device-id"),
+        pytest.param(None, 123, id="non-string-device-id"),
     ],
 )
 async def test_invalid_probe_result_aborts_without_mutations(
     monkeypatch: pytest.MonkeyPatch,
     probe_error: BaseException | None,
-    observed_device_id: str | None,
+    observed_device_id: Any,
 ) -> None:
     """Invalid strict-probe results should abort and close the client."""
     hass = MagicMock()
@@ -1392,20 +1394,81 @@ async def test_removed_entry_aborts_without_mutations(
 
 
 @pytest.mark.asyncio
-async def test_fix_flow_factory_validates_issue_suffix_and_payload() -> None:
+@pytest.mark.parametrize(
+    ("data", "expects_replacement_flow"),
+    [
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "dev1",
+                "new_device_id": "other",
+            },
+            True,
+        ),
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "dev1",
+                "new_device_id": "   ",
+            },
+            False,
+        ),
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "   ",
+                "new_device_id": "other",
+            },
+            False,
+        ),
+    ],
+)
+async def test_fix_flow_factory_validates_issue_suffix_and_payload(
+    data: dict[str, str | int | float | None],
+    expects_replacement_flow: bool,
+) -> None:
     """Only well-formed device-ID issues should construct the destructive flow."""
     hass = MagicMock()
-    data: dict[str, str | int | float | None] = {
-        "entry_id": "entry-1",
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-
     flow = await repairs.async_create_fix_flow(hass, "entry-1_device_id_mismatched", data)
-
-    assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    if expects_replacement_flow:
+        assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    else:
+        assert isinstance(flow, ConfirmRepairFlow)
     unknown_flow = await repairs.async_create_fix_flow(hass, "unrelated", None)
     assert isinstance(unknown_flow, ConfirmRepairFlow)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_device_id", "observed_device_id", "expect_issue"),
+    [
+        ("dev1", "other", True),
+        ("   ", "other", False),
+        ("dev1", "   ", False),
+    ],
+)
+async def test_async_create_device_id_mismatch_issue_ignores_invalid_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    entry_device_id: str,
+    observed_device_id: str,
+    expect_issue: bool,
+) -> None:
+    """Do not create mismatches when configured or observed IDs are malformed."""
+    entry = _make_entry(device_id=entry_device_id)
+    called: dict[str, int] = {"count": 0}
+
+    def _capture_issue(**kwargs: Any) -> None:
+        del kwargs
+        called["count"] += 1
+
+    monkeypatch.setattr(repairs.ir, "async_create_issue", _capture_issue)
+
+    repairs.async_create_device_id_mismatch_issue(MagicMock(), entry, observed_device_id)
+
+    if expect_issue:
+        assert called["count"] == 1
+    else:
+        assert called["count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -976,10 +976,19 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure_point", ["entity", "device"])
+@pytest.mark.parametrize(
+    ("failure_point", "cleanup_exception"),
+    [
+        pytest.param("entity", HomeAssistantError, id="entity-homeassistant-error"),
+        pytest.param("entity", ValueError, id="entity-valueerror"),
+        pytest.param("device", HomeAssistantError, id="device-homeassistant-error"),
+        pytest.param("device", ValueError, id="device-valueerror"),
+    ],
+)
 async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     monkeypatch: pytest.MonkeyPatch,
     failure_point: str,
+    cleanup_exception: type[BaseException],
 ) -> None:
     """Cleanup failure keeps replacement ID for a retry that reruns cleanup."""
     hass = MagicMock()
@@ -1016,7 +1025,7 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
         def _remove(entity_id: str) -> None:
             """Fail entity cleanup to exercise recovery reload behavior."""
             del entity_id
-            raise HomeAssistantError("entity remove")
+            raise cleanup_exception("entity remove")
 
         entity_registry.async_remove.side_effect = _remove
     else:
@@ -1024,7 +1033,7 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
         def _update_device(device_id: str, **_: Any) -> None:
             """Fail device cleanup to exercise recovery reload behavior."""
             del device_id
-            raise HomeAssistantError("device update")
+            raise cleanup_exception("device update")
 
         device_registry.async_update_device.side_effect = _update_device
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,1481 @@
+"""Tests for the OPNsense device-ID replacement repair flow."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from aiopnsense.exceptions import OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.opnsense import repairs
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+
+
+def _make_entry(
+    *,
+    entry_id: str = "entry-1",
+    device_id: str = "dev1",
+    unique_id: str | None = "dev1",
+    state: ConfigEntryState = ConfigEntryState.NOT_LOADED,
+    options: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Build a config entry with connection data used by the repair tests."""
+    data: dict[str, Any] = {
+        "url": "https://router.example",
+        "username": "api-user",
+        "password": "api-password",
+        CONF_DEVICE_UNIQUE_ID: device_id,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data, title="OPNsense Test")
+    object.__setattr__(entry, "entry_id", entry_id)
+    object.__setattr__(entry, "unique_id", unique_id)
+    object.__setattr__(entry, "state", state)
+    object.__setattr__(entry, "options", options or {"scan_interval": 30})
+    return entry
+
+
+def _make_flow(
+    hass: Any,
+    entry: MockConfigEntry,
+    *,
+    old_device_id: str | None = None,
+    new_device_id: str = "other",
+) -> repairs.DeviceIDMismatchRepairFlow:
+    """Create a configured repair flow for direct step testing."""
+    if old_device_id is None:
+        old_device_id = entry.data[CONF_DEVICE_UNIQUE_ID]
+    flow = repairs.DeviceIDMismatchRepairFlow(
+        entry_id=entry.entry_id,
+        old_device_id=old_device_id,
+        new_device_id=new_device_id,
+    )
+    flow.hass = hass
+    flow.handler = DOMAIN
+    flow.issue_id = f"{entry.entry_id}_device_id_mismatched"
+    flow.flow_id = "flow-1"
+    return flow
+
+
+def _configure_hass(hass: Any, entry: MockConfigEntry) -> None:
+    """Configure the config-entry manager methods shared by flow tests."""
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry.return_value = entry
+    hass.config_entries.async_entries.return_value = [entry]
+    hass.config_entries.async_unload = AsyncMock(return_value=True)
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+    hass.config_entries.async_reload = AsyncMock(return_value=True)
+    hass.config_entries.async_schedule_reload = MagicMock()
+
+
+def _patch_registries(
+    monkeypatch: pytest.MonkeyPatch,
+    entities: list[Any] | None = None,
+    devices: list[Any] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Patch entity/device registry lookups and return the fake registries."""
+    entity_registry = MagicMock()
+    device_registry = MagicMock()
+    monkeypatch.setattr(repairs.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        repairs.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: entities or [],
+    )
+    monkeypatch.setattr(repairs.dr, "async_get", lambda hass: device_registry)
+    monkeypatch.setattr(
+        repairs.dr,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: devices or [],
+    )
+    return entity_registry, device_registry
+
+
+def _patch_issue_registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch issue lookups used to render confirmation placeholders."""
+    issue_registry = MagicMock()
+    issue_registry.async_get_issue.return_value = SimpleNamespace(
+        translation_placeholders={
+            "entry_title": "OPNsense Test",
+            "old_device_id": "dev1",
+            "new_device_id": "other",
+        }
+    )
+    monkeypatch.setattr(repairs.ir, "async_get", lambda hass: issue_registry)
+    return issue_registry
+
+
+def _patch_probe_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    observed_device_id: Any = "other",
+    probe_error: BaseException | None = None,
+    events: list[str] | None = None,
+) -> MagicMock:
+    """Patch strict client construction and return the client mock."""
+    client = MagicMock()
+
+    async def _probe() -> Any:
+        """Return the configured replacement identifier."""
+        if events is not None:
+            events.append("probe")
+        return observed_device_id
+
+    async def _validate() -> None:
+        """Record strict client validation."""
+        if events is not None:
+            events.append("validate")
+
+    async def _close() -> None:
+        """Record strict probe client closure."""
+        if events is not None:
+            events.append("close")
+
+    client.get_device_unique_id = AsyncMock(
+        side_effect=probe_error if probe_error is not None else _probe
+    )
+    client.validate = AsyncMock(side_effect=_validate)
+    client.async_close = AsyncMock(side_effect=_close)
+    factory = MagicMock(return_value=client)
+    client.factory = factory
+    monkeypatch.setattr(repairs, "create_opnsense_client_from_config_entry", factory)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_initial_flow_renders_replacement_ids_and_confirmation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial step should show old/new IDs and a destructive-rebuild confirmation."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _patch_issue_registry(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_init()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    assert data_schema({}) == {}
+
+
+@pytest.mark.asyncio
+async def test_confirmation_reprobes_with_strict_client_and_closes_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirmation should re-probe the current ID with throw_errors enabled."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    client = _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    client.factory.assert_called_once_with(hass=hass, config_entry=entry, throw_errors=True)
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_stale_observed_device_id_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale issue with matching observed ID should abort without destructive work."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch, observed_device_id="dev1")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_observed_device_id_mismatch_with_issue_expected_id_aborts_before_unload_or_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Observed IDs that do not match issue expectation must abort without mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch, observed_device_id="third")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_old_device_id_mismatch_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale issue with mismatched old_device_id should abort without mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(
+        hass,
+        entry,
+        old_device_id="stale-old-device-id",
+        new_device_id="other",
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.factory.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    client.validate.assert_not_awaited()
+    client.get_device_unique_id.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate replacement IDs must abort before any destructive mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    hass.config_entries.async_entries.return_value = [entry, duplicate]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    issue_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_unloads_before_registry_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded entry must unload before entities or devices are removed."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    events: list[str] = []
+    _configure_hass(hass, entry)
+
+    def _unload(entry_id: str) -> bool:
+        """Record unload before returning success."""
+        events.append("unload")
+        return True
+
+    class _OtherEntry:
+        """Duplicate-scan candidate whose ID access is observable."""
+
+        entry_id = "entry-2"
+
+        @property
+        def unique_id(self) -> str:
+            """Record the duplicate candidate comparison."""
+            events.append("duplicate_check")
+            return "different"
+
+    def _entries(domain: str) -> list[Any]:
+        """Record the duplicate scan and return only non-conflicting entries."""
+        events.append("duplicate_scan")
+        return [entry, _OtherEntry()]
+
+    hass.config_entries.async_entries.side_effect = _entries
+    hass.config_entries.async_unload.side_effect = _unload
+    entity = SimpleNamespace(entity_id="sensor.old", disabled_by=None)
+    device = SimpleNamespace(id="device")
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch, entities=[entity], devices=[device]
+    )
+    entity_registry.async_remove.side_effect = lambda entity_id: events.append("entity")
+    device_registry.async_update_device.side_effect = lambda device_id, **kwargs: events.append(
+        "device"
+    )
+
+    def _update_entry(*args: Any, **kwargs: Any) -> bool:
+        """Record the config update and report that it changed the entry."""
+        del args, kwargs
+        events.append("config_update")
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    async def _reload(entry_id: str) -> bool:
+        """Record reload scheduling and signal success."""
+        del entry_id
+        events.append("reload")
+        return True
+
+    hass.config_entries.async_reload.side_effect = _reload
+    _patch_probe_client(monkeypatch, events=events)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", lambda *args: events.append("delete"))
+    flow = _make_flow(hass, entry)
+
+    def _create_entry(**_: Any) -> dict[str, str]:
+        """Record creation after the reload was scheduled."""
+        events.append("create")
+        return {"type": "create_entry"}
+
+    object.__setattr__(
+        flow,
+        "async_create_entry",
+        _create_entry,
+    )
+
+    await flow.async_step_confirm({})
+
+    assert events == [
+        "validate",
+        "probe",
+        "close",
+        "duplicate_scan",
+        "duplicate_check",
+        "unload",
+        "config_update",
+        "entity",
+        "device",
+        "reload",
+        "create",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("probe_error", "observed_device_id"),
+    [
+        pytest.param(aiohttp.ClientError("transport"), None, id="transport-error"),
+        pytest.param(TimeoutError("timeout"), None, id="timeout-error"),
+        pytest.param(None, None, id="missing-device-id"),
+        pytest.param(None, "", id="blank-device-id"),
+    ],
+)
+async def test_invalid_probe_result_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+    probe_error: BaseException | None,
+    observed_device_id: str | None,
+) -> None:
+    """Invalid strict-probe results should abort and close the client."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(
+        monkeypatch,
+        observed_device_id=observed_device_id,
+        probe_error=probe_error,
+    )
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    client.async_close.assert_awaited_once_with()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "validation_error",
+    [
+        pytest.param(OPNsenseBelowMinFirmware("unsupported"), id="below-minimum"),
+        pytest.param(OPNsenseUnknownFirmware("unknown"), id="unknown-firmware"),
+    ],
+)
+async def test_firmware_validation_failure_aborts_before_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+    validation_error: BaseException,
+) -> None:
+    """Firmware validation failures must stop the repair before any mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    client.validate.side_effect = validation_error
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_not_awaited()
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unload_failure_aborts_before_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed unload must leave entity/device registries and entry data intact."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_unload.return_value = False
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        ConfigEntryState.FAILED_UNLOAD,
+        ConfigEntryState.SETUP_IN_PROGRESS,
+        ConfigEntryState.UNLOAD_IN_PROGRESS,
+    ],
+)
+async def test_nonrecoverable_entry_state_aborts_before_unload_or_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    state: ConfigEntryState,
+) -> None:
+    """Non-recoverable entry states must not reach unload or repair mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=state)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_removed_during_unload_aborts_before_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A removed entry after unload must not allow stale registry mutations."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_get_entry.side_effect = [entry, entry, None]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation_stage", ["probe", "unload"])
+@pytest.mark.parametrize("field", ["url", "username", "password", "options", "unique_id"])
+async def test_entry_changed_during_probe_or_unload_aborts_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    mutation_stage: str,
+    field: str,
+) -> None:
+    """Config-entry changes during awaited work must stop the destructive repair."""
+    hass = MagicMock()
+    entry = _make_entry(
+        state=ConfigEntryState.LOADED if mutation_stage == "unload" else ConfigEntryState.NOT_LOADED
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    def _mutate_entry() -> None:
+        """Apply one persisted-entry mutation while the repair is awaiting."""
+        if field in {"url", "username", "password"}:
+            object.__setattr__(entry, "data", {**entry.data, field: f"changed-{field}"})
+        elif field == "options":
+            entry.options["scan_interval"] = 99
+        else:
+            object.__setattr__(entry, "unique_id", "changed-unique-id")
+
+    if mutation_stage == "probe":
+
+        async def _probe_and_mutate() -> str:
+            """Mutate the entry before the probe completes."""
+            _mutate_entry()
+            return "other"
+
+        client.get_device_unique_id.side_effect = _probe_and_mutate
+    else:
+
+        def _unload_and_mutate(entry_id: str) -> bool:
+            """Mutate the entry while unloading it."""
+            _mutate_entry()
+            return True
+
+        hass.config_entries.async_unload.side_effect = _unload_and_mutate
+
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    if mutation_stage == "probe":
+        hass.config_entries.async_unload.assert_not_awaited()
+    else:
+        hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_nested_mutable_options_mutation_during_probe_aborts_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutating a nested options list in-place during probe must still abort safely."""
+    hass = MagicMock()
+    nested_devices = ["aa:bb:cc:dd:ee:01"]
+    entry = _make_entry(
+        state=ConfigEntryState.NOT_LOADED,
+        options={"scan_interval": 30, "devices": nested_devices},
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    async def _probe_and_mutate() -> str:
+        nested_devices.append("aa:bb:cc:dd:ee:02")
+        return "other"
+
+    client.get_device_unique_id.side_effect = _probe_and_mutate
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert nested_devices == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"]
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_disabled_entities_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entity cleanup should remove all entries, including integration/user-disabled ones."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entities = [
+        SimpleNamespace(entity_id="sensor.enabled", disabled_by=None),
+        SimpleNamespace(entity_id="sensor.integration_disabled", disabled_by="integration"),
+        SimpleNamespace(entity_id="sensor.user_disabled", disabled_by="user"),
+    ]
+    entity_registry, _ = _patch_registries(monkeypatch, entities=entities)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    assert [call.args[0] for call in entity_registry.async_remove.call_args_list] == [
+        "sensor.enabled",
+        "sensor.integration_disabled",
+        "sensor.user_disabled",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_only_this_config_entry_from_shared_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared devices should retain associations with other config entries."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    devices = [
+        SimpleNamespace(id="device-only", config_entries={entry.entry_id}),
+        SimpleNamespace(id="device-shared", config_entries={entry.entry_id, "entry-2"}),
+    ]
+    _, device_registry = _patch_registries(monkeypatch, devices=devices)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    assert device_registry.async_update_device.call_args_list == [
+        (("device-only",), {"remove_config_entry_id": entry.entry_id}),
+        (("device-shared",), {"remove_config_entry_id": entry.entry_id}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_connection_and_options_while_replacing_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry update should replace only the device ID and unique ID."""
+    hass = MagicMock()
+    entry = _make_entry(options={"scan_interval": 45})
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    assert entry.data["url"] == "https://router.example"
+    assert entry.data["username"] == "api-user"
+    assert entry.data["password"] == "api-password"
+    assert entry.options == {"scan_interval": 45}
+
+
+@pytest.mark.asyncio
+async def test_success_deletes_issue_and_reloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful rebuild should async-reload and let the manager delete the issue."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_update_failure_aborts_without_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry-update failure must abort before any registry mutation."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.side_effect = HomeAssistantError("entry update")
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    issue_delete.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_entry_update_false_aborts_before_registry_mutation_and_recovers_loaded_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-op entry update must leave registries untouched and reload a prior loaded entry."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.return_value = False
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_update_exception_recovers_without_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An update exception after unload should schedule guarded recovery."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.side_effect = HomeAssistantError("entry update")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_expected_id_retry_rechecks_snapshot_after_unload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry must not clean registries after its entry changes during unload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+
+    def _unload_and_mutate(entry_id: str) -> bool:
+        """Mutate persisted data while the retry is awaiting unload."""
+        del entry_id
+        object.__setattr__(entry, "data", {**entry.data, "url": "https://changed.example"})
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload_and_mutate
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loaded retry cleanup failures should stay available without scheduling reload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+
+    def _unload(entry_id: str) -> bool:
+        """Record unload and transition to an unloaded state."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+
+    def _remove_entity(entity_id: str) -> None:
+        """Fail entity cleanup to exercise retry recovery behavior."""
+        del entity_id
+        raise HomeAssistantError("entity remove")
+
+    entity_registry.async_remove.side_effect = _remove_entity
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    issue_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["entity", "device"])
+async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    """Cleanup failure keeps replacement ID for a retry that reruns cleanup."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    observed_device_id = "other"
+    client = _patch_probe_client(monkeypatch, observed_device_id=observed_device_id)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+
+    old_data = dict(entry.data)
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the requested entry mutation to the in-memory test object."""
+        del config_entry
+        object.__setattr__(entry, "data", dict(data))
+        object.__setattr__(entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    if failure_point == "entity":
+
+        def _remove(entity_id: str) -> None:
+            """Fail entity cleanup to exercise recovery reload behavior."""
+            del entity_id
+            raise HomeAssistantError("entity remove")
+
+        entity_registry.async_remove.side_effect = _remove
+    else:
+
+        def _update_device(device_id: str, **_: Any) -> None:
+            """Fail device cleanup to exercise recovery reload behavior."""
+            del device_id
+            raise HomeAssistantError("device update")
+
+        device_registry.async_update_device.side_effect = _update_device
+
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    assert entry.data == expected_updated_data
+    assert entry.unique_id == observed_device_id
+    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+    hass.config_entries.async_reload.reset_mock()
+    entity_registry.async_remove.side_effect = None
+    device_registry.async_update_device.side_effect = None
+    client.get_device_unique_id.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    client.get_device_unique_id.assert_not_awaited()
+    assert hass.config_entries.async_reload.await_count == 1
+    assert hass.config_entries.async_update_entry.call_count == 1
+    if failure_point == "entity":
+        assert entity_registry.async_remove.call_count == 2
+        assert device_registry.async_update_device.call_count == 2
+    else:
+        assert entity_registry.async_remove.call_count == 2
+        assert device_registry.async_update_device.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reload_result", "reload_label"),
+    [
+        pytest.param(False, "reload-false", id="false-result"),
+        pytest.param(
+            HomeAssistantError("entry removed"), "homeassistant-error", id="homeassistant-error"
+        ),
+        pytest.param(KeyError("entry key"), "key-error", id="key-error"),
+    ],
+)
+async def test_reload_failure_keeps_entry_update_and_keeps_issue(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_result: bool | Exception,
+    reload_label: str,
+) -> None:
+    """Reload failures should keep the new ID and schedule a follow-up reload."""
+    del reload_label
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    observed_device_id = "other"
+    _patch_probe_client(monkeypatch, observed_device_id=observed_device_id)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+
+    old_data = dict(entry.data)
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the requested entry mutation to the in-memory test object."""
+        del config_entry
+        object.__setattr__(entry, "data", dict(data))
+        object.__setattr__(entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    if isinstance(reload_result, bool):
+        hass.config_entries.async_reload.return_value = reload_result
+    else:
+        hass.config_entries.async_reload.side_effect = reload_result
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once()
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    assert entry.data == expected_updated_data
+    assert entry.unique_id == observed_device_id
+    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_when_reload_scheduling_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry an updated repair by loading the entry and rerunning cleanup."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entities = [SimpleNamespace(entity_id="sensor.old")]
+    device = SimpleNamespace(id="device")
+    devices = [device]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=entities,
+        devices=devices,
+    )
+    entity_scan_calls: list[str] = []
+    device_scan_calls: list[str] = []
+
+    def _entity_scan(registry: Any, config_entry_id: str) -> list[Any]:
+        """Track entity scan attempts across retries."""
+        del registry
+        entity_scan_calls.append(config_entry_id)
+        return entities
+
+    def _device_scan(registry: Any, config_entry_id: str) -> list[Any]:
+        """Track device scan attempts across retries."""
+        del registry
+        device_scan_calls.append(config_entry_id)
+        return devices
+
+    monkeypatch.setattr(repairs.er, "async_entries_for_config_entry", _entity_scan)
+    monkeypatch.setattr(repairs.dr, "async_entries_for_config_entry", _device_scan)
+    client = _patch_probe_client(monkeypatch)
+
+    def _remove_entity(entity_id: str) -> None:
+        """Remove an entity from the fake registry after successful cleanup."""
+        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
+
+    def _remove_device(device_id: str, **_: Any) -> None:
+        """Remove a device from the fake registry after successful cleanup."""
+        devices[:] = [device for device in devices if device.id != device_id]
+
+    entity_registry.async_remove.side_effect = _remove_entity
+    device_registry.async_update_device.side_effect = _remove_device
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the replacement identity to the in-memory entry."""
+        object.__setattr__(config_entry, "data", dict(data))
+        object.__setattr__(config_entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    hass.config_entries.async_reload.side_effect = [
+        HomeAssistantError("reload failed"),
+        True,
+    ]
+    hass.config_entries.async_schedule_reload.side_effect = HomeAssistantError("schedule failed")
+    flow = _make_flow(hass, entry)
+
+    first_result = await flow.async_step_confirm({})
+
+    assert first_result["type"] is FlowResultType.ABORT
+    assert first_result["reason"] == "repair_failed"
+    assert entry.data[CONF_DEVICE_UNIQUE_ID] == "other"
+
+    hass.config_entries.async_update_entry.reset_mock()
+    entity_registry.async_remove.reset_mock()
+    device_registry.async_update_device.reset_mock()
+    client.get_device_unique_id.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_not_called()
+    assert entity_scan_calls == [entry.entry_id, entry.entry_id]
+    assert device_scan_calls == [entry.entry_id, entry.entry_id]
+    client.get_device_unique_id.assert_not_awaited()
+    assert hass.config_entries.async_reload.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_repeats_registry_cleanup_after_partial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry should clean up registry entries left after a failed cleanup pass."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entities = [SimpleNamespace(entity_id="sensor.old")]
+    device = SimpleNamespace(id="device")
+    devices = [device]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=entities,
+        devices=devices,
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    async def _unload(entry_id: str) -> bool:
+        """Unload the entry so each cleanup pass starts at the hardware boundary."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload
+
+    async def _reload(entry_id: str) -> bool:
+        """Reload the entry after each cleanup attempt."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.LOADED)
+        return True
+
+    hass.config_entries.async_reload.side_effect = _reload
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the replacement identity to the in-memory entry."""
+        object.__setattr__(config_entry, "data", dict(data))
+        object.__setattr__(config_entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    def _remove_entity(entity_id: str) -> None:
+        """Remove an entity from the fake registry."""
+        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
+
+    entity_registry.async_remove.side_effect = _remove_entity
+
+    def _remove_device(device_id: str, **_: Any) -> None:
+        """Remove a device from the fake registry."""
+        devices[:] = [device for device in devices if device.id != device_id]
+
+    cleanup_attempts = 0
+
+    def _update_device(device_id: str, **kwargs: Any) -> None:
+        """Fail the first device cleanup and allow the retry to finish it."""
+        nonlocal cleanup_attempts
+        cleanup_attempts += 1
+        if cleanup_attempts == 1:
+            raise HomeAssistantError("device update")
+        _remove_device(device_id, **kwargs)
+
+    device_registry.async_update_device.side_effect = _update_device
+    flow = _make_flow(hass, entry)
+
+    first_result = await flow.async_step_confirm({})
+
+    assert first_result["type"] is FlowResultType.ABORT
+    assert first_result["reason"] == "repair_failed"
+    assert entities == []
+    assert devices == [device]
+    assert device_registry.async_update_device.call_count == 1
+    assert hass.config_entries.async_reload.await_count == 0
+
+    hass.config_entries.async_update_entry.reset_mock()
+    entity_registry.async_remove.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_not_called()
+    entity_registry.async_remove.assert_not_called()
+    assert device_registry.async_update_device.call_count == 2
+    device_registry.async_update_device.assert_called_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    client.get_device_unique_id.assert_awaited_once_with()
+    assert hass.config_entries.async_unload.await_count == 1
+    assert hass.config_entries.async_reload.await_count == 1
+    assert devices == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reload_result",
+    [False, HomeAssistantError("reload failed"), KeyError("entry key")],
+)
+async def test_retry_keeps_issue_when_recovery_reload_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_result: bool | Exception,
+) -> None:
+    """Keep the repair available when reloading an already-updated entry fails."""
+    hass = MagicMock()
+    entry = _make_entry(device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(monkeypatch)
+    client = _patch_probe_client(monkeypatch)
+    if isinstance(reload_result, bool):
+        hass.config_entries.async_reload.return_value = reload_result
+    else:
+        hass.config_entries.async_reload.side_effect = reload_result
+    flow = _make_flow(hass, entry, old_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_update_entry.assert_not_called()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    client.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_removed_entry_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted config entry should abort before creating a strict client."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    hass.config_entries.async_get_entry.return_value = None
+    client_factory = MagicMock()
+    monkeypatch.setattr(repairs, "create_opnsense_client_from_config_entry", client_factory)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_not_found"
+    client_factory.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_factory_validates_issue_suffix_and_payload() -> None:
+    """Only well-formed device-ID issues should construct the destructive flow."""
+    hass = MagicMock()
+    data: dict[str, str | int | float | None] = {
+        "entry_id": "entry-1",
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+
+    flow = await repairs.async_create_fix_flow(hass, "entry-1_device_id_mismatched", data)
+
+    assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    unknown_flow = await repairs.async_create_fix_flow(hass, "unrelated", None)
+    assert isinstance(unknown_flow, ConfirmRepairFlow)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_reload_false_retries_recovery_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded entry with matching expected ID should recover when resume reload fails."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.return_value = False
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unloaded expected-ID retry should still keep recovery reload on failure."""
+    hass = MagicMock()
+    entry = _make_entry(
+        state=ConfigEntryState.NOT_LOADED,
+        device_id="dev1",
+        unique_id="dev1",
+    )
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.return_value = False
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reload_error",
+    [HomeAssistantError("reload failed"), KeyError("entry-key")],
+)
+async def test_stored_expected_id_resume_exception_recovers_reloaded_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_error: BaseException,
+) -> None:
+    """Handled exceptions during resume should leave a recovery-reload trace."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.side_effect = reload_error
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed retry entry must abort before destructive registry cleanup."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    updated_entry = _make_entry(
+        entry_id=entry.entry_id,
+        device_id="mutated",
+        unique_id="mutated",
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    hass.config_entries.async_get_entry.side_effect = [entry, updated_entry]
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1077,32 +1077,24 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     client.get_device_unique_id.assert_not_awaited()
     assert hass.config_entries.async_reload.await_count == 1
     assert hass.config_entries.async_update_entry.call_count == 1
-    if failure_point == "entity":
-        assert entity_registry.async_remove.call_count == 2
-        assert device_registry.async_update_device.call_count == 2
-    else:
-        assert entity_registry.async_remove.call_count == 2
-        assert device_registry.async_update_device.call_count == 2
+    assert entity_registry.async_remove.call_count == 2
+    assert device_registry.async_update_device.call_count == 2
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("reload_result", "reload_label"),
+    "reload_result",
     [
-        pytest.param(False, "reload-false", id="false-result"),
-        pytest.param(
-            HomeAssistantError("entry removed"), "homeassistant-error", id="homeassistant-error"
-        ),
-        pytest.param(KeyError("entry key"), "key-error", id="key-error"),
+        pytest.param(False, id="false-result"),
+        pytest.param(HomeAssistantError("entry removed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry key"), id="key-error"),
     ],
 )
 async def test_reload_failure_keeps_entry_update_and_keeps_issue(
     monkeypatch: pytest.MonkeyPatch,
     reload_result: bool | Exception,
-    reload_label: str,
 ) -> None:
     """Reload failures should keep the new ID and schedule a follow-up reload."""
-    del reload_label
     hass = MagicMock()
     entry = _make_entry()
     _configure_hass(hass, entry)


### PR DESCRIPTION
## Summary

Adds a fixable Home Assistant repair flow for OPNsense device-ID mismatches caused by replacement hardware. The flow safely rebuilds the entry's entity and device inventory while preserving its connection settings and options.

## What Changed

- Create entry-scoped, fixable repair issues when setup or coordinator updates detect a device-ID mismatch
- Re-probe the replacement device and revalidate the config-entry snapshot before making destructive changes
- Unload the entry, remove its entity and device registry records, update the stored device ID, and reload the integration
- Preserve the configured URL, credentials, and options while clearly warning that entity customizations and IDs may be lost
- Guard against stale observations, duplicate device IDs, entry changes, unload failures, partial cleanup, and reload failures
- Support safe retries and recovery reloads when a repair cannot complete in one attempt
- Add user-facing repair translations, replacement-hardware documentation, and focused regression coverage

## Why

Replacing OPNsense hardware changes the device identity and can invalidate the existing Home Assistant entity inventory. Previously, users had to remove and reinstall the integration manually. This repair flow makes that recovery explicit and guarded while preventing stale entities from appearing valid after a hardware change.

## Related Issues

Depends on #144

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a guided repair for OPNsense device-ID changes after hardware replacement. The main changes are:

- Creates fixable repair issues from setup and coordinator mismatch detection.
- Adds a repair flow that re-probes the device, updates the stored device ID, cleans registries, and reloads the entry.
- Preserves connection settings and options while warning users about entity inventory loss.
- Adds English repair text, README guidance, and tests for the new repair paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/opnsense/repairs.py | Adds the device-ID mismatch repair flow with snapshot checks, duplicate detection, registry cleanup, entry updates, and recovery reload handling. |
| custom_components/opnsense/__init__.py | Creates the new fixable repair issue during setup when a valid replacement device ID is detected. |
| custom_components/opnsense/coordinator.py | Routes repeated runtime device-ID mismatches through the shared repair issue helper and ignores malformed runtime IDs. |
| custom_components/opnsense/translations/en.json | Adds user-facing text for the replacement-hardware repair flow and its abort cases. |
| tests/test_repairs.py | Adds tests for confirmation, validation, duplicate handling, cleanup failures, reload failures, and retry behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Simplify repair recovery tests"](https://github.com/snuffy2/hass-opnsense/commit/9f9bcdbf5a038e7f2bf550e938e1d9e99574b802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44331198)</sub>

**Context used:**

- Rule used - In Python 3.14+, `except ExcTypeA, ExcTypeB:` (com... ([source](https://app.greptile.com/snuffy2/github/Snuffy2/carrier_api/-/custom-context?memory=0402128e-91c3-4dd3-a9a0-49f92b3531f7))
- Rule used - Always check the project's minimum Python version ... ([source](https://app.greptile.com/snuffy2/github/Snuffy2/places/-/custom-context?memory=442bbe98-87a9-414c-a77c-6465ceee15f9))

<!-- /greptile_comment -->