### PR TITLE
Add device-id replacement repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ At minimum, the following permissions are required:
 | API Key | ✅ | | The API key of the OPNsense user created previously |
 | API Secret | ✅ | | The API secret of the API key |
 | Firewall Name | | Uses the `OPNsense hostname` | A custom name to be used for device and entity naming |
-| Enable Granular Sync Options | | False | See [Granular Sync Options](#granular-sync-options) |
+| Enable Granular Sync Options | | False | See [Granular Sync Options](#granular-sync) |
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The persistent CARP maintenance switch remains on physical-node entries. Enablin
 
 Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same.
 
-When an OPNsense device entry reports a device-ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair selectively reconciles the registry with the replacement's inventory: matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created.
+When an OPNsense device entry reports a Device ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair selectively reconciles the registry with the replacement's inventory: matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created.
 
 The repair preserves the URL, credentials, and options. A retry marker makes an interrupted repair resumable. Dashboards and automations remain intact for preserved entity IDs; review references to inventory removed during reconciliation.
 

--- a/README.md
+++ b/README.md
@@ -30,18 +30,14 @@ A Discord server to discuss the integration is available. Click the Discord badg
 ## Table of Contents
 
 * [Installation](#installation)
-  * [Home Assistant Integration](#home-assistant-integration)
-    * [HACS Installation](#hacs-installation)
-
 * [Configuration](#configuration)
   * [OPNsense Device Entry](#opnsense-device-entry)
   * [CARP VIP Entry](#carp-vip-entry)
   * [Recommended CARP Topology](#recommended-carp-topology)
   * [OPNsense User](#opnsense-user)
-    * [Granular Sync Options](#granular-sync-options)
+  * [Granular Sync](#granular-sync)
   * [Basic Configuration](#basic-configuration)
   * [Options](#options)
-
 * [Entities](#entities)
   * [Binary Sensor](#binary-sensor)
   * [Sensor](#sensor)
@@ -50,7 +46,6 @@ A Discord server to discuss the integration is available. Click the Discord badg
   * [CARP VIP Entities and Limitations](#carp-vip-entities-and-limitations)
 
 * [Actions](#actions-services)
-
 * [Replacing OPNsense Hardware](#replacing-opnsense-hardware)
 
 ## Installation
@@ -58,10 +53,6 @@ A Discord server to discuss the integration is available. Click the Discord badg
 This integration **replaces** the built-in OPNsense integration which only provides `device_tracker` functionality. Be sure to remove any associated configuration for the built-in integration **before** installing this replacement.
 
 The deprecated OPNsense Home Assistant plugin is no longer supported or used by hass-opnsense.
-
-### Home Assistant Integration
-
-#### HACS Installation
 
 In HACS, add this as a custom repository: 
 `https://github.com/travisghansen/hass-opnsense`.
@@ -82,7 +73,7 @@ Once the integration is installed be sure to restart Home Assistant. Restart opt
 | ![image](https://github.com/user-attachments/assets/95c324e5-73cb-42f9-8cd2-c4acc35c9711) | ![image](https://github.com/user-attachments/assets/bbb0ac00-1709-4206-9d59-eb47ca40390b) |
 
 <details>
-<summary><h4>Manual Installation</h4></summary>
+<summary><h3>Manual Installation</h3></summary>
 
 Copy the contents of the custom_components folder to the Home Assistant config/custom_components folder and restart Home Assistant.
 
@@ -90,7 +81,7 @@ Copy the contents of the custom_components folder to the Home Assistant config/c
 
 ## Configuration
 
-Configuration is managed entirely from the Home Assistant UI. Simply go to `Configuration -> Integrations -> Add Integration` and search for <ins>OPNsense</ins> in the search box. If it isn't in the list (well-known HA issue), do a 'hard-refresh' of the browser (ctrl-F5) then open the list again.
+Configuration is managed entirely from the Home Assistant UI. Simply go to `Configuration -> Integrations -> Add Integration` and search for <ins>OPNsense</ins> in the search box.
 
 ### OPNsense Device Entry
 
@@ -118,7 +109,7 @@ The official and simplest recommendation is that the service user to be created 
 
 In <ins>OPNsense</ins>, create a new admin role user (or choose an existing admin user) and create an API key associated to the user. When creating the API key, <ins>OPNsense</ins> will download the file containing the API key and API secret to the computer. It will be in the download folder.
 
-### Granular Sync Options
+### Granular Sync
 
 Either at the time of install or in the integration options, Granular Sync Options can be enabled. There, choose the categories to sync with HA as desired. If enabled, the <ins>OPNsense</ins> user can have more narrow permissions.
 
@@ -182,8 +173,8 @@ Many entities are created by `hass-opnsense` for statistics etc. Due to the volu
 
 **All switches are disabled by default**
 
-* Firewall Rules - enable/disable rules (requires OPNsense Firmware 26.1.1+)
-* NAT Rules - enable/disable rules (requires OPNsense Firmware 26.1.1+)
+* Firewall Rules - enable/disable rules *(requires OPNsense Firmware 26.1.1+)*
+* NAT Rules - enable/disable rules *(requires OPNsense Firmware 26.1.1+)*
 * Services - start/stop services
 * VPN Servers and Clients - enable/disable instances
 * Unbound blocklists - enable/disable blocklists

--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ The persistent CARP maintenance switch remains on physical-node entries. Enablin
 
 ### Replacing OPNsense Hardware
 
-Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same. Keeping stale disabled entities is dangerous because they can look valid while referring to hardware that no longer exists.
+Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same.
 
-When an OPNsense device entry reports a device-ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair unloads the entry, removes all current entities and devices for it (including disabled entities), updates the device ID, and schedules a reload to rebuild entities.
+When an OPNsense device entry reports a device-ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair selectively reconciles the registry with the replacement's inventory: matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created.
 
-The repair preserves the URL, credentials, and options. It discards entity registry names, enabled/disabled selections, areas, and other customizations. Recreated entity IDs may differ, so dashboards and automations that reference those IDs may need updates.
+The repair preserves the URL, credentials, and options. A retry marker makes an interrupted repair resumable. Dashboards and automations remain intact for preserved entity IDs; review references to inventory removed during reconciliation.
 
 [commits-shield]: https://img.shields.io/github/last-commit/travisghansen/hass-opnsense?style=for-the-badge
 [commits]: https://github.com/travisghansen/hass-opnsense/commits/main

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ A Discord server to discuss the integration is available. Click the Discord badg
 * [Actions](#actions-services)
 
 * [Known Issues](#known-issues)
-  * [Hardware Changes](#hardware-changes)
+  * [Replacing OPNsense Hardware](#replacing-opnsense-hardware)
 
 ## Installation
 
@@ -235,9 +235,13 @@ The persistent CARP maintenance switch remains on physical-node entries. Enablin
 
 ## Known Issues
 
-### Hardware Changes
+### Replacing OPNsense Hardware
 
-If you partially or fully change the <ins>OPNsense</ins> hardware, it will require a removal and reinstall of this integration. This is to ensure changed interfaces, services, gateways, etc. are accounted for and don't leave duplicate or non-functioning entities.
+Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same. Keeping stale disabled entities is dangerous because they can look valid while referring to hardware that no longer exists.
+
+When an OPNsense device entry reports a device-ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair unloads the entry, removes all current entities and devices for it (including disabled entities), updates the device ID, and schedules a reload to rebuild entities.
+
+The repair preserves the URL, credentials, and options. It discards entity registry names, enabled/disabled selections, areas, and other customizations. Recreated entity IDs may differ, so dashboards and automations that reference those IDs may need updates.
 
 [commits-shield]: https://img.shields.io/github/last-commit/travisghansen/hass-opnsense?style=for-the-badge
 [commits]: https://github.com/travisghansen/hass-opnsense/commits/main

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ A Discord server to discuss the integration is available. Click the Discord badg
 
 * [Actions](#actions-services)
 
-* [Known Issues](#known-issues)
-  * [Replacing OPNsense Hardware](#replacing-opnsense-hardware)
+* [Replacing OPNsense Hardware](#replacing-opnsense-hardware)
 
 ## Installation
 
@@ -233,15 +232,13 @@ The persistent CARP maintenance switch remains on physical-node entries. Enablin
 
 [How to use <ins>action response data</ins> in an HA script or automation](https://www.home-assistant.io/docs/scripts/perform-actions/#use-templates-to-handle-response-data)
 
-## Known Issues
+## Replacing OPNsense Hardware
 
-### Replacing OPNsense Hardware
+Hardware replacement may change a number of OPNsense areas including interfaces, services, gateways, disks, and others.
 
-Hardware replacement is an entity-inventory boundary: interfaces, services, gateways, disks, and other inventory can change even when the connection URL and credentials stay the same.
+When an OPNsense device entry reports a Device ID mismatch, Home Assistant offers a fixable repair. Confirm it once the replacement hardware is reachable and is the intended node. The repair selectively reconciles the registry with the replacement's entities: matching entities and devices retain their registry identity and customizations, entities absent from the replacement are removed, and new entities are created.
 
-When an OPNsense device entry reports a Device ID mismatch, Home Assistant offers a fixable repair. Confirm it only after the replacement hardware is reachable and is the intended node. The repair selectively reconciles the registry with the replacement's inventory: matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created.
-
-The repair preserves the URL, credentials, and options. A retry marker makes an interrupted repair resumable. Dashboards and automations remain intact for preserved entity IDs; review references to inventory removed during reconciliation.
+The repair preserves the URL, credentials, and options. A retry marker makes an interrupted repair resumable. Dashboards and automations remain intact for preserved entity IDs; review references to entities removed during reconciliation.
 
 [commits-shield]: https://img.shields.io/github/last-commit/travisghansen/hass-opnsense?style=for-the-badge
 [commits]: https://github.com/travisghansen/hass-opnsense/commits/main

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -104,13 +104,6 @@ class OPNsenseData:
     should_reload: bool = True
 
 
-@dataclass
-class _ReconciliationForwardingState:
-    """Tracks whether marker-backed forwarding requires runtime retention."""
-
-    preserve_runtime: bool = False
-
-
 def _align_aiopnsense_log_level() -> None:
     """Mirror the integration log level onto aiopnsense when it is unset."""
     aiopnsense_logger = logging.getLogger("aiopnsense")
@@ -143,43 +136,6 @@ def _async_create_marker_repair_issue(
             "new_device_id": repair_marker.new_device_id,
         },
     )
-
-
-async def _async_forward_entry_setups(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    platforms: list[Platform],
-    reconciliation: RepairReconciliation | None,
-    state: _ReconciliationForwardingState | None = None,
-) -> None:
-    """Forward entry setups and restore a marker-backed issue on failure.
-
-    Args:
-        hass: Home Assistant instance.
-        entry: OPNsense config entry being set up.
-        platforms: Platforms to forward for setup.
-        reconciliation: Active Device ID reconciliation, if any.
-        state: Optional mutable state used to report whether runtime should be kept
-            after reconciliation forwarding failure.
-    """
-    if reconciliation is None:
-        await hass.config_entries.async_forward_entry_setups(entry, platforms)
-        return
-
-    forward_completed: bool = False
-    try:
-        await hass.config_entries.async_forward_entry_setups(entry, platforms)
-        forward_completed = True
-    finally:
-        if not forward_completed:
-            _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
-            cleanup_ok: bool = await _unload_setup_platforms_after_reconciliation_failure(
-                hass,
-                entry,
-                platforms,
-            )
-            if state is not None:
-                state.preserve_runtime = not cleanup_ok
 
 
 def _resolve_device_id_probe_state(
@@ -706,17 +662,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
                 return False
 
-            reconciliation_state = _ReconciliationForwardingState()
+            forward_completed = False
             try:
-                await _async_forward_entry_setups(
-                    hass,
-                    entry,
-                    platforms,
-                    reconciliation,
-                    reconciliation_state,
-                )
+                await hass.config_entries.async_forward_entry_setups(entry, platforms)
+                forward_completed = True
             finally:
-                keep_reconciliation_runtime = reconciliation_state.preserve_runtime
+                if not forward_completed:
+                    forwarding_cleanup_ok: bool = await _cleanup_reconciliation_failure(
+                        hass,
+                        entry,
+                        platforms,
+                        reconciliation.marker,
+                    )
+                    keep_reconciliation_runtime = not forwarding_cleanup_ok
             try:
                 reconciliation.require_platforms_complete(platforms)
                 reconciliation.finalize()
@@ -753,7 +711,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 keep_reconciliation_runtime = not cleanup_ok
                 return False
         else:
-            await _async_forward_entry_setups(hass, entry, platforms, reconciliation)
+            await hass.config_entries.async_forward_entry_setups(entry, platforms)
 
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -499,15 +499,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
     repair_marker = parse_repair_marker(entry)
-    if has_repair_marker(entry) and repair_marker is None:
-        _LOGGER.error("OPNsense config entry has a malformed Device ID repair marker")
-        return False
-    if repair_marker is not None and (
-        config_device_id != repair_marker.new_device_id
+    if has_repair_marker(entry) and (
+        repair_marker is None
+        or config_device_id != repair_marker.new_device_id
         or entry.unique_id != repair_marker.new_device_id
     ):
-        _LOGGER.error("OPNsense config entry does not match its Device ID repair marker")
+        marker_error = (
+            "OPNsense config entry has a malformed Device ID repair marker"
+            if repair_marker is None
+            else "OPNsense config entry does not match its Device ID repair marker"
+        )
+        _LOGGER.error("%s", marker_error)
         return False
+    if repair_marker is not None:
+        _async_create_marker_repair_issue(hass, entry, repair_marker)
 
     client: OPNsenseClient | None = None
     try:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -68,7 +68,7 @@ from .migrate import (
     _migrate_3_to_4,
     _migrate_4_to_5,
 )
-from .repairs import async_create_device_id_mismatch_issue
+from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 from .services import async_setup_services
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -416,7 +416,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_device_id,
             router_device_id,
         )
-        if router_device_id != config_device_id and router_device_id:
+        if (
+            is_valid_device_id(config_device_id)
+            and is_valid_device_id(router_device_id)
+            and router_device_id != config_device_id
+        ):
             async_create_device_id_mismatch_issue(hass, entry, router_device_id)
             _LOGGER.error(
                 "OPNsense Device ID has changed which indicates new or changed hardware. "

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -179,7 +179,12 @@ def _resolve_device_id_probe_state(
                 "hass-opnsense is shutting down."
             )
         return False
-    if repair_marker is None:
+    if (
+        repair_marker is None
+        and is_valid_device_id(config_device_id)
+        and is_valid_device_id(router_device_id)
+        and router_device_id == config_device_id
+    ):
         _async_delete_device_id_mismatch_issue(hass, entry)
     return True
 

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -113,16 +113,6 @@ def _align_aiopnsense_log_level() -> None:
     aiopnsense_logger.setLevel(_LOGGER.level)
 
 
-def _async_delete_device_id_mismatch_issue(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Delete a stale nonpersistent device-id mismatch repair issue.
-
-    Args:
-        hass: Home Assistant instance.
-        entry: OPNsense config entry owning the mismatch issue.
-    """
-    ir.async_delete_issue(hass, DOMAIN, build_device_id_mismatch_issue_id(entry.entry_id))
-
-
 def _async_create_marker_repair_issue(
     hass: HomeAssistant, entry: ConfigEntry, repair_marker: RepairMarker
 ) -> None:
@@ -184,7 +174,7 @@ def _resolve_device_id_probe_state(
         and is_valid_device_id(router_device_id)
         and router_device_id == config_device_id
     ):
-        _async_delete_device_id_mismatch_issue(hass, entry)
+        ir.async_delete_issue(hass, DOMAIN, build_device_id_mismatch_issue_id(entry.entry_id))
     return True
 
 

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -199,7 +199,7 @@ async def _unload_setup_platforms_after_reconciliation_failure(
     """Unload forwarded setup platforms when reconciliation aborts."""
     try:
         unloaded: bool = await hass.config_entries.async_unload_platforms(entry, platforms)
-    except HomeAssistantError, KeyError:
+    except HomeAssistantError, KeyError, TimeoutError:
         _LOGGER.exception(
             "Device ID reconciliation cleanup failed for %s; cannot unload entry platforms",
             entry.title,

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -366,7 +366,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_tracker_enabled: bool = options.get(
         CONF_DEVICE_TRACKER_ENABLED, DEFAULT_DEVICE_TRACKER_ENABLED
     )
-    config_device_id: str = config[CONF_DEVICE_UNIQUE_ID]
+    config_device_id = config.get(CONF_DEVICE_UNIQUE_ID)
+    if not is_valid_device_id(config_device_id):
+        _LOGGER.error(
+            "OPNsense config entry has a malformed stored device ID. "
+            "Remove and re-add the integration."
+        )
+        return False
 
     client: OPNsenseClient | None = None
     try:
@@ -421,13 +427,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             and is_valid_device_id(router_device_id)
             and router_device_id != config_device_id
         ):
-            async_create_device_id_mismatch_issue(hass, entry, router_device_id)
-            _LOGGER.error(
-                "OPNsense Device ID has changed which indicates new or changed hardware. "
-                "A fixable repair issue is available to rebuild entities for this "
-                "OPNsense device. "
-                "hass-opnsense is shutting down."
-            )
+            if async_create_device_id_mismatch_issue(hass, entry, router_device_id):
+                _LOGGER.error(
+                    "OPNsense Device ID has changed which indicates new or changed hardware. "
+                    "A fixable repair issue is available to rebuild entities for this "
+                    "OPNsense device. "
+                    "hass-opnsense is shutting down."
+                )
             return False
 
         firmware: str | None = await client.get_host_firmware_version()

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -76,7 +76,11 @@ from .repair_reconciliation import (
     has_repair_marker,
     parse_repair_marker,
 )
-from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
+from .repairs import (
+    async_create_device_id_mismatch_issue,
+    build_device_id_mismatch_issue_id,
+    is_valid_device_id,
+)
 from .services import async_setup_services
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -85,7 +89,6 @@ NATIVE_RULE_ENTITY_TOKENS: tuple[str, ...] = (
     "_firewall_rule_",
     "_firewall_nat_",
 )
-_DEVICE_ID_MISMATCH_ISSUE_SUFFIX = "_device_id_mismatched"
 
 
 @dataclass
@@ -110,11 +113,6 @@ def _align_aiopnsense_log_level() -> None:
     aiopnsense_logger.setLevel(_LOGGER.level)
 
 
-def _build_device_id_mismatch_issue_id(entry_id: str) -> str:
-    """Build the stable mismatch issue ID for a config entry."""
-    return f"{entry_id}{_DEVICE_ID_MISMATCH_ISSUE_SUFFIX}"
-
-
 def _async_delete_device_id_mismatch_issue(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Delete a stale nonpersistent device-id mismatch repair issue.
 
@@ -122,7 +120,7 @@ def _async_delete_device_id_mismatch_issue(hass: HomeAssistant, entry: ConfigEnt
         hass: Home Assistant instance.
         entry: OPNsense config entry owning the mismatch issue.
     """
-    ir.async_delete_issue(hass, DOMAIN, _build_device_id_mismatch_issue_id(entry.entry_id))
+    ir.async_delete_issue(hass, DOMAIN, build_device_id_mismatch_issue_id(entry.entry_id))
 
 
 def _async_create_marker_repair_issue(
@@ -132,7 +130,7 @@ def _async_create_marker_repair_issue(
     ir.async_create_issue(
         hass=hass,
         domain=DOMAIN,
-        issue_id=_build_device_id_mismatch_issue_id(entry.entry_id),
+        issue_id=build_device_id_mismatch_issue_id(entry.entry_id),
         is_fixable=True,
         is_persistent=False,
         severity=ir.IssueSeverity.ERROR,

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -104,6 +104,13 @@ class OPNsenseData:
     should_reload: bool = True
 
 
+@dataclass
+class _ReconciliationForwardingState:
+    """Tracks whether marker-backed forwarding requires runtime retention."""
+
+    preserve_runtime: bool = False
+
+
 def _align_aiopnsense_log_level() -> None:
     """Mirror the integration log level onto aiopnsense when it is unset."""
     aiopnsense_logger = logging.getLogger("aiopnsense")
@@ -143,6 +150,7 @@ async def _async_forward_entry_setups(
     entry: ConfigEntry,
     platforms: list[Platform],
     reconciliation: RepairReconciliation | None,
+    state: _ReconciliationForwardingState | None = None,
 ) -> None:
     """Forward entry setups and restore a marker-backed issue on failure.
 
@@ -151,18 +159,27 @@ async def _async_forward_entry_setups(
         entry: OPNsense config entry being set up.
         platforms: Platforms to forward for setup.
         reconciliation: Active Device ID reconciliation, if any.
+        state: Optional mutable state used to report whether runtime should be kept
+            after reconciliation forwarding failure.
     """
     if reconciliation is None:
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
         return
 
-    forward_completed = False
+    forward_completed: bool = False
     try:
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
         forward_completed = True
     finally:
         if not forward_completed:
             _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
+            cleanup_ok: bool = await _unload_setup_platforms_after_reconciliation_failure(
+                hass,
+                entry,
+                platforms,
+            )
+            if state is not None:
+                state.preserve_runtime = not cleanup_ok
 
 
 def _resolve_device_id_probe_state(
@@ -670,7 +687,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         if device_tracker_enabled and device_tracker_coordinator:
             # Fetch initial data so we have data when entities subscribe
-            await device_tracker_coordinator.async_config_entry_first_refresh()
+            tracker_refreshed: bool = False
+            try:
+                await device_tracker_coordinator.async_config_entry_first_refresh()
+                tracker_refreshed = True
+            finally:
+                if not tracker_refreshed and repair_marker is not None:
+                    _async_create_marker_repair_issue(hass, entry, repair_marker)
 
         if reconciliation is not None:
             try:
@@ -683,8 +706,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
                 return False
 
-        await _async_forward_entry_setups(hass, entry, platforms, reconciliation)
-        if reconciliation is not None:
+            reconciliation_state = _ReconciliationForwardingState()
+            try:
+                await _async_forward_entry_setups(
+                    hass,
+                    entry,
+                    platforms,
+                    reconciliation,
+                    reconciliation_state,
+                )
+            finally:
+                keep_reconciliation_runtime = reconciliation_state.preserve_runtime
             try:
                 reconciliation.require_platforms_complete(platforms)
                 reconciliation.finalize()
@@ -720,6 +752,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     return False
                 keep_reconciliation_runtime = not cleanup_ok
                 return False
+        else:
+            await _async_forward_entry_setups(hass, entry, platforms, reconciliation)
+
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
         setup_succeeded = True

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -159,6 +159,7 @@ def _resolve_device_id_probe_state(
 ) -> bool:
     """Handle marker and mismatch-issue decisions after device-ID probe."""
     if repair_marker is not None and router_device_id != repair_marker.new_device_id:
+        _async_create_marker_repair_issue(hass, entry, repair_marker)
         _LOGGER.error(
             "Device-ID reconciliation probe mismatch for %s: expected %s, got %s",
             entry.title,

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -138,6 +138,21 @@ def _async_create_marker_repair_issue(
     )
 
 
+async def _async_first_refresh_with_marker_issue(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    coordinator: OPNsenseDataUpdateCoordinator,
+    repair_marker: RepairMarker | None,
+) -> None:
+    """Refresh coordinator and recreate a marker-backed issue when setup must retry."""
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady:
+        if repair_marker is not None:
+            _async_create_marker_repair_issue(hass, entry, repair_marker)
+        raise
+
+
 def _resolve_device_id_probe_state(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -606,7 +621,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except awesomeversion.exceptions.AwesomeVersionCompareException, TypeError, ValueError:
             _LOGGER.warning("Unable to confirm OPNsense Firmware version")
 
-        await coordinator.async_config_entry_first_refresh()
+        await _async_first_refresh_with_marker_issue(hass, entry, coordinator, repair_marker)
 
         platforms: list[Platform] = PLATFORMS.copy()
         if not device_tracker_enabled and Platform.DEVICE_TRACKER in platforms:

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -213,11 +213,10 @@ async def _cleanup_reconciliation_failure(
     hass: HomeAssistant,
     entry: ConfigEntry,
     platforms: list[Platform],
-    repair_marker: RepairMarker | None,
+    repair_marker: RepairMarker,
 ) -> bool:
     """Persist marker-backed repair issue and unload any partially loaded platforms."""
-    if repair_marker is not None:
-        _async_create_marker_repair_issue(hass, entry, repair_marker)
+    _async_create_marker_repair_issue(hass, entry, repair_marker)
     return await _unload_setup_platforms_after_reconciliation_failure(hass, entry, platforms)
 
 
@@ -664,8 +663,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Device-ID reconciliation preflight failed for %s; retaining marker",
                     entry.title,
                 )
-                if repair_marker is not None:
-                    _async_create_marker_repair_issue(hass, entry, repair_marker)
+                _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
                 return False
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
@@ -694,7 +692,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         hass,
                         entry,
                         platforms,
-                        repair_marker,
+                        reconciliation.marker,
                     )
                 except HomeAssistantError, KeyError:
                     _LOGGER.exception(

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -70,6 +70,7 @@ from .migrate import (
 )
 from .repair_reconciliation import (
     REPAIR_MARKER_KEY,
+    RepairMarker,
     RepairReconciliation,
     RepairReconciliationError,
     has_repair_marker,
@@ -84,6 +85,7 @@ NATIVE_RULE_ENTITY_TOKENS: tuple[str, ...] = (
     "_firewall_rule_",
     "_firewall_nat_",
 )
+_DEVICE_ID_MISMATCH_ISSUE_SUFFIX = "_device_id_mismatched"
 
 
 @dataclass
@@ -106,6 +108,111 @@ def _align_aiopnsense_log_level() -> None:
         return
 
     aiopnsense_logger.setLevel(_LOGGER.level)
+
+
+def _build_device_id_mismatch_issue_id(entry_id: str) -> str:
+    """Build the stable mismatch issue ID for a config entry."""
+    return f"{entry_id}{_DEVICE_ID_MISMATCH_ISSUE_SUFFIX}"
+
+
+def _async_delete_device_id_mismatch_issue(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Delete a stale nonpersistent device-id mismatch repair issue.
+
+    Args:
+        hass: Home Assistant instance.
+        entry: OPNsense config entry owning the mismatch issue.
+    """
+    ir.async_delete_issue(hass, DOMAIN, _build_device_id_mismatch_issue_id(entry.entry_id))
+
+
+def _async_create_marker_repair_issue(
+    hass: HomeAssistant, entry: ConfigEntry, repair_marker: RepairMarker
+) -> None:
+    """Create a marker-backed nonpersistent mismatch issue for reconciliation retries."""
+    ir.async_create_issue(
+        hass=hass,
+        domain=DOMAIN,
+        issue_id=_build_device_id_mismatch_issue_id(entry.entry_id),
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="device_id_mismatched",
+        translation_placeholders={
+            "entry_title": entry.title,
+            "old_device_id": repair_marker.old_device_id,
+            "new_device_id": repair_marker.new_device_id,
+        },
+        data={
+            "entry_id": entry.entry_id,
+            "old_device_id": repair_marker.old_device_id,
+            "new_device_id": repair_marker.new_device_id,
+        },
+    )
+
+
+def _resolve_device_id_probe_state(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    config_device_id: str | None,
+    router_device_id: str | None,
+    repair_marker: RepairMarker | None,
+) -> bool:
+    """Handle marker and mismatch-issue decisions after device-ID probe."""
+    if repair_marker is not None and router_device_id != repair_marker.new_device_id:
+        _LOGGER.error(
+            "Device-ID reconciliation probe mismatch for %s: expected %s, got %s",
+            entry.title,
+            repair_marker.new_device_id,
+            router_device_id,
+        )
+        return False
+    if (
+        is_valid_device_id(config_device_id)
+        and is_valid_device_id(router_device_id)
+        and router_device_id != config_device_id
+    ):
+        if async_create_device_id_mismatch_issue(hass, entry, router_device_id):
+            _LOGGER.error(
+                "OPNsense Device ID has changed which indicates new or changed hardware. "
+                "A fixable repair issue is available to rebuild entities for this "
+                "OPNsense device. "
+                "hass-opnsense is shutting down."
+            )
+        return False
+    if repair_marker is None:
+        _async_delete_device_id_mismatch_issue(hass, entry)
+    return True
+
+
+async def _unload_setup_platforms_after_reconciliation_failure(
+    hass: HomeAssistant, entry: ConfigEntry, platforms: list[Platform]
+) -> None:
+    """Unload forwarded setup platforms when reconciliation aborts."""
+    try:
+        unloaded: bool = await hass.config_entries.async_unload_platforms(entry, platforms)
+    except HomeAssistantError, KeyError:
+        _LOGGER.exception(
+            "Device-ID reconciliation cleanup failed for %s; cannot unload entry platforms",
+            entry.title,
+        )
+        return
+    if not unloaded:
+        _LOGGER.debug(
+            "Device-ID reconciliation cleanup could not unload all platforms for %s",
+            entry.title,
+        )
+
+
+async def _cleanup_reconciliation_failure(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    platforms: list[Platform],
+    repair_marker: RepairMarker | None,
+) -> None:
+    """Persist marker-backed repair issue and unload any partially loaded platforms."""
+    if repair_marker is not None:
+        _async_create_marker_repair_issue(hass, entry, repair_marker)
+    await _unload_setup_platforms_after_reconciliation_failure(hass, entry, platforms)
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -440,26 +547,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_device_id,
             router_device_id,
         )
-        if repair_marker is not None and router_device_id != repair_marker.new_device_id:
-            _LOGGER.error(
-                "Device-ID reconciliation probe mismatch for %s: expected %s, got %s",
-                entry.title,
-                repair_marker.new_device_id,
-                router_device_id,
-            )
-            return False
-        if (
-            is_valid_device_id(config_device_id)
-            and is_valid_device_id(router_device_id)
-            and router_device_id != config_device_id
+        if not _resolve_device_id_probe_state(
+            hass,
+            entry,
+            config_device_id,
+            router_device_id,
+            repair_marker,
         ):
-            if async_create_device_id_mismatch_issue(hass, entry, router_device_id):
-                _LOGGER.error(
-                    "OPNsense Device ID has changed which indicates new or changed hardware. "
-                    "A fixable repair issue is available to rebuild entities for this "
-                    "OPNsense device. "
-                    "hass-opnsense is shutting down."
-                )
             return False
 
         firmware: str | None = await client.get_host_firmware_version()
@@ -563,6 +657,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Device-ID reconciliation preflight failed for %s; retaining marker",
                     entry.title,
                 )
+                if repair_marker is not None:
+                    _async_create_marker_repair_issue(hass, entry, repair_marker)
                 return False
 
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
@@ -585,6 +681,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _LOGGER.exception(
                     "Device-ID reconciliation cleanup failed for %s; retaining marker",
                     entry.title,
+                )
+                await _cleanup_reconciliation_failure(
+                    hass,
+                    entry,
+                    platforms,
+                    repair_marker,
                 )
                 return False
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -191,7 +191,7 @@ def _resolve_device_id_probe_state(
 
 async def _unload_setup_platforms_after_reconciliation_failure(
     hass: HomeAssistant, entry: ConfigEntry, platforms: list[Platform]
-) -> None:
+) -> bool:
     """Unload forwarded setup platforms when reconciliation aborts."""
     try:
         unloaded: bool = await hass.config_entries.async_unload_platforms(entry, platforms)
@@ -200,12 +200,14 @@ async def _unload_setup_platforms_after_reconciliation_failure(
             "Device-ID reconciliation cleanup failed for %s; cannot unload entry platforms",
             entry.title,
         )
-        return
+        return False
     if not unloaded:
         _LOGGER.debug(
             "Device-ID reconciliation cleanup could not unload all platforms for %s",
             entry.title,
         )
+        return False
+    return True
 
 
 async def _cleanup_reconciliation_failure(
@@ -213,11 +215,11 @@ async def _cleanup_reconciliation_failure(
     entry: ConfigEntry,
     platforms: list[Platform],
     repair_marker: RepairMarker | None,
-) -> None:
+) -> bool:
     """Persist marker-backed repair issue and unload any partially loaded platforms."""
     if repair_marker is not None:
         _async_create_marker_repair_issue(hass, entry, repair_marker)
-    await _unload_setup_platforms_after_reconciliation_failure(hass, entry, platforms)
+    return await _unload_setup_platforms_after_reconciliation_failure(hass, entry, platforms)
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -542,6 +544,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     device_tracker_coordinator: OPNsenseDataUpdateCoordinator | None = None
 
     setup_succeeded: bool = False
+    keep_reconciliation_runtime: bool = False
     try:
         # Trigger repair task and shutdown if device id has changed
         router_device_id: str | None = await client.get_device_unique_id(
@@ -687,19 +690,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "Device-ID reconciliation cleanup failed for %s; retaining marker",
                     entry.title,
                 )
-                await _cleanup_reconciliation_failure(
-                    hass,
-                    entry,
-                    platforms,
-                    repair_marker,
-                )
+                try:
+                    cleanup_ok: bool = await _cleanup_reconciliation_failure(
+                        hass,
+                        entry,
+                        platforms,
+                        repair_marker,
+                    )
+                except HomeAssistantError, KeyError:
+                    _LOGGER.exception(
+                        "Device-ID reconciliation cleanup raised while handling %s",
+                        entry.title,
+                    )
+                    keep_reconciliation_runtime = True
+                    return False
+                keep_reconciliation_runtime = not cleanup_ok
                 return False
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
         setup_succeeded = True
         return True
     finally:
-        if not setup_succeeded:
+        if not setup_succeeded and not keep_reconciliation_runtime:
             entry.runtime_data = None
             if device_tracker_coordinator is not None:
                 await device_tracker_coordinator.async_shutdown()

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -466,6 +466,45 @@ async def _async_setup_carp_entry(hass: HomeAssistant, entry: ConfigEntry) -> bo
                 await client.async_close()
 
 
+async def _async_create_validated_client(hass: HomeAssistant, entry: ConfigEntry) -> OPNsenseClient:
+    """Create and validate a client, closing it when validation fails.
+
+    Args:
+        hass: Home Assistant instance.
+        entry: Config entry containing OPNsense connection credentials.
+
+    Returns:
+        OPNsenseClient: A validated client ready for coordinator setup.
+
+    Raises:
+        ConfigEntryNotReady: If a transient connection failure prevents validation.
+        OPNsenseError: If validation fails with a non-retryable client error.
+        TimeoutError: If validation raises a raw timeout.
+    """
+    client = create_opnsense_client_from_config_entry(hass=hass, config_entry=entry)
+    try:
+        try:
+            await client.validate()
+        except OPNsenseMissingDeviceUniqueID:
+            _LOGGER.debug(
+                "Client validation reported missing Device ID; continuing to Device ID probes"
+            )
+        except OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware:
+            _LOGGER.debug(
+                "Client validation reported firmware issues; continuing to firmware probes"
+            )
+        except OPNsenseTimeoutError as err:
+            raise ConfigEntryNotReady("OPNsense validation timed out") from err
+        except OPNsenseConnectionError as err:
+            if type(err) is not OPNsenseConnectionError:
+                raise
+            raise ConfigEntryNotReady("OPNsense validation could not complete") from err
+    except ConfigEntryNotReady, TimeoutError, OPNsenseError:
+        await client.async_close()
+        raise
+    return client
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up an OPNsense config entry and its runtime resources.
 
@@ -514,29 +553,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if repair_marker is not None:
         _async_create_marker_repair_issue(hass, entry, repair_marker)
 
-    client: OPNsenseClient | None = None
-    try:
-        client = create_opnsense_client_from_config_entry(hass=hass, config_entry=entry)
-        try:
-            await client.validate()
-        except OPNsenseMissingDeviceUniqueID:
-            _LOGGER.debug(
-                "Client validation reported missing Device ID; continuing to Device ID probes"
-            )
-        except OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware:
-            _LOGGER.debug(
-                "Client validation reported firmware issues; continuing to firmware probes"
-            )
-        except OPNsenseTimeoutError as err:
-            raise ConfigEntryNotReady("OPNsense validation timed out") from err
-        except OPNsenseConnectionError as err:
-            if type(err) is not OPNsenseConnectionError:
-                raise
-            raise ConfigEntryNotReady("OPNsense validation could not complete") from err
-    except ConfigEntryNotReady, TimeoutError, OPNsenseError:
-        if client is not None:
-            await client.async_close()
-        raise
+    client = await _async_create_validated_client(hass, entry)
 
     scan_interval: int = options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     _LOGGER.info("Starting hass-opnsense %s", VERSION)

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -68,6 +68,7 @@ from .migrate import (
     _migrate_3_to_4,
     _migrate_4_to_5,
 )
+from .repairs import async_create_device_id_mismatch_issue
 from .services import async_setup_services
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -416,19 +417,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             router_device_id,
         )
         if router_device_id != config_device_id and router_device_id:
-            ir.async_create_issue(
-                hass=hass,
-                domain=DOMAIN,
-                issue_id=f"{config_device_id}_device_id_mismatched",
-                is_fixable=False,
-                is_persistent=False,
-                severity=ir.IssueSeverity.ERROR,
-                translation_key="device_id_mismatched",
-            )
+            async_create_device_id_mismatch_issue(hass, entry, router_device_id)
             _LOGGER.error(
                 "OPNsense Device ID has changed which indicates new or changed hardware. "
-                "In order to accommodate this, hass-opnsense needs to be removed "
-                "and reinstalled for this router. "
+                "A fixable repair issue is available to rebuild entities for this "
+                "OPNsense device. "
                 "hass-opnsense is shutting down."
             )
             return False

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -150,7 +150,7 @@ async def _async_forward_entry_setups(
         hass: Home Assistant instance.
         entry: OPNsense config entry being set up.
         platforms: Platforms to forward for setup.
-        reconciliation: Active device-ID reconciliation, if any.
+        reconciliation: Active Device ID reconciliation, if any.
     """
     if reconciliation is None:
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
@@ -172,11 +172,11 @@ def _resolve_device_id_probe_state(
     router_device_id: str | None,
     repair_marker: RepairMarker | None,
 ) -> bool:
-    """Handle marker and mismatch-issue decisions after device-ID probe."""
+    """Handle marker and mismatch-issue decisions after Device ID probe."""
     if repair_marker is not None and router_device_id != repair_marker.new_device_id:
         _async_create_marker_repair_issue(hass, entry, repair_marker)
         _LOGGER.error(
-            "Device-ID reconciliation probe mismatch for %s: expected %s, got %s",
+            "Device ID reconciliation probe mismatch for %s: expected %s, got %s",
             entry.title,
             repair_marker.new_device_id,
             router_device_id,
@@ -213,13 +213,13 @@ async def _unload_setup_platforms_after_reconciliation_failure(
         unloaded: bool = await hass.config_entries.async_unload_platforms(entry, platforms)
     except HomeAssistantError, KeyError:
         _LOGGER.exception(
-            "Device-ID reconciliation cleanup failed for %s; cannot unload entry platforms",
+            "Device ID reconciliation cleanup failed for %s; cannot unload entry platforms",
             entry.title,
         )
         return False
     if not unloaded:
         _LOGGER.debug(
-            "Device-ID reconciliation cleanup could not unload all platforms for %s",
+            "Device ID reconciliation cleanup could not unload all platforms for %s",
             entry.title,
         )
         return False
@@ -512,13 +512,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
     repair_marker = parse_repair_marker(entry)
     if has_repair_marker(entry) and repair_marker is None:
-        _LOGGER.error("OPNsense config entry has a malformed device-ID repair marker")
+        _LOGGER.error("OPNsense config entry has a malformed Device ID repair marker")
         return False
     if repair_marker is not None and (
         config_device_id != repair_marker.new_device_id
         or entry.unique_id != repair_marker.new_device_id
     ):
-        _LOGGER.error("OPNsense config entry does not match its device-ID repair marker")
+        _LOGGER.error("OPNsense config entry does not match its Device ID repair marker")
         return False
 
     client: OPNsenseClient | None = None
@@ -528,7 +528,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             await client.validate()
         except OPNsenseMissingDeviceUniqueID:
             _LOGGER.debug(
-                "Client validation reported missing device id; continuing to device-id probes"
+                "Client validation reported missing Device ID; continuing to Device ID probes"
             )
         except OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware:
             _LOGGER.debug(
@@ -561,12 +561,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     setup_succeeded: bool = False
     keep_reconciliation_runtime: bool = False
     try:
-        # Trigger repair task and shutdown if device id has changed
+        # Trigger repair task and shutdown if Device ID has changed
         router_device_id: str | None = await client.get_device_unique_id(
             expected_id=config_device_id
         )
         _LOGGER.debug(
-            "[init async_setup_entry]: config device id: %s, router device id: %s",
+            "[init async_setup_entry]: config Device ID: %s, router Device ID: %s",
             config_device_id,
             router_device_id,
         )
@@ -677,7 +677,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 reconciliation.prepare()
             except RepairReconciliationError:
                 _LOGGER.exception(
-                    "Device-ID reconciliation preflight failed for %s; retaining marker",
+                    "Device ID reconciliation preflight failed for %s; retaining marker",
                     entry.title,
                 )
                 _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
@@ -701,7 +701,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 reconciliation.mark_complete()
             except RepairReconciliationError:
                 _LOGGER.exception(
-                    "Device-ID reconciliation cleanup failed for %s; retaining marker",
+                    "Device ID reconciliation cleanup failed for %s; retaining marker",
                     entry.title,
                 )
                 try:
@@ -713,7 +713,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     )
                 except HomeAssistantError, KeyError:
                     _LOGGER.exception(
-                        "Device-ID reconciliation cleanup raised while handling %s",
+                        "Device ID reconciliation cleanup raised while handling %s",
                         entry.title,
                     )
                     keep_reconciliation_runtime = True
@@ -824,7 +824,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 _LOGGER.warning("Deferring migration due to an OPNsense client error")
                 return False
 
-        # 2 -> 3: Change unique device id to use lowest MAC address
+        # 2 -> 3: Change unique Device ID to use lowest MAC address
         if version == 2:
             if migration_client is None:
                 _LOGGER.error("Missing migration client for Migration to Version 3")

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -138,6 +138,33 @@ def _async_create_marker_repair_issue(
     )
 
 
+async def _async_forward_entry_setups(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    platforms: list[Platform],
+    reconciliation: RepairReconciliation | None,
+) -> None:
+    """Forward entry setups and restore a marker-backed issue on failure.
+
+    Args:
+        hass: Home Assistant instance.
+        entry: OPNsense config entry being set up.
+        platforms: Platforms to forward for setup.
+        reconciliation: Active device-ID reconciliation, if any.
+    """
+    if reconciliation is None:
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        return
+
+    forward_completed = False
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        forward_completed = True
+    finally:
+        if not forward_completed:
+            _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
+
+
 def _resolve_device_id_probe_state(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -656,7 +683,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 _async_create_marker_repair_issue(hass, entry, reconciliation.marker)
                 return False
 
-        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        await _async_forward_entry_setups(hass, entry, platforms, reconciliation)
         if reconciliation is not None:
             try:
                 reconciliation.require_platforms_complete(platforms)

--- a/custom_components/opnsense/__init__.py
+++ b/custom_components/opnsense/__init__.py
@@ -24,7 +24,7 @@ import awesomeversion
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -68,6 +68,13 @@ from .migrate import (
     _migrate_3_to_4,
     _migrate_4_to_5,
 )
+from .repair_reconciliation import (
+    REPAIR_MARKER_KEY,
+    RepairReconciliation,
+    RepairReconciliationError,
+    has_repair_marker,
+    parse_repair_marker,
+)
 from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 from .services import async_setup_services
 
@@ -88,6 +95,7 @@ class OPNsenseData:
     opnsense_client: OPNsenseClient
     loaded_platforms: list[Platform]
     device_unique_id: str | None
+    repair_reconciliation: RepairReconciliation | None = None
     should_reload: bool = True
 
 
@@ -373,6 +381,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Remove and re-add the integration."
         )
         return False
+    repair_marker = parse_repair_marker(entry)
+    if has_repair_marker(entry) and repair_marker is None:
+        _LOGGER.error("OPNsense config entry has a malformed device-ID repair marker")
+        return False
+    if repair_marker is not None and (
+        config_device_id != repair_marker.new_device_id
+        or entry.unique_id != repair_marker.new_device_id
+    ):
+        _LOGGER.error("OPNsense config entry does not match its device-ID repair marker")
+        return False
 
     client: OPNsenseClient | None = None
     try:
@@ -422,6 +440,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             config_device_id,
             router_device_id,
         )
+        if repair_marker is not None and router_device_id != repair_marker.new_device_id:
+            _LOGGER.error(
+                "Device-ID reconciliation probe mismatch for %s: expected %s, got %s",
+                entry.title,
+                repair_marker.new_device_id,
+                router_device_id,
+            )
+            return False
         if (
             is_valid_device_id(config_device_id)
             and is_valid_device_id(router_device_id)
@@ -513,19 +539,54 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data.setdefault(DOMAIN, {})
         hass.data[DOMAIN][entry.entry_id] = client
 
+        reconciliation = (
+            RepairReconciliation(hass, entry, repair_marker) if repair_marker is not None else None
+        )
         entry.runtime_data = OPNsenseData(
             coordinator=coordinator,
             device_tracker_coordinator=device_tracker_coordinator,
             opnsense_client=client,
             device_unique_id=config_device_id,
             loaded_platforms=platforms,
+            repair_reconciliation=reconciliation,
         )
 
         if device_tracker_enabled and device_tracker_coordinator:
             # Fetch initial data so we have data when entities subscribe
             await device_tracker_coordinator.async_config_entry_first_refresh()
 
+        if reconciliation is not None:
+            try:
+                reconciliation.prepare()
+            except RepairReconciliationError:
+                _LOGGER.exception(
+                    "Device-ID reconciliation preflight failed for %s; retaining marker",
+                    entry.title,
+                )
+                return False
+
         await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        if reconciliation is not None:
+            try:
+                reconciliation.require_platforms_complete(platforms)
+                reconciliation.finalize()
+                repaired_data = dict(entry.data)
+                repaired_data.pop(REPAIR_MARKER_KEY, None)
+                try:
+                    marker_cleared = hass.config_entries.async_update_entry(
+                        entry, data=repaired_data
+                    )
+                except (HomeAssistantError, KeyError) as err:
+                    raise RepairReconciliationError("repair marker clearance failed") from err
+                if not marker_cleared:
+                    raise RepairReconciliationError("repair marker clearance failed")
+                reconciliation.mark_complete()
+            except RepairReconciliationError:
+                _LOGGER.exception(
+                    "Device-ID reconciliation cleanup failed for %s; retaining marker",
+                    entry.title,
+                )
+                return False
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
         setup_succeeded = True

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -176,13 +176,33 @@ async def async_setup_entry(
         async_add_entities: Callback used to register new entities.
     """
     coordinator: OPNsenseDataUpdateCoordinator = getattr(config_entry.runtime_data, COORDINATOR)
+    state: Any = coordinator.data
+    if not isinstance(state, MutableMapping):
+        _LOGGER.error("Missing state data in binary sensor async_setup_entry")
+        return
     config: Mapping[str, Any] = config_entry.data
+    reconciliation_complete = True
 
     entities: list = []
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_interface_enabled_binary_sensors(config_entry, coordinator))
+        if "interfaces" in state and isinstance(state.get("interfaces"), Mapping):
+            entities.extend(
+                await _compile_interface_enabled_binary_sensors(config_entry, coordinator)
+            )
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_smart_status_binary_sensors(config_entry, coordinator))
+        smart_data = state.get("smart")
+        smart_info = state.get("smart_info")
+        if (
+            "smart" in state
+            and isinstance(smart_data, list)
+            and "smart_info" in state
+            and isinstance(smart_info, Mapping)
+        ):
+            entities.extend(await _compile_smart_status_binary_sensors(config_entry, coordinator))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_NOTICES, DEFAULT_SYNC_OPTION_VALUE):
         entities.append(
             OPNsensePendingNoticesPresentBinarySensor(
@@ -191,7 +211,9 @@ async def async_setup_entry(
                 entity_description=_build_pending_notices_present_binary_sensor_description(),
             ),
         )
-    record_desired_entities(config_entry, "binary_sensor", entities)
+    record_desired_entities(
+        config_entry, "binary_sensor", entities if reconciliation_complete else None
+    )
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -24,6 +24,7 @@ from .const import (
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import coerce_bool, dict_get, get_smart_device_name
+from .repair_reconciliation import record_desired_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -190,6 +191,7 @@ async def async_setup_entry(
                 entity_description=_build_pending_notices_present_binary_sensor_description(),
             ),
         )
+    record_desired_entities(config_entry, "binary_sensor", entities)
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -36,11 +36,7 @@ def _is_valid_interface_row(interface_name: Any, interface: Any) -> bool:
 
 def _is_valid_smart_device_row(smart_device: Any) -> bool:
     """Return whether a SMART device row can produce a binary sensor."""
-    return (
-        isinstance(smart_device, Mapping)
-        and isinstance(smart_device.get("device"), str)
-        and bool(smart_device["device"].strip())
-    )
+    return isinstance(smart_device, Mapping) and bool(get_smart_device_name(smart_device))
 
 
 def _smart_device_slug(device_name: str) -> str:
@@ -175,8 +171,7 @@ async def _compile_smart_status_binary_sensors(
     for smart_device in smart_devices:
         if not _is_valid_smart_device_row(smart_device):
             continue
-        device_name = smart_device["device"]
-        device_name = device_name.strip()
+        device_name = get_smart_device_name(smart_device)
 
         entities.append(
             OPNsenseSmartStatusBinarySensor(

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -29,6 +29,32 @@ from .repair_reconciliation import record_desired_entities
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _is_valid_interface_row(interface_name: Any, interface: Any) -> bool:
+    """Return whether an interface row can produce a binary sensor."""
+    return isinstance(interface_name, str) and isinstance(interface, Mapping)
+
+
+def _is_valid_smart_device_row(smart_device: Any) -> bool:
+    """Return whether a SMART device row can produce a binary sensor."""
+    return (
+        isinstance(smart_device, Mapping)
+        and isinstance(smart_device.get("device"), str)
+        and bool(smart_device["device"].strip())
+    )
+
+
+def _smart_device_slug(device_name: str) -> str:
+    """Return the entity key slug for a SMART device name.
+
+    Args:
+        device_name: SMART device name to normalize.
+
+    Returns:
+        The slugified device name, or ``unknown`` when slugification fails.
+    """
+    return slugify(device_name) or "unknown"
+
+
 def _build_interface_enabled_binary_sensor_description(
     interface_name: str,
     interface: Mapping[str, Any],
@@ -108,7 +134,7 @@ async def _compile_interface_enabled_binary_sensors(
 
     entities: list = []
     for interface_name, interface in interfaces.items():
-        if not isinstance(interface_name, str) or not isinstance(interface, Mapping):
+        if not _is_valid_interface_row(interface_name, interface):
             continue
 
         entities.append(
@@ -147,11 +173,10 @@ async def _compile_smart_status_binary_sensors(
 
     entities: list = []
     for smart_device in smart_devices:
-        if not isinstance(smart_device, Mapping):
+        if not _is_valid_smart_device_row(smart_device):
             continue
-        device_name = get_smart_device_name(smart_device)
-        if not device_name:
-            continue
+        device_name = smart_device["device"]
+        device_name = device_name.strip()
 
         entities.append(
             OPNsenseSmartStatusBinarySensor(
@@ -185,16 +210,24 @@ async def async_setup_entry(
 
     entities: list = []
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
-        if "interfaces" in state and isinstance(state.get("interfaces"), Mapping):
+        interfaces = state.get("interfaces")
+        if "interfaces" in state and isinstance(interfaces, Mapping):
             entities.extend(
                 await _compile_interface_enabled_binary_sensors(config_entry, coordinator)
             )
+            if not all(
+                _is_valid_interface_row(interface_name, interface)
+                for interface_name, interface in interfaces.items()
+            ):
+                reconciliation_complete = False
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
         smart_data = state.get("smart")
         if "smart" in state and isinstance(smart_data, list):
             entities.extend(await _compile_smart_status_binary_sensors(config_entry, coordinator))
+            if not all(_is_valid_smart_device_row(device) for device in smart_data):
+                reconciliation_complete = False
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_NOTICES, DEFAULT_SYNC_OPTION_VALUE):

--- a/custom_components/opnsense/binary_sensor.py
+++ b/custom_components/opnsense/binary_sensor.py
@@ -193,13 +193,7 @@ async def async_setup_entry(
             reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
         smart_data = state.get("smart")
-        smart_info = state.get("smart_info")
-        if (
-            "smart" in state
-            and isinstance(smart_data, list)
-            and "smart_info" in state
-            and isinstance(smart_info, Mapping)
-        ):
+        if "smart" in state and isinstance(smart_data, list):
             entities.extend(await _compile_smart_status_binary_sensors(config_entry, coordinator))
         else:
             reconciliation_complete = False

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -265,6 +265,10 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         ):
             return True
         runtime_device_id = self._state.get("device_unique_id")
+        if not is_valid_device_id(self._device_unique_id):
+            _LOGGER.warning("Coordinator has a malformed configured OPNsense Router Unique ID")
+            self._mismatched_count = 0
+            return False
         if not is_valid_device_id(runtime_device_id):
             _LOGGER.warning("Coordinator received malformed OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0
@@ -284,18 +288,20 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             self._mismatched_count += 1
             # Trigger repair task and shutdown if this happens 3 times in a row
             if self._mismatched_count == 3:
-                if self.config_entry is not None:
+                repair_issue_created = self.config_entry is not None and (
                     async_create_device_id_mismatch_issue(
                         self.hass,
                         self.config_entry,
                         runtime_device_id,
                     )
-                _LOGGER.error(
-                    "OPNsense Device ID has changed which indicates new or changed hardware. "
-                    "A fixable repair issue is available to rebuild entities for this "
-                    "OPNsense device. "
-                    "hass-opnsense is shutting down."
                 )
+                if repair_issue_created:
+                    _LOGGER.error(
+                        "OPNsense Device ID has changed which indicates new or changed hardware. "
+                        "A fixable repair issue is available to rebuild entities for this "
+                        "OPNsense device. "
+                        "hass-opnsense is shutting down."
+                    )
                 await self.async_shutdown()
             return False
         self._mismatched_count = 0

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -34,7 +34,11 @@ from .const import (
 )
 from .helpers import dict_get, get_smart_device_name, is_carp_entry
 from .repair_reconciliation import has_repair_marker
-from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
+from .repairs import (
+    async_create_device_id_mismatch_issue,
+    build_device_id_mismatch_issue_id,
+    is_valid_device_id,
+)
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -312,7 +316,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             ir.async_delete_issue(
                 self.hass,
                 DOMAIN,
-                f"{config_entry.entry_id}_device_id_mismatched",
+                build_device_id_mismatch_issue_id(config_entry.entry_id),
             )
         self._mismatched_count = 0
         return True

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -294,7 +294,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             )
             self._mismatched_count += 1
             # Trigger repair task and shutdown if this happens 3 times in a row
-            if self._mismatched_count == 3:
+            if self._mismatched_count >= 3:
                 repair_issue_created = self.config_entry is not None and (
                     async_create_device_id_mismatch_issue(
                         self.hass,
@@ -309,7 +309,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                         "OPNsense device. "
                         "hass-opnsense is shutting down."
                     )
-                await self.async_shutdown()
+                    await self.async_shutdown()
             return False
         config_entry = self.config_entry
         if config_entry is not None and not has_repair_marker(config_entry):

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -282,7 +282,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             return False
         if runtime_device_id != self._device_unique_id:
             _LOGGER.debug(
-                "[Coordinator async_update_data]: config device id: %s, router device id: %s",
+                "[Coordinator async_update_data]: config Device ID: %s, router Device ID: %s",
                 self._device_unique_id,
                 runtime_device_id,
             )

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -31,7 +31,7 @@ from .const import (
     DEFAULT_SYNC_OPTION_VALUE,
 )
 from .helpers import dict_get, get_smart_device_name, is_carp_entry
-from .repairs import async_create_device_id_mismatch_issue
+from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -265,8 +265,8 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
         ):
             return True
         runtime_device_id = self._state.get("device_unique_id")
-        if not isinstance(runtime_device_id, str) or not runtime_device_id:
-            _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
+        if not is_valid_device_id(runtime_device_id):
+            _LOGGER.warning("Coordinator received malformed OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0
             return False
         if runtime_device_id != self._device_unique_id:

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -264,20 +264,21 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             and is_carp_entry(self.config_entry)
         ):
             return True
-        if self._state.get("device_unique_id") is None:
+        runtime_device_id = self._state.get("device_unique_id")
+        if not isinstance(runtime_device_id, str) or not runtime_device_id:
             _LOGGER.warning("Coordinator failed to confirm OPNsense Router Unique ID. Will retry")
             self._mismatched_count = 0
             return False
-        if self._state.get("device_unique_id") != self._device_unique_id:
+        if runtime_device_id != self._device_unique_id:
             _LOGGER.debug(
                 "[Coordinator async_update_data]: config device id: %s, router device id: %s",
                 self._device_unique_id,
-                self._state.get("device_unique_id"),
+                runtime_device_id,
             )
             _LOGGER.error(
                 "Coordinator error. "
                 "OPNsense Router Device ID (%s) differs from the one saved in hass-opnsense (%s)",
-                self._state.get("device_unique_id"),
+                runtime_device_id,
                 self._device_unique_id,
             )
             self._mismatched_count += 1
@@ -287,7 +288,7 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     async_create_device_id_mismatch_issue(
                         self.hass,
                         self.config_entry,
-                        self._state["device_unique_id"],
+                        runtime_device_id,
                     )
                 _LOGGER.error(
                     "OPNsense Device ID has changed which indicates new or changed hardware. "

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -30,9 +29,9 @@ from .const import (
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     DEFAULT_SYNC_OPTION_VALUE,
-    DOMAIN,
 )
 from .helpers import dict_get, get_smart_device_name, is_carp_entry
+from .repairs import async_create_device_id_mismatch_issue
 
 if TYPE_CHECKING:
     from aiopnsense import OPNsenseClient
@@ -284,19 +283,16 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
             self._mismatched_count += 1
             # Trigger repair task and shutdown if this happens 3 times in a row
             if self._mismatched_count == 3:
-                ir.async_create_issue(
-                    hass=self.hass,
-                    domain=DOMAIN,
-                    issue_id=f"{self._device_unique_id}_device_id_mismatched",
-                    is_fixable=False,
-                    is_persistent=False,
-                    severity=ir.IssueSeverity.ERROR,
-                    translation_key="device_id_mismatched",
-                )
+                if self.config_entry is not None:
+                    async_create_device_id_mismatch_issue(
+                        self.hass,
+                        self.config_entry,
+                        self._state["device_unique_id"],
+                    )
                 _LOGGER.error(
                     "OPNsense Device ID has changed which indicates new or changed hardware. "
-                    "In order to accommodate this, hass-opnsense needs to be removed and "
-                    "reinstalled for this router. "
+                    "A fixable repair issue is available to rebuild entities for this "
+                    "OPNsense device. "
                     "hass-opnsense is shutting down."
                 )
                 await self.async_shutdown()

--- a/custom_components/opnsense/coordinator.py
+++ b/custom_components/opnsense/coordinator.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -29,8 +30,10 @@ from .const import (
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     DEFAULT_SYNC_OPTION_VALUE,
+    DOMAIN,
 )
 from .helpers import dict_get, get_smart_device_name, is_carp_entry
+from .repair_reconciliation import has_repair_marker
 from .repairs import async_create_device_id_mismatch_issue, is_valid_device_id
 
 if TYPE_CHECKING:
@@ -304,6 +307,13 @@ class OPNsenseDataUpdateCoordinator(DataUpdateCoordinator):
                     )
                 await self.async_shutdown()
             return False
+        config_entry = self.config_entry
+        if config_entry is not None and not has_repair_marker(config_entry):
+            ir.async_delete_issue(
+                self.hass,
+                DOMAIN,
+                f"{config_entry.entry_id}_device_id_mismatched",
+            )
         self._mismatched_count = 0
         return True
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -139,6 +139,27 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
     return devices, mac_addresses
 
 
+def _track_all_arp_entries_are_complete(arp_entries: list[Any]) -> bool:
+    """Return whether every ARP row can produce at least one tracked MAC in track-all mode.
+
+    Args:
+        arp_entries: Raw ARP entries returned by OPNsense.
+
+    Returns:
+        ``True`` when each row is a mapping with a usable MAC address.
+    """
+    seen_macs: list[str] = []
+    for arp_entry in arp_entries:
+        if not isinstance(arp_entry, MutableMapping):
+            return False
+        mac_address = get_arp_mac(arp_entry)
+        normalized_mac = _normalize_mac_for_device_tracker(mac_address) if mac_address else None
+        if not mac_address or not normalized_mac or normalized_mac in seen_macs:
+            return False
+        seen_macs.append(normalized_mac)
+    return True
+
+
 def _hostname_from_arp_entry(entry: MutableMapping[str, Any]) -> str | None:
     """Return the normalized hostname from an ARP entry.
 
@@ -274,6 +295,8 @@ async def async_setup_entry(
         if not has_configured_macs:
             reconciliation_complete = False
         arp_entries = []
+    elif not has_configured_macs:
+        reconciliation_complete = _track_all_arp_entries_are_complete(arp_entries)
     devices, mac_addresses, enabled_default = _compile_tracked_devices(config_entry, arp_entries)
 
     for device in devices:

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -140,22 +140,25 @@ def _devices_from_arp_entries(arp_entries: list[Any]) -> tuple[list[dict[str, An
 
 
 def _track_all_arp_entries_are_complete(arp_entries: list[Any]) -> bool:
-    """Return whether every ARP row can produce at least one tracked MAC in track-all mode.
+    """Return whether every non-entity ARP row is skippable in track-all mode.
 
     Args:
         arp_entries: Raw ARP entries returned by OPNsense.
 
     Returns:
-        ``True`` when each row is a mapping with a usable MAC address.
+        ``True`` when every row is a mapping and any row with a normalizable MAC
+        contributes a unique MAC address.
     """
     seen_macs: list[str] = []
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
             return False
         mac_address = get_arp_mac(arp_entry)
-        normalized_mac = _normalize_mac_for_device_tracker(mac_address) if mac_address else None
-        if not mac_address or not normalized_mac:
-            return False
+        if not mac_address:
+            continue
+        normalized_mac = _normalize_mac_for_device_tracker(mac_address)
+        if not normalized_mac:
+            continue
         if normalized_mac in seen_macs:
             continue
         seen_macs.append(normalized_mac)

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -149,7 +149,7 @@ def _track_all_arp_entries_are_complete(arp_entries: list[Any]) -> bool:
         ``True`` when every row is a mapping and any row with a normalizable MAC
         contributes a unique MAC address.
     """
-    seen_macs: list[str] = []
+    seen_macs: set[str] = set()
     for arp_entry in arp_entries:
         if not isinstance(arp_entry, MutableMapping):
             return False
@@ -161,7 +161,7 @@ def _track_all_arp_entries_are_complete(arp_entries: list[Any]) -> bool:
             continue
         if normalized_mac in seen_macs:
             continue
-        seen_macs.append(normalized_mac)
+        seen_macs.add(normalized_mac)
     return True
 
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -43,6 +43,7 @@ from .helpers import (
     get_arp_mac,
     normalize_arp_mac,
 )
+from .repair_reconciliation import is_reconciliation_active, record_desired_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -278,13 +279,14 @@ async def async_setup_entry(
             hostname=device.get("hostname", None),
         )
         entities.append(entity)
-    _cleanup_stale_tracked_devices(
-        hass=hass,
-        config_entry=config_entry,
-        device_registry=dev_reg,
-        previous_mac_addresses=previous_mac_addresses,
-        current_mac_addresses=mac_addresses,
-    )
+    if not is_reconciliation_active(config_entry):
+        _cleanup_stale_tracked_devices(
+            hass=hass,
+            config_entry=config_entry,
+            device_registry=dev_reg,
+            previous_mac_addresses=previous_mac_addresses,
+            current_mac_addresses=mac_addresses,
+        )
 
     if set(mac_addresses) != set(previous_mac_addresses):
         setattr(config_entry.runtime_data, SHOULD_RELOAD, False)
@@ -293,6 +295,7 @@ async def async_setup_entry(
         hass.config_entries.async_update_entry(config_entry, data=new_data)
 
     _LOGGER.debug("[device_tracker async_setup_entry] entities: %s", len(entities))
+    record_desired_entities(config_entry, "device_tracker", entities)
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -259,10 +259,20 @@ async def async_setup_entry(
     if not isinstance(state, MutableMapping):
         _LOGGER.error("Missing state data in device tracker async_setup_entry")
         return
+    reconciliation_complete = True
     entities: list = []
 
     arp_entries = dict_get(state, "arp_table")
+    configured_macs = config_entry.options.get(CONF_DEVICES, [])
+    has_configured_macs = bool(
+        isinstance(configured_macs, list)
+        and any(
+            isinstance(mac_address, str) and mac_address.strip() for mac_address in configured_macs
+        )
+    )
     if not isinstance(arp_entries, list):
+        if not has_configured_macs:
+            reconciliation_complete = False
         arp_entries = []
     devices, mac_addresses, enabled_default = _compile_tracked_devices(config_entry, arp_entries)
 
@@ -295,7 +305,9 @@ async def async_setup_entry(
         hass.config_entries.async_update_entry(config_entry, data=new_data)
 
     _LOGGER.debug("[device_tracker async_setup_entry] entities: %s", len(entities))
-    record_desired_entities(config_entry, "device_tracker", entities)
+    record_desired_entities(
+        config_entry, "device_tracker", entities if reconciliation_complete else None
+    )
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/device_tracker.py
+++ b/custom_components/opnsense/device_tracker.py
@@ -154,8 +154,10 @@ def _track_all_arp_entries_are_complete(arp_entries: list[Any]) -> bool:
             return False
         mac_address = get_arp_mac(arp_entry)
         normalized_mac = _normalize_mac_for_device_tracker(mac_address) if mac_address else None
-        if not mac_address or not normalized_mac or normalized_mac in seen_macs:
+        if not mac_address or not normalized_mac:
             return False
+        if normalized_mac in seen_macs:
+            continue
         seen_macs.append(normalized_mac)
     return True
 

--- a/custom_components/opnsense/helpers.py
+++ b/custom_components/opnsense/helpers.py
@@ -257,7 +257,7 @@ def find_replacement_router_device_id(
     config_entries: ConfigEntries,
     device_registry: DeviceRegistry,
 ) -> str | None:
-    """Find a replacement OPNsense router device id for a shared tracked device.
+    """Find a replacement OPNsense router Device ID for a shared tracked device.
 
     Args:
         shared_config_entry_id: The config entry currently being detached.

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -138,15 +137,9 @@ class RepairReconciliation:
                     old_main.id, new_identifiers=new_identifiers
                 )
             for candidate, target_unique_id in migrations:
-                changes: dict[str, Any] = {"new_unique_id": target_unique_id}
-                if (
-                    old_main is not None
-                    and new_main is not None
-                    and old_main.id != new_main.id
-                    and candidate.device_id == old_main.id
-                ):
-                    changes["device_id"] = new_main.id
-                entity_registry.async_update_entity(candidate.entity_id, **changes)
+                entity_registry.async_update_entity(
+                    candidate.entity_id, new_unique_id=target_unique_id
+                )
         except (
             dr.DeviceIdentifierCollisionError,
             HomeAssistantError,

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -1,4 +1,4 @@
-"""Restart-safe registry reconciliation for device-ID repairs."""
+"""Restart-safe registry reconciliation for Device ID repairs."""
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
@@ -38,7 +38,7 @@ class RepairMarker:
 
 
 def build_repair_marker(old_device_id: str, new_device_id: str) -> dict[str, object]:
-    """Build the current persisted device-ID repair marker."""
+    """Build the current persisted Device ID repair marker."""
     return {
         "version": _REPAIR_MARKER_VERSION,
         "old_device_id": old_device_id,
@@ -146,7 +146,7 @@ class RepairReconciliation:
         ) as err:
             raise RepairReconciliationError("registry identifier migration failed") from err
         _LOGGER.debug(
-            "Device-ID reconciliation prepared for %s: candidate_entities=%d, "
+            "Device ID reconciliation prepared for %s: candidate_entities=%d, "
             "migrated_entities=%d, primary_device_migrated=%s",
             self.config_entry.title,
             len(candidates),
@@ -175,7 +175,7 @@ class RepairReconciliation:
                 if isinstance(mac_address, str) and mac_address:
                     self.desired_device_connections.add((CONNECTION_NETWORK_MAC, mac_address))
         _LOGGER.debug(
-            "Device-ID reconciliation recorded platform discovery for %s: "
+            "Device ID reconciliation recorded platform discovery for %s: "
             "platform=%s, desired_entities=%d",
             self.config_entry.title,
             domain,
@@ -242,7 +242,7 @@ class RepairReconciliation:
         except (HomeAssistantError, KeyError, ValueError) as err:
             raise RepairReconciliationError("registry finalization failed") from err
         _LOGGER.info(
-            "Device-ID reconciliation finalized for %s: removed_entities=%d, "
+            "Device ID reconciliation finalized for %s: removed_entities=%d, "
             "detached_devices=%d, preserved_disabled_tracker_devices=%d",
             self.config_entry.title,
             removed_entities,
@@ -253,7 +253,7 @@ class RepairReconciliation:
     def mark_complete(self) -> None:
         """Disable reconciliation-only behavior after persisted marker clearance."""
         self.active = False
-        _LOGGER.info("Device-ID reconciliation completed for %s", self.config_entry.title)
+        _LOGGER.info("Device ID reconciliation completed for %s", self.config_entry.title)
 
 
 def record_desired_entities(
@@ -268,6 +268,6 @@ def record_desired_entities(
 
 
 def is_reconciliation_active(config_entry: ConfigEntry) -> bool:
-    """Return whether this setup is performing device-ID reconciliation."""
+    """Return whether this setup is performing Device ID reconciliation."""
     reconciliation = config_entry.runtime_data.repair_reconciliation
     return isinstance(reconciliation, RepairReconciliation) and reconciliation.active

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -100,7 +100,7 @@ class RepairReconciliation:
         old_prefix = f"{slugify(self.marker.old_device_id)}_"
         new_prefix = f"{slugify(self.marker.new_device_id)}_"
 
-        migrations: list[tuple[er.RegistryEntry, str, er.RegistryEntry | None]] = []
+        migrations: list[tuple[er.RegistryEntry, str]] = []
         for candidate in candidates:
             if not candidate.unique_id.startswith(old_prefix):
                 continue
@@ -114,7 +114,7 @@ class RepairReconciliation:
                     f"entity target collision: {candidate.domain}, "
                     f"{candidate.platform}, {target_unique_id}"
                 )
-            migrations.append((candidate, target_unique_id, target))
+            migrations.append((candidate, target_unique_id))
 
         old_main = device_registry.async_get_device(
             identifiers={(DOMAIN, self.marker.old_device_id)}
@@ -137,9 +137,7 @@ class RepairReconciliation:
                 new_main = device_registry.async_update_device(
                     old_main.id, new_identifiers=new_identifiers
                 )
-            for candidate, target_unique_id, target in migrations:
-                if target is not None and target.entity_id != candidate.entity_id:
-                    continue
+            for candidate, target_unique_id in migrations:
                 changes: dict[str, Any] = {"new_unique_id": target_unique_id}
                 if (
                     old_main is not None

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -133,9 +133,7 @@ class RepairReconciliation:
                     (DOMAIN, self.marker.new_device_id) if domain == DOMAIN else (domain, value)
                     for domain, value in old_main.identifiers
                 }
-                new_main = device_registry.async_update_device(
-                    old_main.id, new_identifiers=new_identifiers
-                )
+                device_registry.async_update_device(old_main.id, new_identifiers=new_identifiers)
             for candidate, target_unique_id in migrations:
                 entity_registry.async_update_entity(
                     candidate.entity_id, new_unique_id=target_unique_id

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -60,7 +60,8 @@ def parse_repair_marker(entry: ConfigEntry) -> RepairMarker | None:
     old_device_id = value.get("old_device_id")
     new_device_id = value.get("new_device_id")
     if (
-        version != _REPAIR_MARKER_VERSION
+        type(version) is not int
+        or version != _REPAIR_MARKER_VERSION
         or not isinstance(old_device_id, str)
         or not old_device_id.strip()
         or not isinstance(new_device_id, str)

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -220,12 +220,12 @@ def record_desired_entities(
     entities: Iterable[Entity] | None,
 ) -> None:
     """Record a final platform entity list when reconciliation is active."""
-    reconciliation = getattr(config_entry.runtime_data, "repair_reconciliation", None)
+    reconciliation = config_entry.runtime_data.repair_reconciliation
     if isinstance(reconciliation, RepairReconciliation) and reconciliation.active:
         reconciliation.record_desired_entities(platform_domain, entities)
 
 
 def is_reconciliation_active(config_entry: ConfigEntry) -> bool:
     """Return whether this setup is performing device-ID reconciliation."""
-    reconciliation = getattr(config_entry.runtime_data, "repair_reconciliation", None)
+    reconciliation = config_entry.runtime_data.repair_reconciliation
     return isinstance(reconciliation, RepairReconciliation) and reconciliation.active

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -68,11 +68,6 @@ def parse_repair_marker(entry: ConfigEntry) -> RepairMarker | None:
     return RepairMarker(version, old_device_id, new_device_id)
 
 
-def _registry_identity(entry: er.RegistryEntry) -> EntityIdentity:
-    """Return an entity's full registry collision identity."""
-    return entry.domain, entry.platform, entry.unique_id
-
-
 def _platform_domain_value(platform_domain: PlatformDomain) -> str:
     """Return the string entity domain for a platform value."""
     return platform_domain.value if isinstance(platform_domain, Platform) else platform_domain
@@ -179,7 +174,11 @@ class RepairReconciliation:
         try:
             for entity_id in self._candidate_entity_ids:
                 candidate = entity_registry.async_get(entity_id)
-                if candidate is None or _registry_identity(candidate) in self.desired_identities:
+                if (
+                    candidate is None
+                    or (candidate.domain, candidate.platform, candidate.unique_id)
+                    in self.desired_identities
+                ):
                     continue
                 entity_registry.async_remove(entity_id)
 

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -158,9 +158,15 @@ class RepairReconciliation:
             raise RepairReconciliationError("registry identifier migration failed") from err
 
     def record_desired_entities(
-        self, platform_domain: PlatformDomain, entities: Iterable[Entity]
+        self, platform_domain: PlatformDomain, entities: Iterable[Entity] | None
     ) -> None:
-        """Record a platform's complete intended entity list, including disabled rows."""
+        """Record a platform's complete intended entity list, including disabled rows.
+
+        If ``entities`` is ``None``, the platform discovery payload was missing
+        or malformed and should not be treated as complete.
+        """
+        if entities is None:
+            return
         domain = _platform_domain_value(platform_domain)
         self.completed_platform_domains.add(domain)
         for entity in entities:
@@ -222,7 +228,7 @@ class RepairReconciliation:
 def record_desired_entities(
     config_entry: ConfigEntry,
     platform_domain: PlatformDomain,
-    entities: Iterable[Entity],
+    entities: Iterable[Entity] | None,
 ) -> None:
     """Record a final platform entity list when reconciliation is active."""
     reconciliation = getattr(config_entry.runtime_data, "repair_reconciliation", None)

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -129,12 +129,17 @@ class RepairReconciliation:
 
         try:
             primary_device_migrated = old_main is not None and new_main is None
-            if old_main is not None and new_main is None:
+            if old_main is not None and (new_main is None or new_main.id == old_main.id):
+                old_identifier = (DOMAIN, self.marker.old_device_id)
+                new_identifier = (DOMAIN, self.marker.new_device_id)
                 new_identifiers = {
-                    (DOMAIN, self.marker.new_device_id) if domain == DOMAIN else (domain, value)
-                    for domain, value in old_main.identifiers
+                    new_identifier if identity == old_identifier else identity
+                    for identity in old_main.identifiers
                 }
-                device_registry.async_update_device(old_main.id, new_identifiers=new_identifiers)
+                if old_identifier in old_main.identifiers:
+                    device_registry.async_update_device(
+                        old_main.id, new_identifiers=new_identifiers
+                    )
             for candidate, target_unique_id in migrations:
                 entity_registry.async_update_entity(
                     candidate.entity_id, new_unique_id=target_unique_id

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -1,0 +1,230 @@
+"""Restart-safe registry reconciliation for device-ID repairs."""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import Entity
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+
+REPAIR_MARKER_KEY: str = "device_id_repair"
+_REPAIR_MARKER_VERSION = 1
+
+type EntityIdentity = tuple[str, str, str]
+type PlatformDomain = Platform | str
+
+
+class RepairReconciliationError(HomeAssistantError):
+    """Raised when registry reconciliation cannot continue safely."""
+
+
+@dataclass(frozen=True)
+class RepairMarker:
+    """Validated persisted repair marker."""
+
+    version: int
+    old_device_id: str
+    new_device_id: str
+
+
+def build_repair_marker(old_device_id: str, new_device_id: str) -> dict[str, object]:
+    """Build the current persisted device-ID repair marker."""
+    return {
+        "version": _REPAIR_MARKER_VERSION,
+        "old_device_id": old_device_id,
+        "new_device_id": new_device_id,
+    }
+
+
+def has_repair_marker(entry: ConfigEntry) -> bool:
+    """Return whether the entry contains a persisted repair marker."""
+    return REPAIR_MARKER_KEY in entry.data
+
+
+def parse_repair_marker(entry: ConfigEntry) -> RepairMarker | None:
+    """Parse and validate the entry's persisted repair marker."""
+    value = entry.data.get(REPAIR_MARKER_KEY)
+    if not isinstance(value, Mapping):
+        return None
+    version = value.get("version")
+    old_device_id = value.get("old_device_id")
+    new_device_id = value.get("new_device_id")
+    if (
+        version != _REPAIR_MARKER_VERSION
+        or not isinstance(old_device_id, str)
+        or not old_device_id.strip()
+        or not isinstance(new_device_id, str)
+        or not new_device_id.strip()
+        or old_device_id == new_device_id
+    ):
+        return None
+    return RepairMarker(version, old_device_id, new_device_id)
+
+
+def _registry_identity(entry: er.RegistryEntry) -> EntityIdentity:
+    """Return an entity's full registry collision identity."""
+    return entry.domain, entry.platform, entry.unique_id
+
+
+def _platform_domain_value(platform_domain: PlatformDomain) -> str:
+    """Return the string entity domain for a platform value."""
+    return platform_domain.value if isinstance(platform_domain, Platform) else platform_domain
+
+
+@dataclass
+class RepairReconciliation:
+    """Coordinate in-place identity migration with platform discovery."""
+
+    hass: HomeAssistant
+    config_entry: ConfigEntry
+    marker: RepairMarker
+    desired_identities: set[EntityIdentity] = field(default_factory=set)
+    completed_platform_domains: set[str] = field(default_factory=set)
+    active: bool = True
+    _candidate_entity_ids: set[str] = field(default_factory=set)
+
+    def prepare(self) -> None:
+        """Preflight every target collision, then migrate identifiers in place."""
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        candidates = er.async_entries_for_config_entry(entity_registry, self.config_entry.entry_id)
+        self._candidate_entity_ids = {candidate.entity_id for candidate in candidates}
+        old_prefix = f"{slugify(self.marker.old_device_id)}_"
+        new_prefix = f"{slugify(self.marker.new_device_id)}_"
+
+        migrations: list[tuple[er.RegistryEntry, str, er.RegistryEntry | None]] = []
+        for candidate in candidates:
+            if not candidate.unique_id.startswith(old_prefix):
+                continue
+            target_unique_id = f"{new_prefix}{candidate.unique_id[len(old_prefix) :]}"
+            target_entity_id = entity_registry.async_get_entity_id(
+                candidate.domain, candidate.platform, target_unique_id
+            )
+            target = entity_registry.async_get(target_entity_id) if target_entity_id else None
+            if target is not None and target.entity_id != candidate.entity_id:
+                raise RepairReconciliationError(
+                    f"entity target collision: {candidate.domain}, "
+                    f"{candidate.platform}, {target_unique_id}"
+                )
+            migrations.append((candidate, target_unique_id, target))
+
+        old_main = device_registry.async_get_device(
+            identifiers={(DOMAIN, self.marker.old_device_id)}
+        )
+        new_main = device_registry.async_get_device(
+            identifiers={(DOMAIN, self.marker.new_device_id)}
+        )
+        if new_main is not None:
+            if old_main is not None and new_main.id != old_main.id:
+                raise RepairReconciliationError("primary device identifier target collision")
+            if old_main is None and self.config_entry.entry_id not in new_main.config_entries:
+                raise RepairReconciliationError("primary device identifier target collision")
+
+        try:
+            if old_main is not None and new_main is None:
+                new_identifiers = {
+                    (DOMAIN, self.marker.new_device_id) if domain == DOMAIN else (domain, value)
+                    for domain, value in old_main.identifiers
+                }
+                new_main = device_registry.async_update_device(
+                    old_main.id, new_identifiers=new_identifiers
+                )
+            for candidate, target_unique_id, target in migrations:
+                if target is not None and target.entity_id != candidate.entity_id:
+                    continue
+                changes: dict[str, Any] = {"new_unique_id": target_unique_id}
+                if (
+                    old_main is not None
+                    and new_main is not None
+                    and old_main.id != new_main.id
+                    and candidate.device_id == old_main.id
+                ):
+                    changes["device_id"] = new_main.id
+                entity_registry.async_update_entity(candidate.entity_id, **changes)
+        except (
+            dr.DeviceIdentifierCollisionError,
+            HomeAssistantError,
+            KeyError,
+            ValueError,
+        ) as err:
+            raise RepairReconciliationError("registry identifier migration failed") from err
+
+    def record_desired_entities(
+        self, platform_domain: PlatformDomain, entities: Iterable[Entity]
+    ) -> None:
+        """Record a platform's complete intended entity list, including disabled rows."""
+        domain = _platform_domain_value(platform_domain)
+        self.completed_platform_domains.add(domain)
+        for entity in entities:
+            if entity.unique_id is not None:
+                self.desired_identities.add((domain, DOMAIN, entity.unique_id))
+
+    def require_platforms_complete(self, platform_domains: Iterable[PlatformDomain]) -> None:
+        """Fail unless every forwarded platform reported its final entity list."""
+        required_domains = {
+            _platform_domain_value(platform_domain) for platform_domain in platform_domains
+        }
+        missing_domains = required_domains - self.completed_platform_domains
+        if missing_domains:
+            missing = ", ".join(sorted(missing_domains))
+            raise RepairReconciliationError(f"platform discovery incomplete: {missing}")
+
+    def finalize(self) -> None:
+        """Remove stale candidates and detach only unreferenced obsolete devices."""
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        try:
+            for entity_id in self._candidate_entity_ids:
+                candidate = entity_registry.async_get(entity_id)
+                if candidate is None or _registry_identity(candidate) in self.desired_identities:
+                    continue
+                entity_registry.async_remove(entity_id)
+
+            surviving_entities = er.async_entries_for_config_entry(
+                entity_registry, self.config_entry.entry_id
+            )
+            preserved_device_ids = {
+                entity.device_id for entity in surviving_entities if entity.device_id is not None
+            }
+            main_device = device_registry.async_get_device(
+                identifiers={(DOMAIN, self.marker.new_device_id)}
+            )
+            if main_device is not None:
+                preserved_device_ids.add(main_device.id)
+            for device in dr.async_entries_for_config_entry(
+                device_registry, self.config_entry.entry_id
+            ):
+                if device.id not in preserved_device_ids:
+                    device_registry.async_update_device(
+                        device.id, remove_config_entry_id=self.config_entry.entry_id
+                    )
+        except (HomeAssistantError, KeyError, ValueError) as err:
+            raise RepairReconciliationError("registry finalization failed") from err
+
+    def mark_complete(self) -> None:
+        """Disable reconciliation-only behavior after persisted marker clearance."""
+        self.active = False
+
+
+def record_desired_entities(
+    config_entry: ConfigEntry,
+    platform_domain: PlatformDomain,
+    entities: Iterable[Entity],
+) -> None:
+    """Record a final platform entity list when reconciliation is active."""
+    reconciliation = getattr(config_entry.runtime_data, "repair_reconciliation", None)
+    if isinstance(reconciliation, RepairReconciliation) and reconciliation.active:
+        reconciliation.record_desired_entities(platform_domain, entities)
+
+
+def is_reconciliation_active(config_entry: ConfigEntry) -> bool:
+    """Return whether this setup is performing device-ID reconciliation."""
+    reconciliation = getattr(config_entry.runtime_data, "repair_reconciliation", None)
+    return isinstance(reconciliation, RepairReconciliation) and reconciliation.active

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
 from .const import DOMAIN
+from .helpers import detach_shared_router_parent
 
 REPAIR_MARKER_KEY: str = "device_id_repair"
 _REPAIR_MARKER_VERSION = 1
@@ -202,8 +203,13 @@ class RepairReconciliation:
                 device_registry, self.config_entry.entry_id
             ):
                 if device.id not in preserved_device_ids:
-                    device_registry.async_update_device(
-                        device.id, remove_config_entry_id=self.config_entry.entry_id
+                    router_device_id = main_device.id if main_device is not None else None
+                    detach_shared_router_parent(
+                        shared_config_entry_id=self.config_entry.entry_id,
+                        shared_device_entry=device,
+                        router_device_id=router_device_id,
+                        config_entries=self.hass.config_entries,
+                        device_registry=device_registry,
                     )
         except (HomeAssistantError, KeyError, ValueError) as err:
             raise RepairReconciliationError("registry finalization failed") from err

--- a/custom_components/opnsense/repair_reconciliation.py
+++ b/custom_components/opnsense/repair_reconciliation.py
@@ -2,12 +2,14 @@
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
@@ -16,6 +18,7 @@ from .helpers import detach_shared_router_parent
 
 REPAIR_MARKER_KEY: str = "device_id_repair"
 _REPAIR_MARKER_VERSION = 1
+_LOGGER = logging.getLogger(__name__)
 
 type EntityIdentity = tuple[str, str, str]
 type PlatformDomain = Platform | str
@@ -81,6 +84,7 @@ class RepairReconciliation:
     config_entry: ConfigEntry
     marker: RepairMarker
     desired_identities: set[EntityIdentity] = field(default_factory=set)
+    desired_device_connections: set[tuple[str, str]] = field(default_factory=set)
     completed_platform_domains: set[str] = field(default_factory=set)
     active: bool = True
     _candidate_entity_ids: set[str] = field(default_factory=set)
@@ -123,6 +127,7 @@ class RepairReconciliation:
                 raise RepairReconciliationError("primary device identifier target collision")
 
         try:
+            primary_device_migrated = old_main is not None and new_main is None
             if old_main is not None and new_main is None:
                 new_identifiers = {
                     (DOMAIN, self.marker.new_device_id) if domain == DOMAIN else (domain, value)
@@ -140,6 +145,14 @@ class RepairReconciliation:
             ValueError,
         ) as err:
             raise RepairReconciliationError("registry identifier migration failed") from err
+        _LOGGER.debug(
+            "Device-ID reconciliation prepared for %s: candidate_entities=%d, "
+            "migrated_entities=%d, primary_device_migrated=%s",
+            self.config_entry.title,
+            len(candidates),
+            len(migrations),
+            primary_device_migrated,
+        )
 
     def record_desired_entities(
         self, platform_domain: PlatformDomain, entities: Iterable[Entity] | None
@@ -152,10 +165,22 @@ class RepairReconciliation:
         if entities is None:
             return
         domain = _platform_domain_value(platform_domain)
+        desired_entities = list(entities)
         self.completed_platform_domains.add(domain)
-        for entity in entities:
+        for entity in desired_entities:
             if entity.unique_id is not None:
                 self.desired_identities.add((domain, DOMAIN, entity.unique_id))
+            if domain == Platform.DEVICE_TRACKER.value:
+                mac_address = getattr(entity, "mac_address", None)
+                if isinstance(mac_address, str) and mac_address:
+                    self.desired_device_connections.add((CONNECTION_NETWORK_MAC, mac_address))
+        _LOGGER.debug(
+            "Device-ID reconciliation recorded platform discovery for %s: "
+            "platform=%s, desired_entities=%d",
+            self.config_entry.title,
+            domain,
+            len(desired_entities),
+        )
 
     def require_platforms_complete(self, platform_domains: Iterable[PlatformDomain]) -> None:
         """Fail unless every forwarded platform reported its final entity list."""
@@ -172,6 +197,7 @@ class RepairReconciliation:
         entity_registry = er.async_get(self.hass)
         device_registry = dr.async_get(self.hass)
         try:
+            removed_entities = 0
             for entity_id in self._candidate_entity_ids:
                 candidate = entity_registry.async_get(entity_id)
                 if (
@@ -181,6 +207,7 @@ class RepairReconciliation:
                 ):
                     continue
                 entity_registry.async_remove(entity_id)
+                removed_entities += 1
 
             surviving_entities = er.async_entries_for_config_entry(
                 entity_registry, self.config_entry.entry_id
@@ -193,24 +220,40 @@ class RepairReconciliation:
             )
             if main_device is not None:
                 preserved_device_ids.add(main_device.id)
+            preserved_tracker_devices = 0
+            detached_devices = 0
             for device in dr.async_entries_for_config_entry(
                 device_registry, self.config_entry.entry_id
             ):
-                if device.id not in preserved_device_ids:
-                    router_device_id = main_device.id if main_device is not None else None
-                    detach_shared_router_parent(
-                        shared_config_entry_id=self.config_entry.entry_id,
-                        shared_device_entry=device,
-                        router_device_id=router_device_id,
-                        config_entries=self.hass.config_entries,
-                        device_registry=device_registry,
-                    )
+                if device.id in preserved_device_ids:
+                    continue
+                if set(device.connections) & self.desired_device_connections:
+                    preserved_tracker_devices += 1
+                    continue
+                router_device_id = main_device.id if main_device is not None else None
+                detach_shared_router_parent(
+                    shared_config_entry_id=self.config_entry.entry_id,
+                    shared_device_entry=device,
+                    router_device_id=router_device_id,
+                    config_entries=self.hass.config_entries,
+                    device_registry=device_registry,
+                )
+                detached_devices += 1
         except (HomeAssistantError, KeyError, ValueError) as err:
             raise RepairReconciliationError("registry finalization failed") from err
+        _LOGGER.info(
+            "Device-ID reconciliation finalized for %s: removed_entities=%d, "
+            "detached_devices=%d, preserved_disabled_tracker_devices=%d",
+            self.config_entry.title,
+            removed_entities,
+            detached_devices,
+            preserved_tracker_devices,
+        )
 
     def mark_complete(self) -> None:
         """Disable reconciliation-only behavior after persisted marker clearance."""
         self.active = False
+        _LOGGER.info("Device-ID reconciliation completed for %s", self.config_entry.title)
 
 
 def record_desired_entities(

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -293,7 +293,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             if await self.hass.config_entries.async_reload(entry.entry_id):
                 _LOGGER.info("Device ID repair reload completed for %s", entry.title)
                 return self.async_create_entry(data={})
-        except HomeAssistantError, KeyError:
+        except HomeAssistantError, TimeoutError, KeyError:
             _LOGGER.exception(
                 "Device ID repair did not finish for %s; cannot reload entry",
                 entry.title,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -529,7 +529,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 return self.async_abort(reason="entry_changed")
             try:
                 observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
-            except OPNsenseError:
+            except OPNsenseError, TimeoutError:
                 return self.async_abort(reason="cannot_connect")
             if not is_valid_device_id(observed_device_id):
                 return self.async_abort(reason="cannot_connect")
@@ -558,7 +558,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
 
         try:
             observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
-        except OPNsenseError:
+        except OPNsenseError, TimeoutError:
             return self.async_abort(reason="cannot_connect")
 
         current_entry = _get_entry_matching_snapshot(

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -158,17 +158,20 @@ def async_create_device_id_mismatch_issue(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
     observed_device_id: object,
-) -> None:
+) -> bool:
     """Create a fixable hardware-replacement issue for a normal device entry.
 
     Args:
         hass: Home Assistant instance that owns the issue registry.
         config_entry: Device config entry with the stale identifier.
         observed_device_id: Replacement device identifier observed at runtime.
+
+    Returns:
+        bool: `True` when the issue was created; otherwise `False` for invalid IDs.
     """
     old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
     if not is_valid_device_id(old_device_id) or not is_valid_device_id(observed_device_id):
-        return
+        return False
     ir.async_create_issue(
         hass=hass,
         domain=DOMAIN,
@@ -188,6 +191,7 @@ def async_create_device_id_mismatch_issue(
             "new_device_id": observed_device_id,
         },
     )
+    return True
 
 
 class DeviceIDMismatchRepairFlow(RepairsFlow):

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import logging
 from typing import TypeGuard
 
-from aiopnsense.exceptions import OPNsenseError
+from aiopnsense.exceptions import OPNsenseError, OPNsenseMissingDeviceUniqueID
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -128,7 +128,12 @@ async def _async_validate_and_probe_device_id(
         throw_errors=True,
     )
     try:
-        await client.validate()
+        try:
+            await client.validate()
+        except OPNsenseMissingDeviceUniqueID:
+            _LOGGER.debug(
+                "Device validation could not return the current unique ID; probing directly"
+            )
         return await client.get_device_unique_id()
     finally:
         await client.async_close()
@@ -418,7 +423,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         """
         try:
             reprobed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
-        except OPNsenseError:
+        except OPNsenseError, TimeoutError:
             self._schedule_changed_entry_reload_if_needed(
                 entry_was_loaded=entry_was_loaded,
                 entry=entry,
@@ -506,6 +511,8 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             self._expected_device_id,
         )
         if stored_device_id == self._expected_device_id:
+            if entry.unique_id != self._expected_device_id:
+                return self.async_abort(reason="entry_changed")
             if REPAIR_MARKER_KEY not in entry.data:
                 return await self._async_reload_with_recovery(
                     entry,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -9,11 +9,12 @@ from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, Rep
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
+from homeassistant.helpers import issue_registry as ir
 import voluptuous as vol
 
 from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN
 from .helpers import create_opnsense_client_from_config_entry
+from .repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker, parse_repair_marker
 
 _ISSUE_SUFFIX = "_device_id_mismatched"
 _LOGGER = logging.getLogger(__name__)
@@ -318,47 +319,6 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 entry_title,
             )
 
-    def _cleanup_entry_registries(self, entry: ConfigEntry) -> bool:
-        """Remove the entry's entities and device associations from the registries.
-
-        Args:
-            entry: Config entry whose old registry data should be removed.
-
-        Returns:
-            bool: ``True`` when all registry cleanup operations succeeded.
-        """
-        entity_registry = er.async_get(self.hass)
-        device_registry = dr.async_get(self.hass)
-        entities_to_cleanup = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-        devices_to_cleanup = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-
-        failed_cleanup = False
-        for entity in entities_to_cleanup:
-            try:
-                entity_registry.async_remove(entity.entity_id)
-            except HomeAssistantError, KeyError, ValueError:
-                failed_cleanup = True
-                _LOGGER.exception(
-                    "Device-ID repair did not finish for %s; cannot remove entity %s",
-                    entry.title,
-                    entity.entity_id,
-                )
-
-        for device in devices_to_cleanup:
-            try:
-                device_registry.async_update_device(
-                    device.id,
-                    remove_config_entry_id=entry.entry_id,
-                )
-            except HomeAssistantError, KeyError, ValueError:
-                failed_cleanup = True
-                _LOGGER.exception(
-                    "Device-ID repair did not finish for %s; cannot update device %s",
-                    entry.title,
-                    device.id,
-                )
-        return not failed_cleanup
-
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
     ) -> RepairsFlowResult:
@@ -384,7 +344,25 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry_options_snapshot = deepcopy(dict(entry.options))
         entry_unique_id_snapshot = entry.unique_id
         stored_device_id = entry.data.get(CONF_DEVICE_UNIQUE_ID)
+        expected_repair_marker = build_repair_marker(
+            self._old_device_id,
+            self._expected_device_id,
+        )
         if stored_device_id == self._expected_device_id:
+            if REPAIR_MARKER_KEY not in entry.data:
+                return await self._async_reload_with_recovery(
+                    entry,
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                )
+            repair_marker = parse_repair_marker(entry)
+            if (
+                repair_marker is None
+                or repair_marker.old_device_id != self._old_device_id
+                or repair_marker.new_device_id != self._expected_device_id
+            ):
+                return self.async_abort(reason="entry_changed")
             try:
                 observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
             except OPNsenseError:
@@ -410,15 +388,6 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                         entry_title=entry.title,
                     )
                 return self.async_abort(reason="entry_changed")
-            if not self._cleanup_entry_registries(current_entry):
-                self._schedule_recovery_reload(
-                    data_snapshot=entry_data_snapshot,
-                    options_snapshot=entry_options_snapshot,
-                    unique_id_snapshot=entry_unique_id_snapshot,
-                    entry_id=current_entry.entry_id,
-                    entry_title=current_entry.title,
-                )
-                return self.async_abort(reason="repair_failed")
             return await self._async_reload_with_recovery(
                 current_entry,
                 data_snapshot=entry_data_snapshot,
@@ -495,7 +464,11 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         if duplicate is not None:
             return self.async_abort(reason="already_configured")
 
-        new_data = {**entry.data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+        new_data = {
+            **entry.data,
+            CONF_DEVICE_UNIQUE_ID: observed_device_id,
+            REPAIR_MARKER_KEY: expected_repair_marker,
+        }
 
         try:
             updated = self.hass.config_entries.async_update_entry(
@@ -536,18 +509,9 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         post_update_entry_data_snapshot: dict[str, object] = {
             **entry_data_snapshot,
             CONF_DEVICE_UNIQUE_ID: observed_device_id,
+            REPAIR_MARKER_KEY: expected_repair_marker,
         }
         post_update_entry_unique_id_snapshot = observed_device_id
-
-        if not self._cleanup_entry_registries(entry):
-            self._schedule_recovery_reload(
-                data_snapshot=post_update_entry_data_snapshot,
-                options_snapshot=entry_options_snapshot,
-                unique_id_snapshot=post_update_entry_unique_id_snapshot,
-                entry_id=entry.entry_id,
-                entry_title=entry.title,
-            )
-            return self.async_abort(reason="repair_failed")
 
         return await self._async_reload_with_recovery(
             entry,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -1,0 +1,528 @@
+"""Repair flows for the OPNsense integration."""
+
+from copy import deepcopy
+import logging
+
+import aiohttp
+from aiopnsense.exceptions import OPNsenseError
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
+import voluptuous as vol
+
+from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from .helpers import create_opnsense_client_from_config_entry
+
+_ISSUE_SUFFIX = "_device_id_mismatched"
+_LOGGER = logging.getLogger(__name__)
+
+
+def _entry_matches_snapshot(
+    entry: ConfigEntry | None,
+    entry_id: str,
+    data_snapshot: dict[str, object],
+    options_snapshot: dict[str, object],
+    unique_id_snapshot: str | None,
+) -> bool:
+    """Return whether a re-fetched entry still matches the repair snapshot.
+
+    Args:
+        entry: Current config entry, if it still exists.
+        entry_id: Entry ID captured when the repair started.
+        data_snapshot: Original config-entry data mapping.
+        options_snapshot: Original config-entry options mapping.
+        unique_id_snapshot: Original config-entry unique ID.
+
+    Returns:
+        bool: ``True`` when the entry identity and persisted values are unchanged.
+    """
+    return bool(
+        entry is not None
+        and entry.entry_id == entry_id
+        and dict(entry.data) == data_snapshot
+        and dict(entry.options) == options_snapshot
+        and entry.unique_id == unique_id_snapshot
+    )
+
+
+def _get_entry_matching_snapshot(
+    hass: HomeAssistant,
+    entry_id: str,
+    data_snapshot: dict[str, object],
+    options_snapshot: dict[str, object],
+    unique_id_snapshot: str | None,
+) -> ConfigEntry | None:
+    """Return the current entry only when it still matches the repair snapshot.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        entry_id: Entry ID captured when the repair started.
+        data_snapshot: Original config-entry data mapping.
+        options_snapshot: Original config-entry options mapping.
+        unique_id_snapshot: Original config-entry unique ID.
+
+    Returns:
+        ConfigEntry | None: Matching current entry, if it is still owned.
+    """
+    current_entry = hass.config_entries.async_get_entry(entry_id)
+    if not _entry_matches_snapshot(
+        current_entry,
+        entry_id,
+        data_snapshot,
+        options_snapshot,
+        unique_id_snapshot,
+    ):
+        return None
+    return current_entry
+
+
+async def _async_validate_and_probe_device_id(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> str | None:
+    """Validate an OPNsense client and probe the current device identifier.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        config_entry: OPNsense config entry used to build the client.
+
+    Returns:
+        str | None: Device identifier returned by OPNsense.
+
+    Raises:
+        OPNsenseError: If validation or the device-ID probe fails.
+        aiohttp.ClientError: If the client encounters a transport failure.
+        TimeoutError: If the client request times out.
+    """
+    client = create_opnsense_client_from_config_entry(
+        hass=hass,
+        config_entry=config_entry,
+        throw_errors=True,
+    )
+    try:
+        await client.validate()
+        return await client.get_device_unique_id()
+    finally:
+        await client.async_close()
+
+
+async def _async_prepare_entry_for_repair(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+) -> tuple[bool, bool]:
+    """Check whether an entry can be safely unloaded before repair mutation.
+
+    Args:
+        hass: Home Assistant instance that owns the config entry.
+        config_entry: OPNsense config entry being repaired.
+
+    Returns:
+        tuple[bool, bool]: Whether the entry is ready and whether it was loaded.
+    """
+    entry_was_loaded = config_entry.state is ConfigEntryState.LOADED
+    if not config_entry.state.recoverable:
+        return False, entry_was_loaded
+    if entry_was_loaded and not await hass.config_entries.async_unload(config_entry.entry_id):
+        return False, entry_was_loaded
+    return True, entry_was_loaded
+
+
+def _device_id_repair_abort_reason(
+    observed_device_id: object,
+    expected_device_id: str,
+    current_device_id: object,
+) -> str | None:
+    """Return the abort reason for an invalid replacement device ID.
+
+    Args:
+        observed_device_id: Device identifier returned by the firewall.
+        expected_device_id: Replacement identifier stored in the repair issue.
+        current_device_id: Identifier currently stored on the config entry.
+
+    Returns:
+        str | None: Repair abort reason, or ``None`` when the replacement is valid.
+    """
+    if not isinstance(observed_device_id, str) or not observed_device_id:
+        return "cannot_connect"
+    if observed_device_id != expected_device_id or observed_device_id == current_device_id:
+        return "entry_changed"
+    return None
+
+
+def async_create_device_id_mismatch_issue(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    observed_device_id: str,
+) -> None:
+    """Create a fixable hardware-replacement issue for a normal device entry.
+
+    Args:
+        hass: Home Assistant instance that owns the issue registry.
+        config_entry: Device config entry with the stale identifier.
+        observed_device_id: Replacement device identifier observed at runtime.
+    """
+    old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+    ir.async_create_issue(
+        hass=hass,
+        domain=DOMAIN,
+        issue_id=f"{config_entry.entry_id}{_ISSUE_SUFFIX}",
+        is_fixable=True,
+        is_persistent=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="device_id_mismatched",
+        translation_placeholders={
+            "entry_title": config_entry.title,
+            "old_device_id": old_device_id,
+            "new_device_id": observed_device_id,
+        },
+        data={
+            "entry_id": config_entry.entry_id,
+            "old_device_id": old_device_id,
+            "new_device_id": observed_device_id,
+        },
+    )
+
+
+class DeviceIDMismatchRepairFlow(RepairsFlow):
+    """Rebuild one OPNsense config entry after confirmed hardware replacement."""
+
+    def __init__(self, entry_id: str, old_device_id: str, new_device_id: str) -> None:
+        """Initialize a repair flow from issue data.
+
+        Args:
+            entry_id: Config-entry ID associated with the repair issue.
+            old_device_id: Device identifier stored before the repair.
+            new_device_id: Replacement identifier expected by the issue.
+        """
+        self._entry_id = entry_id
+        self._old_device_id = old_device_id
+        self._expected_device_id = new_device_id
+        self._description_placeholders: dict[str, str] = {
+            "entry_title": "",
+            "old_device_id": old_device_id,
+            "new_device_id": new_device_id,
+        }
+
+    async def async_step_init(self, user_input: dict[str, str] | None = None) -> RepairsFlowResult:
+        """Load issue placeholders and display the confirmation step.
+
+        Args:
+            user_input: Ignored initialization payload.
+
+        Returns:
+            RepairsFlowResult: Confirmation form result.
+        """
+        del user_input
+        issue_registry = ir.async_get(self.hass)
+        issue = issue_registry.async_get_issue(self.handler, self.issue_id)
+        if issue is not None and issue.translation_placeholders is not None:
+            self._description_placeholders = dict(issue.translation_placeholders)
+        return await self.async_step_confirm()
+
+    async def _async_reload_with_recovery(
+        self,
+        entry: ConfigEntry,
+        *,
+        data_snapshot: dict[str, object],
+        options_snapshot: dict[str, object],
+        unique_id_snapshot: str | None,
+    ) -> RepairsFlowResult:
+        """Reload an updated entry and schedule guarded recovery on any reload failure.
+
+        Args:
+            entry: Updated OPNsense config entry to reload.
+            data_snapshot: Persisted data expected before repair completion.
+            options_snapshot: Persisted options expected before repair completion.
+            unique_id_snapshot: Persisted unique ID expected before repair completion.
+
+        Returns:
+            RepairsFlowResult: Successful completion or a retryable repair failure.
+        """
+        try:
+            if await self.hass.config_entries.async_reload(entry.entry_id):
+                return self.async_create_entry(data={})
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot reload entry",
+                entry.title,
+            )
+        self._schedule_recovery_reload(
+            data_snapshot=data_snapshot,
+            options_snapshot=options_snapshot,
+            unique_id_snapshot=unique_id_snapshot,
+            entry_id=entry.entry_id,
+            entry_title=entry.title,
+        )
+        return self.async_abort(reason="repair_failed")
+
+    def _schedule_recovery_reload(
+        self,
+        *,
+        data_snapshot: dict[str, object],
+        options_snapshot: dict[str, object],
+        unique_id_snapshot: str | None,
+        entry_id: str,
+        entry_title: str,
+    ) -> None:
+        """Schedule a recovery reload without mutating an untouched repair entry.
+
+        Args:
+            data_snapshot: Snapshot of the entry data used to detect changes.
+            options_snapshot: Snapshot of entry options used to detect changes.
+            unique_id_snapshot: Snapshot of the entry unique ID used to detect changes.
+            entry_id: Config entry ID used to resolve the entry for reload.
+            entry_title: Human-readable entry title for log context.
+        """
+        current_entry = self.hass.config_entries.async_get_entry(entry_id)
+        if not _entry_matches_snapshot(
+            current_entry,
+            entry_id,
+            data_snapshot,
+            options_snapshot,
+            unique_id_snapshot,
+        ):
+            return
+        try:
+            self.hass.config_entries.async_schedule_reload(entry_id)
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot schedule recovery "
+                "reload after a non-mutating failure",
+                entry_title,
+            )
+
+    def _cleanup_entry_registries(self, entry: ConfigEntry) -> bool:
+        """Remove the entry's entities and device associations from the registries.
+
+        Args:
+            entry: Config entry whose old registry data should be removed.
+
+        Returns:
+            bool: ``True`` when all registry cleanup operations succeeded.
+        """
+        entity_registry = er.async_get(self.hass)
+        device_registry = dr.async_get(self.hass)
+        entities_to_cleanup = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+        devices_to_cleanup = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+
+        failed_cleanup = False
+        for entity in entities_to_cleanup:
+            try:
+                entity_registry.async_remove(entity.entity_id)
+            except HomeAssistantError, KeyError:
+                failed_cleanup = True
+                _LOGGER.exception(
+                    "Device-ID repair did not finish for %s; cannot remove entity %s",
+                    entry.title,
+                    entity.entity_id,
+                )
+
+        for device in devices_to_cleanup:
+            try:
+                device_registry.async_update_device(
+                    device.id,
+                    remove_config_entry_id=entry.entry_id,
+                )
+            except HomeAssistantError, KeyError:
+                failed_cleanup = True
+                _LOGGER.exception(
+                    "Device-ID repair did not finish for %s; cannot update device %s",
+                    entry.title,
+                    device.id,
+                )
+        return not failed_cleanup
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> RepairsFlowResult:
+        """Confirm and perform the ordered registry rebuild.
+
+        Args:
+            user_input: Confirmation payload, or ``None`` to render the form.
+
+        Returns:
+            RepairsFlowResult: Confirmation form, abort result, or successful completion.
+        """
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm",
+                data_schema=vol.Schema({}),
+                description_placeholders=self._description_placeholders,
+            )
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None:
+            return self.async_abort(reason="entry_not_found")
+        entry_data_snapshot = deepcopy(dict(entry.data))
+        entry_options_snapshot = deepcopy(dict(entry.options))
+        entry_unique_id_snapshot = entry.unique_id
+        stored_device_id = entry.data.get(CONF_DEVICE_UNIQUE_ID)
+        if stored_device_id == self._expected_device_id:
+            entry_ready, _ = await _async_prepare_entry_for_repair(self.hass, entry)
+            if not entry_ready:
+                return self.async_abort(reason="cannot_unload")
+            current_entry = _get_entry_matching_snapshot(
+                self.hass,
+                self._entry_id,
+                entry_data_snapshot,
+                entry_options_snapshot,
+                entry_unique_id_snapshot,
+            )
+            if current_entry is None:
+                return self.async_abort(reason="entry_changed")
+            if not self._cleanup_entry_registries(current_entry):
+                return self.async_abort(reason="repair_failed")
+            return await self._async_reload_with_recovery(
+                current_entry,
+                data_snapshot=entry_data_snapshot,
+                options_snapshot=entry_options_snapshot,
+                unique_id_snapshot=entry_unique_id_snapshot,
+            )
+        if stored_device_id != self._old_device_id:
+            return self.async_abort(reason="entry_changed")
+
+        try:
+            observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
+        except OPNsenseError, aiohttp.ClientError, TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+
+        current_entry = _get_entry_matching_snapshot(
+            self.hass,
+            self._entry_id,
+            entry_data_snapshot,
+            entry_options_snapshot,
+            entry_unique_id_snapshot,
+        )
+        if current_entry is None:
+            return self.async_abort(reason="entry_changed")
+        entry = current_entry
+
+        if abort_reason := _device_id_repair_abort_reason(
+            observed_device_id,
+            self._expected_device_id,
+            entry.data.get(CONF_DEVICE_UNIQUE_ID),
+        ):
+            return self.async_abort(reason=abort_reason)
+
+        duplicate = next(
+            (
+                candidate
+                for candidate in self.hass.config_entries.async_entries(DOMAIN)
+                if candidate.entry_id != entry.entry_id
+                and candidate.unique_id == observed_device_id
+            ),
+            None,
+        )
+        if duplicate is not None:
+            return self.async_abort(reason="already_configured")
+
+        entry_ready, entry_was_loaded = await _async_prepare_entry_for_repair(self.hass, entry)
+        if not entry_ready:
+            return self.async_abort(reason="cannot_unload")
+
+        current_entry = _get_entry_matching_snapshot(
+            self.hass,
+            self._entry_id,
+            entry_data_snapshot,
+            entry_options_snapshot,
+            entry_unique_id_snapshot,
+        )
+        if current_entry is None:
+            return self.async_abort(reason="entry_changed")
+        entry = current_entry
+
+        new_data = {**entry.data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+
+        try:
+            updated = self.hass.config_entries.async_update_entry(
+                entry,
+                data=new_data,
+                unique_id=observed_device_id,
+            )
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot update config entry",
+                entry.title,
+            )
+            if entry_was_loaded:
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=entry.entry_id,
+                    entry_title=entry.title,
+                )
+            return self.async_abort(reason="repair_failed")
+
+        if not updated:
+            _LOGGER.error(
+                "Device-ID repair did not finish for %s; config-entry update made no changes",
+                entry.title,
+            )
+            if entry_was_loaded:
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=entry.entry_id,
+                    entry_title=entry.title,
+                )
+            return self.async_abort(reason="repair_failed")
+
+        post_update_entry_data_snapshot: dict[str, object] = {
+            **entry_data_snapshot,
+            CONF_DEVICE_UNIQUE_ID: observed_device_id,
+        }
+        post_update_entry_unique_id_snapshot = observed_device_id
+
+        if not self._cleanup_entry_registries(entry):
+            return self.async_abort(reason="repair_failed")
+
+        return await self._async_reload_with_recovery(
+            entry,
+            data_snapshot=post_update_entry_data_snapshot,
+            options_snapshot=entry_options_snapshot,
+            unique_id_snapshot=post_update_entry_unique_id_snapshot,
+        )
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create a device-ID replacement flow for a well-formed issue.
+
+    Args:
+        hass: Home Assistant instance that owns the repair flow.
+        issue_id: Issue identifier used to select the repair type.
+        data: Issue data containing the entry and device identifiers.
+
+    Returns:
+        RepairsFlow: Device-ID repair flow or a generic confirmation flow.
+    """
+    del hass
+    if not issue_id.endswith(_ISSUE_SUFFIX) or data is None:
+        return ConfirmRepairFlow()
+
+    entry_id = data.get("entry_id")
+    old_device_id = data.get("old_device_id")
+    new_device_id = data.get("new_device_id")
+    if not (
+        isinstance(entry_id, str)
+        and entry_id
+        and isinstance(old_device_id, str)
+        and old_device_id
+        and isinstance(new_device_id, str)
+        and new_device_id
+        and issue_id == f"{entry_id}{_ISSUE_SUFFIX}"
+    ):
+        return ConfirmRepairFlow()
+
+    return DeviceIDMismatchRepairFlow(
+        entry_id=entry_id,
+        old_device_id=old_device_id,
+        new_device_id=new_device_id,
+    )

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import issue_registry as ir
 import voluptuous as vol
 
 from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
-from .helpers import create_opnsense_client_from_config_entry
+from .helpers import create_opnsense_client_from_config_entry, is_carp_entry
 from .repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker, parse_repair_marker
 
 _DEVICE_ID_MISMATCH_ISSUE_SUFFIX = "_device_id_mismatched"
@@ -202,7 +202,9 @@ def async_create_device_id_mismatch_issue(
     Returns:
         bool: `True` when the issue was created; otherwise `False` for invalid IDs.
     """
-    old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+    if is_carp_entry(config_entry):
+        return False
+    old_device_id = config_entry.data.get(CONF_DEVICE_UNIQUE_ID)
     if not is_valid_device_id(old_device_id) or not is_valid_device_id(observed_device_id):
         return False
     ir.async_create_issue(
@@ -457,6 +459,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 candidate
                 for candidate in self.hass.config_entries.async_entries(DOMAIN)
                 if candidate.entry_id != entry.entry_id
+                and not is_carp_entry(candidate)
                 and candidate.unique_id == reprobed_device_id
             ),
             None,
@@ -491,6 +494,8 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
             return self.async_abort(reason="entry_not_found")
+        if is_carp_entry(entry):
+            return self.async_abort(reason="entry_changed")
         _LOGGER.info("Starting Device ID repair for %s", entry.title)
         entry_data_snapshot = deepcopy(dict(entry.data))
         entry_options_snapshot = deepcopy(dict(entry.options))
@@ -572,6 +577,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 candidate
                 for candidate in self.hass.config_entries.async_entries(DOMAIN)
                 if candidate.entry_id != entry.entry_id
+                and not is_carp_entry(candidate)
                 and candidate.unique_id == observed_device_id
             ),
             None,
@@ -683,7 +689,6 @@ async def async_create_fix_flow(
     Returns:
         RepairsFlow: Device ID repair flow or a generic confirmation flow.
     """
-    del hass
     if not issue_id.endswith(_DEVICE_ID_MISMATCH_ISSUE_SUFFIX) or data is None:
         return ConfirmRepairFlow()
 
@@ -697,6 +702,10 @@ async def async_create_fix_flow(
         and is_valid_device_id(new_device_id)
         and issue_id == build_device_id_mismatch_issue_id(entry_id)
     ):
+        return ConfirmRepairFlow()
+
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if entry is not None and is_carp_entry(entry):
         return ConfirmRepairFlow()
 
     return DeviceIDMismatchRepairFlow(

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -284,6 +284,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         """
         try:
             if await self.hass.config_entries.async_reload(entry.entry_id):
+                _LOGGER.info("Device-ID repair reload completed for %s", entry.title)
                 return self.async_create_entry(data={})
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
@@ -490,6 +491,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
             return self.async_abort(reason="entry_not_found")
+        _LOGGER.info("Starting device-ID repair for %s", entry.title)
         entry_data_snapshot = deepcopy(dict(entry.data))
         entry_options_snapshot = deepcopy(dict(entry.options))
         entry_unique_id_snapshot = entry.unique_id
@@ -644,6 +646,12 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                     entry_title=entry.title,
                 )
             return self.async_abort(reason="repair_failed")
+
+        _LOGGER.info(
+            "Device-ID repair persisted replacement identity for %s; "
+            "reloading for registry reconciliation",
+            entry.title,
+        )
 
         post_update_entry_data_snapshot: dict[str, object] = {
             **entry_data_snapshot,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -16,8 +16,13 @@ from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
 from .helpers import create_opnsense_client_from_config_entry
 from .repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker, parse_repair_marker
 
-_ISSUE_SUFFIX = "_device_id_mismatched"
+_DEVICE_ID_MISMATCH_ISSUE_SUFFIX = "_device_id_mismatched"
 _LOGGER = logging.getLogger(__name__)
+
+
+def build_device_id_mismatch_issue_id(entry_id: str) -> str:
+    """Build the stable mismatch issue ID for a config entry."""
+    return f"{entry_id}{_DEVICE_ID_MISMATCH_ISSUE_SUFFIX}"
 
 
 def is_valid_device_id(device_id: object) -> TypeGuard[str]:
@@ -203,7 +208,7 @@ def async_create_device_id_mismatch_issue(
     ir.async_create_issue(
         hass=hass,
         domain=DOMAIN,
-        issue_id=f"{config_entry.entry_id}{_ISSUE_SUFFIX}",
+        issue_id=build_device_id_mismatch_issue_id(config_entry.entry_id),
         is_fixable=True,
         is_persistent=False,
         severity=ir.IssueSeverity.ERROR,
@@ -598,7 +603,7 @@ async def async_create_fix_flow(
         RepairsFlow: Device-ID repair flow or a generic confirmation flow.
     """
     del hass
-    if not issue_id.endswith(_ISSUE_SUFFIX) or data is None:
+    if not issue_id.endswith(_DEVICE_ID_MISMATCH_ISSUE_SUFFIX) or data is None:
         return ConfirmRepairFlow()
 
     entry_id = data.get("entry_id")
@@ -609,7 +614,7 @@ async def async_create_fix_flow(
         and entry_id
         and is_valid_device_id(old_device_id)
         and is_valid_device_id(new_device_id)
-        and issue_id == f"{entry_id}{_ISSUE_SUFFIX}"
+        and issue_id == build_device_id_mismatch_issue_id(entry_id)
     ):
         return ConfirmRepairFlow()
 

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 import logging
+from typing import TypeGuard
 
 import aiohttp
 from aiopnsense.exceptions import OPNsenseError
@@ -17,6 +18,11 @@ from .helpers import create_opnsense_client_from_config_entry
 
 _ISSUE_SUFFIX = "_device_id_mismatched"
 _LOGGER = logging.getLogger(__name__)
+
+
+def is_valid_device_id(device_id: object) -> TypeGuard[str]:
+    """Return whether a device ID is a usable string identifier."""
+    return isinstance(device_id, str) and bool(device_id.strip())
 
 
 def _entry_matches_snapshot(
@@ -144,7 +150,7 @@ def _device_id_repair_abort_reason(
     Returns:
         str | None: Repair abort reason, or ``None`` when the replacement is valid.
     """
-    if not isinstance(observed_device_id, str) or not observed_device_id:
+    if not is_valid_device_id(observed_device_id):
         return "cannot_connect"
     if observed_device_id != expected_device_id or observed_device_id == current_device_id:
         return "entry_changed"
@@ -154,7 +160,7 @@ def _device_id_repair_abort_reason(
 def async_create_device_id_mismatch_issue(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    observed_device_id: str,
+    observed_device_id: object,
 ) -> None:
     """Create a fixable hardware-replacement issue for a normal device entry.
 
@@ -164,6 +170,8 @@ def async_create_device_id_mismatch_issue(
         observed_device_id: Replacement device identifier observed at runtime.
     """
     old_device_id = config_entry.data[CONF_DEVICE_UNIQUE_ID]
+    if not is_valid_device_id(old_device_id) or not is_valid_device_id(observed_device_id):
+        return
     ir.async_create_issue(
         hass=hass,
         domain=DOMAIN,
@@ -527,10 +535,8 @@ async def async_create_fix_flow(
     if not (
         isinstance(entry_id, str)
         and entry_id
-        and isinstance(old_device_id, str)
-        and old_device_id
-        and isinstance(new_device_id, str)
-        and new_device_id
+        and is_valid_device_id(old_device_id)
+        and is_valid_device_id(new_device_id)
         and issue_id == f"{entry_id}{_ISSUE_SUFFIX}"
     ):
         return ConfirmRepairFlow()

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -301,6 +301,22 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 entry_title,
             )
 
+    def _schedule_changed_entry_reload(self, *, entry_id: str, entry_title: str) -> None:
+        """Schedule recovery for an entry that changed while it was being unloaded.
+
+        Args:
+            entry_id: Config entry ID to schedule for reload.
+            entry_title: Human-readable entry title for log context.
+        """
+        try:
+            self.hass.config_entries.async_schedule_reload(entry_id)
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair did not finish for %s; cannot schedule recovery "
+                "reload after the config entry changed during unload",
+                entry_title,
+            )
+
     def _cleanup_entry_registries(self, entry: ConfigEntry) -> bool:
         """Remove the entry's entities and device associations from the registries.
 
@@ -368,17 +384,22 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry_unique_id_snapshot = entry.unique_id
         stored_device_id = entry.data.get(CONF_DEVICE_UNIQUE_ID)
         if stored_device_id == self._expected_device_id:
-            entry_ready, _ = await _async_prepare_entry_for_repair(self.hass, entry)
+            entry_ready, entry_was_loaded = await _async_prepare_entry_for_repair(self.hass, entry)
             if not entry_ready:
                 return self.async_abort(reason="cannot_unload")
-            current_entry = _get_entry_matching_snapshot(
-                self.hass,
+            current_entry = self.hass.config_entries.async_get_entry(self._entry_id)
+            if current_entry is None or not _entry_matches_snapshot(
+                current_entry,
                 self._entry_id,
                 entry_data_snapshot,
                 entry_options_snapshot,
                 entry_unique_id_snapshot,
-            )
-            if current_entry is None:
+            ):
+                if entry_was_loaded and current_entry is not None:
+                    self._schedule_changed_entry_reload(
+                        entry_id=entry.entry_id,
+                        entry_title=entry.title,
+                    )
                 return self.async_abort(reason="entry_changed")
             if not self._cleanup_entry_registries(current_entry):
                 self._schedule_recovery_reload(
@@ -437,14 +458,19 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         if not entry_ready:
             return self.async_abort(reason="cannot_unload")
 
-        current_entry = _get_entry_matching_snapshot(
-            self.hass,
+        current_entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if current_entry is None or not _entry_matches_snapshot(
+            current_entry,
             self._entry_id,
             entry_data_snapshot,
             entry_options_snapshot,
             entry_unique_id_snapshot,
-        )
-        if current_entry is None:
+        ):
+            if entry_was_loaded and current_entry is not None:
+                self._schedule_changed_entry_reload(
+                    entry_id=entry.entry_id,
+                    entry_title=entry.title,
+                )
             return self.async_abort(reason="entry_changed")
         entry = current_entry
 

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import logging
 from typing import TypeGuard
 
-import aiohttp
 from aiopnsense.exceptions import OPNsenseError
 from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow, RepairsFlowResult
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -99,8 +98,6 @@ async def _async_validate_and_probe_device_id(
 
     Raises:
         OPNsenseError: If validation or the device-ID probe fails.
-        aiohttp.ClientError: If the client encounters a transport failure.
-        TimeoutError: If the client request times out.
     """
     client = create_opnsense_client_from_config_entry(
         hass=hass,
@@ -421,7 +418,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
 
         try:
             observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
-        except OPNsenseError, aiohttp.ClientError, TimeoutError:
+        except OPNsenseError:
             return self.async_abort(reason="cannot_connect")
 
         current_entry = _get_entry_matching_snapshot(

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -311,7 +311,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         for entity in entities_to_cleanup:
             try:
                 entity_registry.async_remove(entity.entity_id)
-            except HomeAssistantError, KeyError:
+            except HomeAssistantError, KeyError, ValueError:
                 failed_cleanup = True
                 _LOGGER.exception(
                     "Device-ID repair did not finish for %s; cannot remove entity %s",
@@ -325,7 +325,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                     device.id,
                     remove_config_entry_id=entry.entry_id,
                 )
-            except HomeAssistantError, KeyError:
+            except HomeAssistantError, KeyError, ValueError:
                 failed_cleanup = True
                 _LOGGER.exception(
                     "Device-ID repair did not finish for %s; cannot update device %s",

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -266,7 +266,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry_id: str,
         entry_title: str,
     ) -> None:
-        """Schedule a recovery reload without mutating an untouched repair entry.
+        """Schedule a guarded recovery reload when the repair may have mutated state.
 
         Args:
             data_snapshot: Snapshot of the entry data used to detect changes.
@@ -289,7 +289,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
                 "Device-ID repair did not finish for %s; cannot schedule recovery "
-                "reload after a non-mutating failure",
+                "reload after an interrupted repair mutation",
                 entry_title,
             )
 
@@ -373,6 +373,13 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             if current_entry is None:
                 return self.async_abort(reason="entry_changed")
             if not self._cleanup_entry_registries(current_entry):
+                self._schedule_recovery_reload(
+                    data_snapshot=entry_data_snapshot,
+                    options_snapshot=entry_options_snapshot,
+                    unique_id_snapshot=entry_unique_id_snapshot,
+                    entry_id=current_entry.entry_id,
+                    entry_title=current_entry.title,
+                )
                 return self.async_abort(reason="repair_failed")
             return await self._async_reload_with_recovery(
                 current_entry,
@@ -478,6 +485,13 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         post_update_entry_unique_id_snapshot = observed_device_id
 
         if not self._cleanup_entry_registries(entry):
+            self._schedule_recovery_reload(
+                data_snapshot=post_update_entry_data_snapshot,
+                options_snapshot=entry_options_snapshot,
+                unique_id_snapshot=post_update_entry_unique_id_snapshot,
+                entry_id=entry.entry_id,
+                entry_title=entry.title,
+            )
             return self.async_abort(reason="repair_failed")
 
         return await self._async_reload_with_recovery(

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -145,8 +145,18 @@ async def _async_prepare_entry_for_repair(
     entry_was_loaded = config_entry.state is ConfigEntryState.LOADED
     if not config_entry.state.recoverable:
         return False, entry_was_loaded
-    if entry_was_loaded and not await hass.config_entries.async_unload(config_entry.entry_id):
-        return False, entry_was_loaded
+    if entry_was_loaded:
+        try:
+            unload_ok = await hass.config_entries.async_unload(config_entry.entry_id)
+        except HomeAssistantError, KeyError:
+            _LOGGER.exception(
+                "Device-ID repair could not unload %s; aborting repair",
+                config_entry.title,
+            )
+            return False, entry_was_loaded
+        if not unload_ok:
+            _LOGGER.debug("Device-ID repair could not unload %s", config_entry.title)
+            return False, entry_was_loaded
     return True, entry_was_loaded
 
 

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -158,7 +158,7 @@ async def _async_prepare_entry_for_repair(
     if entry_was_loaded:
         try:
             unload_ok = await hass.config_entries.async_unload(config_entry.entry_id)
-        except HomeAssistantError, KeyError:
+        except HomeAssistantError, KeyError, TimeoutError:
             _LOGGER.exception(
                 "Device ID repair could not unload %s; aborting repair",
                 config_entry.title,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -385,6 +385,14 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry_unique_id_snapshot = entry.unique_id
         stored_device_id = entry.data.get(CONF_DEVICE_UNIQUE_ID)
         if stored_device_id == self._expected_device_id:
+            try:
+                observed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
+            except OPNsenseError:
+                return self.async_abort(reason="cannot_connect")
+            if not is_valid_device_id(observed_device_id):
+                return self.async_abort(reason="cannot_connect")
+            if observed_device_id != self._expected_device_id:
+                return self.async_abort(reason="entry_changed")
             entry_ready, entry_was_loaded = await _async_prepare_entry_for_repair(self.hass, entry)
             if not entry_ready:
                 return self.async_abort(reason="cannot_unload")

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -475,6 +475,18 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             return self.async_abort(reason="entry_changed")
         entry = current_entry
 
+        duplicate = next(
+            (
+                candidate
+                for candidate in self.hass.config_entries.async_entries(DOMAIN)
+                if candidate.entry_id != entry.entry_id
+                and candidate.unique_id == observed_device_id
+            ),
+            None,
+        )
+        if duplicate is not None:
+            return self.async_abort(reason="already_configured")
+
         new_data = {**entry.data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
 
         try:

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -120,7 +120,7 @@ async def _async_validate_and_probe_device_id(
         str | None: Device identifier returned by OPNsense.
 
     Raises:
-        OPNsenseError: If validation or the device-ID probe fails.
+        OPNsenseError: If validation or the Device ID probe fails.
     """
     client = create_opnsense_client_from_config_entry(
         hass=hass,
@@ -155,12 +155,12 @@ async def _async_prepare_entry_for_repair(
             unload_ok = await hass.config_entries.async_unload(config_entry.entry_id)
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
-                "Device-ID repair could not unload %s; aborting repair",
+                "Device ID repair could not unload %s; aborting repair",
                 config_entry.title,
             )
             return False, entry_was_loaded
         if not unload_ok:
-            _LOGGER.debug("Device-ID repair could not unload %s", config_entry.title)
+            _LOGGER.debug("Device ID repair could not unload %s", config_entry.title)
             return False, entry_was_loaded
     return True, entry_was_loaded
 
@@ -284,11 +284,11 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         """
         try:
             if await self.hass.config_entries.async_reload(entry.entry_id):
-                _LOGGER.info("Device-ID repair reload completed for %s", entry.title)
+                _LOGGER.info("Device ID repair reload completed for %s", entry.title)
                 return self.async_create_entry(data={})
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
-                "Device-ID repair did not finish for %s; cannot reload entry",
+                "Device ID repair did not finish for %s; cannot reload entry",
                 entry.title,
             )
         self._schedule_recovery_reload(
@@ -332,7 +332,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             self.hass.config_entries.async_schedule_reload(entry_id)
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
-                "Device-ID repair did not finish for %s; cannot schedule recovery "
+                "Device ID repair did not finish for %s; cannot schedule recovery "
                 "reload after an interrupted repair mutation",
                 entry_title,
             )
@@ -348,7 +348,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             self.hass.config_entries.async_schedule_reload(entry_id)
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
-                "Device-ID repair did not finish for %s; cannot schedule recovery "
+                "Device ID repair did not finish for %s; cannot schedule recovery "
                 "reload after the config entry changed during unload",
                 entry_title,
             )
@@ -491,7 +491,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         entry = self.hass.config_entries.async_get_entry(self._entry_id)
         if entry is None:
             return self.async_abort(reason="entry_not_found")
-        _LOGGER.info("Starting device-ID repair for %s", entry.title)
+        _LOGGER.info("Starting Device ID repair for %s", entry.title)
         entry_data_snapshot = deepcopy(dict(entry.data))
         entry_options_snapshot = deepcopy(dict(entry.options))
         entry_unique_id_snapshot = entry.unique_id
@@ -619,7 +619,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             )
         except HomeAssistantError, KeyError:
             _LOGGER.exception(
-                "Device-ID repair did not finish for %s; cannot update config entry",
+                "Device ID repair did not finish for %s; cannot update config entry",
                 entry.title,
             )
             if entry_was_loaded:
@@ -634,7 +634,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
 
         if not updated:
             _LOGGER.error(
-                "Device-ID repair did not finish for %s; config-entry update made no changes",
+                "Device ID repair did not finish for %s; config-entry update made no changes",
                 entry.title,
             )
             if entry_was_loaded:
@@ -648,7 +648,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             return self.async_abort(reason="repair_failed")
 
         _LOGGER.info(
-            "Device-ID repair persisted replacement identity for %s; "
+            "Device ID repair persisted replacement identity for %s; "
             "reloading for registry reconciliation",
             entry.title,
         )
@@ -673,7 +673,7 @@ async def async_create_fix_flow(
     issue_id: str,
     data: dict[str, str | int | float | None] | None,
 ) -> RepairsFlow:
-    """Create a device-ID replacement flow for a well-formed issue.
+    """Create a Device ID replacement flow for a well-formed issue.
 
     Args:
         hass: Home Assistant instance that owns the repair flow.
@@ -681,7 +681,7 @@ async def async_create_fix_flow(
         data: Issue data containing the entry and device identifiers.
 
     Returns:
-        RepairsFlow: Device-ID repair flow or a generic confirmation flow.
+        RepairsFlow: Device ID repair flow or a generic confirmation flow.
     """
     del hass
     if not issue_id.endswith(_DEVICE_ID_MISMATCH_ISSUE_SUFFIX) or data is None:

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -391,6 +391,84 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             )
         return None
 
+    async def _async_validate_post_unload_reprobe(
+        self,
+        *,
+        entry: ConfigEntry,
+        entry_was_loaded: bool,
+        entry_data_snapshot: dict[str, object],
+        entry_options_snapshot: dict[str, object],
+        entry_unique_id_snapshot: str | None,
+    ) -> tuple[ConfigEntry, str] | str:
+        """Strictly re-probe and validate an entry after it has been unloaded.
+
+        Args:
+            entry: Unloaded OPNsense config entry to re-probe.
+            entry_was_loaded: Whether the entry was loaded before repair preparation.
+            entry_data_snapshot: Original config-entry data mapping.
+            entry_options_snapshot: Original config-entry options mapping.
+            entry_unique_id_snapshot: Original config-entry unique ID.
+
+        Returns:
+            tuple[ConfigEntry, str] | str: Validated entry and device ID, or the
+            repair abort reason.
+        """
+        try:
+            reprobed_device_id = await _async_validate_and_probe_device_id(self.hass, entry)
+        except OPNsenseError:
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=entry,
+            )
+            return "cannot_connect"
+
+        if not is_valid_device_id(reprobed_device_id):
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=entry,
+            )
+            return "cannot_connect"
+
+        current_entry = self._validate_entry_snapshot(
+            current_entry=self.hass.config_entries.async_get_entry(self._entry_id),
+            entry_was_loaded=entry_was_loaded,
+            entry_data_snapshot=entry_data_snapshot,
+            entry_options_snapshot=entry_options_snapshot,
+            entry_unique_id_snapshot=entry_unique_id_snapshot,
+        )
+        if current_entry is None:
+            return "entry_changed"
+        entry = current_entry
+
+        if abort_reason := _device_id_repair_abort_reason(
+            reprobed_device_id,
+            self._expected_device_id,
+            entry.data.get(CONF_DEVICE_UNIQUE_ID),
+        ):
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=entry,
+            )
+            return abort_reason
+
+        duplicate = next(
+            (
+                candidate
+                for candidate in self.hass.config_entries.async_entries(DOMAIN)
+                if candidate.entry_id != entry.entry_id
+                and candidate.unique_id == reprobed_device_id
+            ),
+            None,
+        )
+        if duplicate is not None:
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=entry,
+            )
+            return "already_configured"
+
+        return entry, reprobed_device_id
+
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
     ) -> RepairsFlowResult:
@@ -514,25 +592,20 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             return self.async_abort(reason="entry_changed")
         entry = current_entry
 
-        duplicate = next(
-            (
-                candidate
-                for candidate in self.hass.config_entries.async_entries(DOMAIN)
-                if candidate.entry_id != entry.entry_id
-                and candidate.unique_id == observed_device_id
-            ),
-            None,
+        reprobe_result = await self._async_validate_post_unload_reprobe(
+            entry=entry,
+            entry_was_loaded=entry_was_loaded,
+            entry_data_snapshot=entry_data_snapshot,
+            entry_options_snapshot=entry_options_snapshot,
+            entry_unique_id_snapshot=entry_unique_id_snapshot,
         )
-        if duplicate is not None:
-            self._schedule_changed_entry_reload_if_needed(
-                entry_was_loaded=entry_was_loaded,
-                entry=entry,
-            )
-            return self.async_abort(reason="already_configured")
+        if isinstance(reprobe_result, str):
+            return self.async_abort(reason=reprobe_result)
+        entry, reprobed_device_id = reprobe_result
 
         new_data = {
             **entry.data,
-            CONF_DEVICE_UNIQUE_ID: observed_device_id,
+            CONF_DEVICE_UNIQUE_ID: reprobed_device_id,
             REPAIR_MARKER_KEY: expected_repair_marker,
         }
 
@@ -574,10 +647,10 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
 
         post_update_entry_data_snapshot: dict[str, object] = {
             **entry_data_snapshot,
-            CONF_DEVICE_UNIQUE_ID: observed_device_id,
+            CONF_DEVICE_UNIQUE_ID: reprobed_device_id,
             REPAIR_MARKER_KEY: expected_repair_marker,
         }
-        post_update_entry_unique_id_snapshot = observed_device_id
+        post_update_entry_unique_id_snapshot = reprobed_device_id
 
         return await self._async_reload_with_recovery(
             entry,

--- a/custom_components/opnsense/repairs.py
+++ b/custom_components/opnsense/repairs.py
@@ -12,7 +12,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 import voluptuous as vol
 
-from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from .const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
 from .helpers import create_opnsense_client_from_config_entry
 from .repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker, parse_repair_marker
 
@@ -31,6 +31,8 @@ def _entry_matches_snapshot(
     data_snapshot: dict[str, object],
     options_snapshot: dict[str, object],
     unique_id_snapshot: str | None,
+    *,
+    allow_tracked_macs_mutation: bool = False,
 ) -> bool:
     """Return whether a re-fetched entry still matches the repair snapshot.
 
@@ -40,17 +42,32 @@ def _entry_matches_snapshot(
         data_snapshot: Original config-entry data mapping.
         options_snapshot: Original config-entry options mapping.
         unique_id_snapshot: Original config-entry unique ID.
+        allow_tracked_macs_mutation: Whether tracked-MACS-only changes are ignored.
 
     Returns:
         bool: ``True`` when the entry identity and persisted values are unchanged.
     """
+    normalized_snapshot = data_snapshot
+    normalized_entry_data = dict(entry.data) if entry is not None else None
+    if allow_tracked_macs_mutation:
+        normalized_snapshot = _without_tracked_macs_for_recovery(normalized_snapshot)
+        if normalized_entry_data is not None:
+            normalized_entry_data = _without_tracked_macs_for_recovery(normalized_entry_data)
+
     return bool(
         entry is not None
         and entry.entry_id == entry_id
-        and dict(entry.data) == data_snapshot
+        and normalized_entry_data == normalized_snapshot
         and dict(entry.options) == options_snapshot
         and entry.unique_id == unique_id_snapshot
     )
+
+
+def _without_tracked_macs_for_recovery(payload: dict[str, object]) -> dict[str, object]:
+    """Return a snapshot copy that ignores setup-time tracked MAC mutations."""
+    normalized_payload: dict[str, object] = dict(payload)
+    normalized_payload.pop(TRACKED_MACS, None)
+    return normalized_payload
 
 
 def _get_entry_matching_snapshot(
@@ -292,6 +309,7 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             data_snapshot,
             options_snapshot,
             unique_id_snapshot,
+            allow_tracked_macs_mutation=True,
         ):
             return
         try:
@@ -318,6 +336,45 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
                 "reload after the config entry changed during unload",
                 entry_title,
             )
+
+    def _schedule_changed_entry_reload_if_needed(
+        self,
+        *,
+        entry_was_loaded: bool,
+        entry: ConfigEntry,
+    ) -> None:
+        """Schedule a recovery reload when a previously loaded entry changed."""
+        if entry_was_loaded:
+            self._schedule_changed_entry_reload(
+                entry_id=entry.entry_id,
+                entry_title=entry.title,
+            )
+
+    def _validate_entry_snapshot(
+        self,
+        *,
+        current_entry: ConfigEntry | None,
+        entry_was_loaded: bool,
+        entry_data_snapshot: dict[str, object],
+        entry_options_snapshot: dict[str, object],
+        entry_unique_id_snapshot: str | None,
+    ) -> ConfigEntry | None:
+        """Return the entry when the runtime snapshot still matches."""
+        if _entry_matches_snapshot(
+            current_entry,
+            self._entry_id,
+            entry_data_snapshot,
+            entry_options_snapshot,
+            entry_unique_id_snapshot,
+        ):
+            return current_entry
+
+        if current_entry is not None:
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=current_entry,
+            )
+        return None
 
     async def async_step_confirm(
         self, user_input: dict[str, str] | None = None
@@ -374,19 +431,14 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             entry_ready, entry_was_loaded = await _async_prepare_entry_for_repair(self.hass, entry)
             if not entry_ready:
                 return self.async_abort(reason="cannot_unload")
-            current_entry = self.hass.config_entries.async_get_entry(self._entry_id)
-            if current_entry is None or not _entry_matches_snapshot(
-                current_entry,
-                self._entry_id,
-                entry_data_snapshot,
-                entry_options_snapshot,
-                entry_unique_id_snapshot,
-            ):
-                if entry_was_loaded and current_entry is not None:
-                    self._schedule_changed_entry_reload(
-                        entry_id=entry.entry_id,
-                        entry_title=entry.title,
-                    )
+            current_entry = self._validate_entry_snapshot(
+                current_entry=self.hass.config_entries.async_get_entry(self._entry_id),
+                entry_was_loaded=entry_was_loaded,
+                entry_data_snapshot=entry_data_snapshot,
+                entry_options_snapshot=entry_options_snapshot,
+                entry_unique_id_snapshot=entry_unique_id_snapshot,
+            )
+            if current_entry is None:
                 return self.async_abort(reason="entry_changed")
             return await self._async_reload_with_recovery(
                 current_entry,
@@ -436,19 +488,14 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
         if not entry_ready:
             return self.async_abort(reason="cannot_unload")
 
-        current_entry = self.hass.config_entries.async_get_entry(self._entry_id)
-        if current_entry is None or not _entry_matches_snapshot(
-            current_entry,
-            self._entry_id,
-            entry_data_snapshot,
-            entry_options_snapshot,
-            entry_unique_id_snapshot,
-        ):
-            if entry_was_loaded and current_entry is not None:
-                self._schedule_changed_entry_reload(
-                    entry_id=entry.entry_id,
-                    entry_title=entry.title,
-                )
+        current_entry = self._validate_entry_snapshot(
+            current_entry=self.hass.config_entries.async_get_entry(self._entry_id),
+            entry_was_loaded=entry_was_loaded,
+            entry_data_snapshot=entry_data_snapshot,
+            entry_options_snapshot=entry_options_snapshot,
+            entry_unique_id_snapshot=entry_unique_id_snapshot,
+        )
+        if current_entry is None:
             return self.async_abort(reason="entry_changed")
         entry = current_entry
 
@@ -462,6 +509,10 @@ class DeviceIDMismatchRepairFlow(RepairsFlow):
             None,
         )
         if duplicate is not None:
+            self._schedule_changed_entry_reload_if_needed(
+                entry_was_loaded=entry_was_loaded,
+                entry=entry,
+            )
             return self.async_abort(reason="already_configured")
 
         new_data = {

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -47,6 +47,7 @@ from .const import (
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import coerce_bool, dict_get, get_smart_device_name, is_carp_entry
+from .repair_reconciliation import record_desired_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -1610,6 +1611,7 @@ async def async_setup_entry(
         entities.extend(await _compile_dhcp_leases_sensors(config_entry, coordinator, state))
 
     _LOGGER.debug("[sensor async_setup_entry] entities: %s", len(entities))
+    record_desired_entities(config_entry, "sensor", entities)
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1618,12 +1618,17 @@ async def async_setup_entry(
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
-        has_smart_inventory = (
-            "smart" in state
-            and isinstance(state.get("smart"), list)
-            and "smart_info" in state
-            and isinstance(state.get("smart_info"), Mapping)
-        )
+        client = getattr(config_entry.runtime_data, OPNSENSE_CLIENT, None)
+        client_supports_smart = callable(getattr(client, "get_smart", None))
+        client_supports_smart_info = callable(getattr(client, "get_smart_info", None))
+        has_smart = "smart" in state and isinstance(state.get("smart"), list)
+        has_smart_info = "smart_info" in state and isinstance(state.get("smart_info"), Mapping)
+        if client is None:
+            has_smart_inventory = has_smart and has_smart_info
+        elif client_supports_smart:
+            has_smart_inventory = has_smart and (not client_supports_smart_info or has_smart_info)
+        else:
+            has_smart_inventory = False
         entities.extend(await _compile_smart_sensors(config_entry, coordinator, state))
         if not has_smart_inventory:
             reconciliation_complete = False

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -93,7 +93,6 @@ _CARP_STATUS_ICONS: Final[Mapping[str, str]] = {
 }
 
 
-
 def _is_valid_vnstat_interface_row(interface_name: Any) -> TypeIs[str]:
     """Return whether a vnStat interface key can produce sensors."""
     return isinstance(interface_name, str)
@@ -101,11 +100,7 @@ def _is_valid_vnstat_interface_row(interface_name: Any) -> TypeIs[str]:
 
 def _is_valid_smart_device_row(smart_device: Any) -> bool:
     """Return whether a SMART device row can produce a sensor."""
-    return (
-        isinstance(smart_device, Mapping)
-        and isinstance(smart_device.get("device"), str)
-        and bool(smart_device["device"].strip())
-    )
+    return isinstance(smart_device, Mapping) and bool(get_smart_device_name(smart_device))
 
 
 def _is_valid_filesystem_row(filesystem: Any) -> bool:
@@ -1092,8 +1087,7 @@ async def _compile_smart_sensors(
     for smart_device in smart_devices:
         if not _is_valid_smart_device_row(smart_device):
             continue
-        device_name = smart_device["device"]
-        device_name = device_name.strip()
+        device_name = get_smart_device_name(smart_device)
         entities.append(
             _create_sensor(
                 OPNsenseSmartSensor,

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -133,7 +133,7 @@ def _is_valid_vpn_sensor_row(instance: Any) -> bool:
 
 def _vnstat_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
     """Return whether every consumed vnStat interface row is valid."""
-    interfaces = dict_get(state, "vnstat.interfaces", {}) or {}
+    interfaces = dict_get(state, "vnstat.interfaces", {})
     return isinstance(interfaces, MutableMapping) and all(
         _is_valid_vnstat_interface_row(interface_name) for interface_name in interfaces
     )
@@ -146,7 +146,7 @@ def _vpn_sensor_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
         ("wireguard", ("clients", "servers")),
     ):
         for group in groups:
-            instances = dict_get(state, f"{vpn_type}.{group}", {}) or {}
+            instances = dict_get(state, f"{vpn_type}.{group}", {})
             if not isinstance(instances, MutableMapping) or not all(
                 _is_valid_vpn_sensor_row(instance) for instance in instances.values()
             ):

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -5,7 +5,7 @@ import inspect
 import ipaddress
 import logging
 import re
-from typing import Any, Final
+from typing import Any, Final, TypeIs
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -91,6 +91,85 @@ _CARP_STATUS_ICONS: Final[Mapping[str, str]] = {
     "MASTER": "mdi:check-network",
     "BACKUP": "mdi:backup-restore",
 }
+
+
+
+def _is_valid_vnstat_interface_row(interface_name: Any) -> TypeIs[str]:
+    """Return whether a vnStat interface key can produce sensors."""
+    return isinstance(interface_name, str)
+
+
+def _is_valid_smart_device_row(smart_device: Any) -> bool:
+    """Return whether a SMART device row can produce a sensor."""
+    return (
+        isinstance(smart_device, Mapping)
+        and isinstance(smart_device.get("device"), str)
+        and bool(smart_device["device"].strip())
+    )
+
+
+def _is_valid_filesystem_row(filesystem: Any) -> bool:
+    """Return whether a filesystem row can produce a sensor."""
+    return (
+        isinstance(filesystem, Mapping)
+        and isinstance(filesystem.get("mountpoint"), str)
+        and bool(filesystem["mountpoint"].strip())
+    )
+
+
+def _is_valid_carp_interface_row(interface: Any) -> bool:
+    """Return whether a CARP interface row can produce a sensor."""
+    return (
+        isinstance(interface, MutableMapping)
+        and isinstance(interface.get("subnet"), str)
+        and bool(interface["subnet"].strip())
+    )
+
+
+def _is_valid_mutable_mapping_row(row: Any) -> bool:
+    """Return whether a dynamic inventory row is a mutable mapping."""
+    return isinstance(row, MutableMapping)
+
+
+def _is_valid_vpn_sensor_row(instance: Any) -> bool:
+    """Return whether a VPN instance row can produce sensors."""
+    return isinstance(instance, MutableMapping) and len(instance) > 0
+
+
+def _vnstat_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
+    """Return whether every consumed vnStat interface row is valid."""
+    interfaces = dict_get(state, "vnstat.interfaces", {}) or {}
+    return isinstance(interfaces, MutableMapping) and all(
+        _is_valid_vnstat_interface_row(interface_name) for interface_name in interfaces
+    )
+
+
+def _vpn_sensor_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
+    """Return whether every VPN row consumed by the sensor compiler is valid."""
+    for vpn_type, groups in (
+        ("openvpn", ("servers",)),
+        ("wireguard", ("clients", "servers")),
+    ):
+        for group in groups:
+            instances = dict_get(state, f"{vpn_type}.{group}", {}) or {}
+            if not isinstance(instances, MutableMapping) or not all(
+                _is_valid_vpn_sensor_row(instance) for instance in instances.values()
+            ):
+                return False
+    return True
+
+
+def _telemetry_rows_are_complete(telemetry: Any) -> bool:
+    """Return whether telemetry inventories and all consumed rows are valid."""
+    return (
+        isinstance(telemetry, MutableMapping)
+        and "filesystems" in telemetry
+        and isinstance(telemetry.get("filesystems"), list)
+        and all(_is_valid_filesystem_row(row) for row in telemetry["filesystems"])
+        and "temps" in telemetry
+        and isinstance(telemetry.get("temps"), MutableMapping)
+        and all(_is_valid_mutable_mapping_row(row) for row in telemetry["temps"].values())
+    )
 
 
 STATIC_TELEMETRY_SENSORS: Final[tuple[SensorEntityDescription, ...]] = (
@@ -897,7 +976,7 @@ async def _compile_vnstat_sensors(
 
     entities: list = []
     for interface_name in vnstat_interfaces:
-        if not isinstance(interface_name, str):
+        if not _is_valid_vnstat_interface_row(interface_name):
             continue
         interface_display_name = interface_descriptions.get(interface_name, interface_name)
         for metric_name, metric_def in metric_defs.items():
@@ -1011,11 +1090,10 @@ async def _compile_smart_sensors(
         return []
     entities: list = []
     for smart_device in smart_devices:
-        if not isinstance(smart_device, Mapping):
+        if not _is_valid_smart_device_row(smart_device):
             continue
-        device_name = get_smart_device_name(smart_device)
-        if not device_name:
-            continue
+        device_name = smart_device["device"]
+        device_name = device_name.strip()
         entities.append(
             _create_sensor(
                 OPNsenseSmartSensor,
@@ -1054,9 +1132,7 @@ async def _compile_filesystem_sensors(
         [
             _build_filesystem_sensor_description(filesystem)
             for filesystem in filesystems
-            if isinstance(filesystem, Mapping)
-            and isinstance(filesystem.get("mountpoint"), str)
-            and filesystem["mountpoint"].strip()
+            if _is_valid_filesystem_row(filesystem)
         ],
     )
 
@@ -1085,18 +1161,14 @@ async def _compile_carp_interface_sensors(
     )
     carp_interfaces = dict_get(state, "carp.interfaces", []) or []
     for interface in carp_interfaces:
-        if not isinstance(interface, MutableMapping):
+        if not _is_valid_carp_interface_row(interface):
             _LOGGER.debug(
-                "Skipping malformed CARP interface entry that is not a mapping: %r",
+                "Skipping malformed CARP interface entry: %r",
                 interface,
             )
             continue
         try:
-            subnet = interface.get("subnet")
-            if not isinstance(subnet, str) or not subnet.strip():
-                _LOGGER.debug("Skipping CARP interface entry with invalid subnet: %r", interface)
-                continue
-            subnet = subnet.strip()
+            subnet = interface["subnet"].strip()
 
             interface_name = interface.get("interface")
             interface_label = str(interface_name).strip() if interface_name is not None else ""
@@ -1344,7 +1416,7 @@ async def _compile_interface_sensors(
         return []
 
     for interface_name, interface in interfaces.items():
-        if not isinstance(interface, MutableMapping):
+        if not _is_valid_mutable_mapping_row(interface):
             continue
         entities.extend(
             _create_sensor(
@@ -1383,7 +1455,7 @@ async def _compile_gateway_sensors(
         return []
 
     for gateway_key, gateway in gateways.items():
-        if not isinstance(gateway, MutableMapping):
+        if not _is_valid_mutable_mapping_row(gateway):
             continue
         gateway_name = OPNsenseEntity.payload_display_name(gateway, str(gateway_key), "name")
         entities.extend(
@@ -1425,7 +1497,7 @@ async def _compile_temperature_sensors(
         return []
 
     for temp_device, temp in temps.items():
-        if not isinstance(temp, MutableMapping):
+        if not _is_valid_mutable_mapping_row(temp):
             continue
         entities.append(
             _create_sensor(
@@ -1514,7 +1586,7 @@ async def _compile_vpn_sensors(
             if not isinstance(vpn_instances, MutableMapping):
                 continue
             for uuid, instance in vpn_instances.items():
-                if not isinstance(instance, MutableMapping) or len(instance) == 0:
+                if not _is_valid_vpn_sensor_row(instance):
                     continue
                 instance_name = OPNsenseEntity.payload_display_name(
                     instance,
@@ -1590,26 +1662,15 @@ async def async_setup_entry(
 
     if config.get(CONF_SYNC_TELEMETRY, DEFAULT_SYNC_OPTION_VALUE):
         telemetry = state.get("telemetry")
-        has_filesystem_inventory = (
-            "telemetry" in state
-            and isinstance(telemetry, MutableMapping)
-            and "filesystems" in telemetry
-            and isinstance(telemetry.get("filesystems"), list)
-        )
-        has_temperature_inventory = (
-            "telemetry" in state
-            and isinstance(telemetry, MutableMapping)
-            and "temps" in telemetry
-            and isinstance(telemetry.get("temps"), Mapping)
-        )
         entities.extend(await _compile_static_telemetry_sensors(config_entry, coordinator))
         entities.extend(await _compile_filesystem_sensors(config_entry, coordinator, state))
         entities.extend(await _compile_temperature_sensors(config_entry, coordinator, state))
-        if not (has_filesystem_inventory and has_temperature_inventory):
+        if "telemetry" not in state or not _telemetry_rows_are_complete(telemetry):
             reconciliation_complete = False
     if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
         if "vnstat" in state and isinstance(state.get("vnstat"), MutableMapping):
             entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
+            reconciliation_complete &= _vnstat_rows_are_complete(state)
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SPEEDTEST, DEFAULT_SYNC_OPTION_VALUE):
@@ -1629,6 +1690,9 @@ async def async_setup_entry(
             has_smart_inventory = has_smart and (not client_supports_smart_info or has_smart_info)
         else:
             has_smart_inventory = False
+        has_smart_inventory = has_smart_inventory and all(
+            _is_valid_smart_device_row(device) for device in state["smart"]
+        )
         entities.extend(await _compile_smart_sensors(config_entry, coordinator, state))
         if not has_smart_inventory:
             reconciliation_complete = False
@@ -1642,16 +1706,28 @@ async def async_setup_entry(
             state.get("wireguard"), MutableMapping
         )
         entities.extend(await _compile_vpn_sensors(config_entry, coordinator, state))
-        if not (has_openvpn_inventory and has_wireguard_inventory):
+        if not (
+            has_openvpn_inventory
+            and has_wireguard_inventory
+            and _vpn_sensor_rows_are_complete(state)
+        ):
             reconciliation_complete = False
     if config.get(CONF_SYNC_GATEWAYS, DEFAULT_SYNC_OPTION_VALUE):
-        if "gateways" in state and isinstance(state.get("gateways"), MutableMapping):
+        gateways = state.get("gateways")
+        if "gateways" in state and isinstance(gateways, MutableMapping):
             entities.extend(await _compile_gateway_sensors(config_entry, coordinator, state))
+            reconciliation_complete &= all(
+                _is_valid_mutable_mapping_row(row) for row in gateways.values()
+            )
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
-        if "interfaces" in state and isinstance(state.get("interfaces"), MutableMapping):
+        interfaces = state.get("interfaces")
+        if "interfaces" in state and isinstance(interfaces, MutableMapping):
             entities.extend(await _compile_interface_sensors(config_entry, coordinator, state))
+            reconciliation_complete &= all(
+                _is_valid_mutable_mapping_row(row) for row in interfaces.values()
+            )
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
@@ -1664,6 +1740,9 @@ async def async_setup_entry(
             and isinstance(carp.get("interfaces"), list)
         ):
             entities.extend(await _compile_carp_interface_sensors(config_entry, coordinator, state))
+            reconciliation_complete &= all(
+                _is_valid_carp_interface_row(interface) for interface in carp["interfaces"]
+            )
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_DHCP_LEASES, DEFAULT_SYNC_OPTION_VALUE):

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1589,9 +1589,24 @@ async def async_setup_entry(
     reconciliation_complete = True
 
     if config.get(CONF_SYNC_TELEMETRY, DEFAULT_SYNC_OPTION_VALUE):
+        telemetry = state.get("telemetry")
+        has_filesystem_inventory = (
+            "telemetry" in state
+            and isinstance(telemetry, MutableMapping)
+            and "filesystems" in telemetry
+            and isinstance(telemetry.get("filesystems"), list)
+        )
+        has_temperature_inventory = (
+            "telemetry" in state
+            and isinstance(telemetry, MutableMapping)
+            and "temps" in telemetry
+            and isinstance(telemetry.get("temps"), Mapping)
+        )
         entities.extend(await _compile_static_telemetry_sensors(config_entry, coordinator))
         entities.extend(await _compile_filesystem_sensors(config_entry, coordinator, state))
         entities.extend(await _compile_temperature_sensors(config_entry, coordinator, state))
+        if not (has_filesystem_inventory and has_temperature_inventory):
+            reconciliation_complete = False
     if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
         if "vnstat" in state and isinstance(state.get("vnstat"), MutableMapping):
             entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
@@ -1603,7 +1618,15 @@ async def async_setup_entry(
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
+        has_smart_inventory = (
+            "smart" in state
+            and isinstance(state.get("smart"), list)
+            and "smart_info" in state
+            and isinstance(state.get("smart_info"), Mapping)
+        )
         entities.extend(await _compile_smart_sensors(config_entry, coordinator, state))
+        if not has_smart_inventory:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_CERTIFICATES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_certificate_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
@@ -1613,9 +1636,8 @@ async def async_setup_entry(
         has_wireguard_inventory = "wireguard" in state and isinstance(
             state.get("wireguard"), MutableMapping
         )
-        if has_openvpn_inventory or has_wireguard_inventory:
-            entities.extend(await _compile_vpn_sensors(config_entry, coordinator, state))
-        else:
+        entities.extend(await _compile_vpn_sensors(config_entry, coordinator, state))
+        if not (has_openvpn_inventory and has_wireguard_inventory):
             reconciliation_complete = False
     if config.get(CONF_SYNC_GATEWAYS, DEFAULT_SYNC_OPTION_VALUE):
         if "gateways" in state and isinstance(state.get("gateways"), MutableMapping):
@@ -1629,9 +1651,26 @@ async def async_setup_entry(
             reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_carp_status_sensor(config_entry, coordinator, state))
-        entities.extend(await _compile_carp_interface_sensors(config_entry, coordinator, state))
+        carp = state.get("carp")
+        if (
+            "carp" in state
+            and isinstance(carp, MutableMapping)
+            and "interfaces" in carp
+            and isinstance(carp.get("interfaces"), list)
+        ):
+            entities.extend(await _compile_carp_interface_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_DHCP_LEASES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_dhcp_leases_sensors(config_entry, coordinator, state))
+        dhcp_leases = state.get("dhcp_leases")
+        if not (
+            "dhcp_leases" in state
+            and isinstance(dhcp_leases, MutableMapping)
+            and "lease_interfaces" in dhcp_leases
+            and isinstance(dhcp_leases.get("lease_interfaces"), MutableMapping)
+        ):
+            reconciliation_complete = False
 
     _LOGGER.debug("[sensor async_setup_entry] entities: %s", len(entities))
     record_desired_entities(config_entry, "sensor", entities if reconciliation_complete else None)

--- a/custom_components/opnsense/sensor.py
+++ b/custom_components/opnsense/sensor.py
@@ -1586,24 +1586,47 @@ async def async_setup_entry(
         async_add_entities(entities)
         return
 
+    reconciliation_complete = True
+
     if config.get(CONF_SYNC_TELEMETRY, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_telemetry_sensors(config_entry, coordinator))
         entities.extend(await _compile_filesystem_sensors(config_entry, coordinator, state))
         entities.extend(await _compile_temperature_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_VNSTAT, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
+        if "vnstat" in state and isinstance(state.get("vnstat"), MutableMapping):
+            entities.extend(await _compile_vnstat_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_SPEEDTEST, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_speedtest_sensors(config_entry, coordinator, state))
+        if "speedtest" in state and isinstance(state.get("speedtest"), MutableMapping):
+            entities.extend(await _compile_speedtest_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_SMART, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_smart_sensors(config_entry, coordinator, state))
     if config.get(CONF_SYNC_CERTIFICATES, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_static_certificate_sensors(config_entry, coordinator))
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_vpn_sensors(config_entry, coordinator, state))
+        has_openvpn_inventory = "openvpn" in state and isinstance(
+            state.get("openvpn"), MutableMapping
+        )
+        has_wireguard_inventory = "wireguard" in state and isinstance(
+            state.get("wireguard"), MutableMapping
+        )
+        if has_openvpn_inventory or has_wireguard_inventory:
+            entities.extend(await _compile_vpn_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_GATEWAYS, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_gateway_sensors(config_entry, coordinator, state))
+        if "gateways" in state and isinstance(state.get("gateways"), MutableMapping):
+            entities.extend(await _compile_gateway_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_INTERFACES, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_interface_sensors(config_entry, coordinator, state))
+        if "interfaces" in state and isinstance(state.get("interfaces"), MutableMapping):
+            entities.extend(await _compile_interface_sensors(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_carp_status_sensor(config_entry, coordinator, state))
         entities.extend(await _compile_carp_interface_sensors(config_entry, coordinator, state))
@@ -1611,7 +1634,7 @@ async def async_setup_entry(
         entities.extend(await _compile_dhcp_leases_sensors(config_entry, coordinator, state))
 
     _LOGGER.debug("[sensor async_setup_entry] entities: %s", len(entities))
-    record_desired_entities(config_entry, "sensor", entities)
+    record_desired_entities(config_entry, "sensor", entities if reconciliation_complete else None)
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -40,7 +40,7 @@ def _is_valid_vpn_switch_row(instance: Any) -> bool:
 
 def _is_valid_unbound_row(dnsbl: Any) -> bool:
     """Return whether an Unbound blocklist row can produce a switch."""
-    return isinstance(dnsbl, MutableMapping)
+    return isinstance(dnsbl, MutableMapping) and bool(dnsbl)
 
 
 def _is_valid_firewall_rule_row(rule_key: Any, rule: Any) -> bool:

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -548,30 +548,59 @@ async def async_setup_entry(
         _LOGGER.error("Missing state data in switch async_setup_entry")
         return
     config: Mapping[str, Any] = config_entry.data
+    reconciliation_complete = True
 
     entities: list = []
 
     if config.get(CONF_SYNC_FIREWALL_AND_NAT, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_firewall_rules_switches(config_entry, coordinator, state))
-        entities.extend(await _compile_nat_source_rules_switches(config_entry, coordinator, state))
-        entities.extend(
-            await _compile_nat_destination_rules_switches(config_entry, coordinator, state)
-        )
-        entities.extend(
-            await _compile_nat_one_to_one_rules_switches(config_entry, coordinator, state)
-        )
-        entities.extend(await _compile_nat_npt_rules_switches(config_entry, coordinator, state))
+        if "firewall" in state and isinstance(state.get("firewall"), MutableMapping):
+            entities.extend(
+                await _compile_firewall_rules_switches(config_entry, coordinator, state)
+            )
+            entities.extend(
+                await _compile_nat_source_rules_switches(config_entry, coordinator, state)
+            )
+            entities.extend(
+                await _compile_nat_destination_rules_switches(config_entry, coordinator, state)
+            )
+            entities.extend(
+                await _compile_nat_one_to_one_rules_switches(config_entry, coordinator, state)
+            )
+            entities.extend(await _compile_nat_npt_rules_switches(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_SERVICES, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_service_switches(config_entry, coordinator, state))
+        if "services" in state and isinstance(state.get("services"), list):
+            entities.extend(await _compile_service_switches(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
+        has_openvpn_inventory = "openvpn" in state and isinstance(
+            state.get("openvpn"), MutableMapping
+        )
+        has_wireguard_inventory = "wireguard" in state and isinstance(
+            state.get("wireguard"), MutableMapping
+        )
+        if has_openvpn_inventory or has_wireguard_inventory:
+            entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_carp_maintenance_switch(config_entry, coordinator, state))
     if config.get(CONF_SYNC_UNBOUND, DEFAULT_SYNC_OPTION_VALUE):
-        entities.extend(await _compile_unbound_switches(config_entry, coordinator, state))
+        if ATTR_UNBOUND_BLOCKLIST in state and isinstance(
+            state.get(ATTR_UNBOUND_BLOCKLIST), MutableMapping
+        ):
+            entities.extend(await _compile_unbound_switches(config_entry, coordinator, state))
+        else:
+            reconciliation_complete = False
 
     _LOGGER.debug("[switch async_setup_entry] entities: %s", len(entities))
-    record_desired_entities(config_entry, "switch", entities)
+    record_desired_entities(
+        config_entry,
+        "switch",
+        entities if reconciliation_complete else None,
+    )
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -30,7 +30,24 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 def _is_valid_service_row(service: Any) -> bool:
     """Return whether a service row can be evaluated by the compiler."""
-    return isinstance(service, Mapping)
+    return isinstance(service, Mapping) and _service_identity(service) is not None
+
+
+def _service_identity(service: Mapping[str, Any]) -> str | None:
+    """Return a stable service identity from a row when available."""
+    service_id = service.get("id")
+    if isinstance(service_id, str):
+        service_id = service_id.strip()
+        if service_id:
+            return service_id
+
+    service_name = service.get("name")
+    if isinstance(service_name, str):
+        service_name = service_name.strip()
+        if service_name:
+            return service_name
+
+    return None
 
 
 def _is_valid_vpn_switch_row(instance: Any) -> bool:
@@ -107,7 +124,7 @@ def _build_service_switch_description(service: Mapping[str, Any]) -> SwitchEntit
         A switch entity description for the service status toggle.
     """
     prop_name = "status"
-    service_id = service.get("id", service.get("name", "unknown"))
+    service_id = _service_identity(service) or "unknown"
     service_name = service.get("description", service.get("name", "Unknown"))
     return SwitchEntityDescription(
         key=f"service.{service_id}.{prop_name}",

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -65,7 +65,7 @@ def _vpn_switch_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
     """Return whether every VPN row consumed by the switch compiler is valid."""
     for vpn_type in ("openvpn", "wireguard"):
         for group in ("clients", "servers"):
-            instances = dict_get(state, f"{vpn_type}.{group}", {}) or {}
+            instances = dict_get(state, f"{vpn_type}.{group}", {})
             if not isinstance(instances, MutableMapping) or not all(
                 _is_valid_vpn_switch_row(instance) for instance in instances.values()
             ):
@@ -661,7 +661,9 @@ async def async_setup_entry(
         ):
             entities.extend(await _compile_unbound_switches(config_entry, coordinator, state))
             if not all(
-                _is_valid_unbound_row(dnsbl) for dnsbl in state[ATTR_UNBOUND_BLOCKLIST].values()
+                _is_valid_unbound_row(dnsbl)
+                for key, dnsbl in state[ATTR_UNBOUND_BLOCKLIST].items()
+                if key != "legacy"
             ):
                 reconciliation_complete = False
         else:

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -23,6 +23,7 @@ from .const import (
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import coerce_bool, dict_get, firewall_rule_id_from_payload
+from .repair_reconciliation import record_desired_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -570,6 +571,7 @@ async def async_setup_entry(
         entities.extend(await _compile_unbound_switches(config_entry, coordinator, state))
 
     _LOGGER.debug("[switch async_setup_entry] entities: %s", len(entities))
+    record_desired_entities(config_entry, "switch", entities)
     async_add_entities(entities)
 
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -28,6 +28,51 @@ from .repair_reconciliation import record_desired_entities
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
+def _is_valid_service_row(service: Any) -> bool:
+    """Return whether a service row can be evaluated by the compiler."""
+    return isinstance(service, Mapping)
+
+
+def _is_valid_vpn_switch_row(instance: Any) -> bool:
+    """Return whether a VPN instance row can produce a switch."""
+    return isinstance(instance, MutableMapping) and instance.get("enabled") is not None
+
+
+def _is_valid_unbound_row(dnsbl: Any) -> bool:
+    """Return whether an Unbound blocklist row can produce a switch."""
+    return isinstance(dnsbl, MutableMapping)
+
+
+def _is_valid_firewall_rule_row(rule_key: Any, rule: Any) -> bool:
+    """Return whether a firewall rule row can produce a switch."""
+    if not isinstance(rule, MutableMapping):
+        return False
+    rule_id = firewall_rule_id_from_payload(rule_key, rule)
+    interface = rule.get("%interface", rule.get("interface", ""))
+    return bool(rule_id) and isinstance(interface, str)
+
+
+def _is_valid_nat_rule_row(rule_key: Any, rule: Any) -> bool:
+    """Return whether a NAT rule row can produce a switch."""
+    if not isinstance(rule, MutableMapping):
+        return False
+    rule_id = firewall_rule_id_from_payload(rule_key, rule)
+    interface = rule.get("%interface", rule.get("interface", ""))
+    return bool(rule_id) and isinstance(interface, str) and bool(interface.strip())
+
+
+def _vpn_switch_rows_are_complete(state: MutableMapping[str, Any]) -> bool:
+    """Return whether every VPN row consumed by the switch compiler is valid."""
+    for vpn_type in ("openvpn", "wireguard"):
+        for group in ("clients", "servers"):
+            instances = dict_get(state, f"{vpn_type}.{group}", {}) or {}
+            if not isinstance(instances, MutableMapping) or not all(
+                _is_valid_vpn_switch_row(instance) for instance in instances.values()
+            ):
+                return False
+    return True
+
+
 def _create_switch[EntityT: OPNsenseSwitch](
     entity_cls: type[EntityT],
     config_entry: ConfigEntry,
@@ -232,7 +277,7 @@ async def _compile_service_switches(
 
     entities: list = []
     for service in state.get("services", []):
-        if not isinstance(service, Mapping):
+        if not _is_valid_service_row(service):
             continue
         if service.get("locked", 1) == 1:
             continue
@@ -271,10 +316,7 @@ async def _compile_vpn_switches(
             if not isinstance(vpn_instances, MutableMapping):
                 continue
             for uuid, instance in vpn_instances.items():
-                if (
-                    not isinstance(instance, MutableMapping)
-                    or instance.get("enabled", None) is None
-                ):
+                if not _is_valid_vpn_switch_row(instance):
                     continue
 
                 entities.append(
@@ -340,7 +382,7 @@ async def _compile_unbound_switches(
         return []
 
     entities: list = []
-    if isinstance(unbound_blocklist.get("legacy"), MutableMapping):
+    if _is_valid_unbound_row(unbound_blocklist.get("legacy")):
         entities.append(
             _create_switch(
                 OPNsenseUnboundBlocklistSwitchLegacy,
@@ -353,7 +395,7 @@ async def _compile_unbound_switches(
     for uuid, dnsbl in unbound_blocklist.items():
         if uuid == "legacy":
             continue
-        if not isinstance(dnsbl, MutableMapping):
+        if not _is_valid_unbound_row(dnsbl):
             continue
 
         entities.append(
@@ -389,13 +431,10 @@ async def _compile_firewall_rules_switches(
 
     entities: list = []
     for rule_key, rule in rules.items():
-        if not isinstance(rule, MutableMapping):
+        if not _is_valid_firewall_rule_row(rule_key, rule):
             continue
         rule_id = firewall_rule_id_from_payload(rule_key, rule)
-        if not rule_id:
-            continue
-        interface = rule.get("%interface", rule.get("interface", ""))
-        if not isinstance(interface, str):
+        if not isinstance(rule_id, str) or not rule_id:
             continue
         entities.append(
             _create_switch(
@@ -433,13 +472,10 @@ async def _compile_nat_rule_switches(
 
     entities: list = []
     for rule_key, rule in rules.items():
-        if not isinstance(rule, MutableMapping):
+        if not _is_valid_nat_rule_row(rule_key, rule):
             continue
         rule_id = firewall_rule_id_from_payload(rule_key, rule)
-        if not rule_id:
-            continue
-        interface = rule.get("%interface", rule.get("interface", ""))
-        if not isinstance(interface, str) or not interface.strip():
+        if not isinstance(rule_id, str) or not rule_id:
             continue
         entities.append(
             _create_switch(
@@ -578,11 +614,27 @@ async def async_setup_entry(
                 and isinstance(firewall_nat.get("npt"), MutableMapping)
             ):
                 reconciliation_complete = False
+            else:
+                rule_inventories = (
+                    (firewall["rules"], _is_valid_firewall_rule_row),
+                    (firewall_nat["source_nat"], _is_valid_nat_rule_row),
+                    (firewall_nat["d_nat"], _is_valid_nat_rule_row),
+                    (firewall_nat["one_to_one"], _is_valid_nat_rule_row),
+                    (firewall_nat["npt"], _is_valid_nat_rule_row),
+                )
+                if not all(
+                    all(predicate(rule_key, rule) for rule_key, rule in rules.items())
+                    for rules, predicate in rule_inventories
+                ):
+                    reconciliation_complete = False
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SERVICES, DEFAULT_SYNC_OPTION_VALUE):
-        if "services" in state and isinstance(state.get("services"), list):
+        services = state.get("services")
+        if "services" in state and isinstance(services, list):
             entities.extend(await _compile_service_switches(config_entry, coordinator, state))
+            if not all(_is_valid_service_row(service) for service in services):
+                reconciliation_complete = False
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_VPN, DEFAULT_SYNC_OPTION_VALUE):
@@ -593,7 +645,11 @@ async def async_setup_entry(
             state.get("wireguard"), MutableMapping
         )
         entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
-        if not (has_openvpn_inventory and has_wireguard_inventory):
+        if not (
+            has_openvpn_inventory
+            and has_wireguard_inventory
+            and _vpn_switch_rows_are_complete(state)
+        ):
             reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
         if not isinstance(dict_get(state, "carp.status_summary"), MutableMapping):
@@ -604,6 +660,10 @@ async def async_setup_entry(
             state.get(ATTR_UNBOUND_BLOCKLIST), MutableMapping
         ):
             entities.extend(await _compile_unbound_switches(config_entry, coordinator, state))
+            if not all(
+                _is_valid_unbound_row(dnsbl) for dnsbl in state[ATTR_UNBOUND_BLOCKLIST].values()
+            ):
+                reconciliation_complete = False
         else:
             reconciliation_complete = False
 

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -553,7 +553,9 @@ async def async_setup_entry(
     entities: list = []
 
     if config.get(CONF_SYNC_FIREWALL_AND_NAT, DEFAULT_SYNC_OPTION_VALUE):
-        if "firewall" in state and isinstance(state.get("firewall"), MutableMapping):
+        firewall = state.get("firewall")
+        if "firewall" in state and isinstance(firewall, MutableMapping):
+            firewall_nat = firewall.get("nat")
             entities.extend(
                 await _compile_firewall_rules_switches(config_entry, coordinator, state)
             )
@@ -567,6 +569,15 @@ async def async_setup_entry(
                 await _compile_nat_one_to_one_rules_switches(config_entry, coordinator, state)
             )
             entities.extend(await _compile_nat_npt_rules_switches(config_entry, coordinator, state))
+            if not (
+                isinstance(firewall.get("rules"), MutableMapping)
+                and isinstance(firewall_nat, MutableMapping)
+                and isinstance(firewall_nat.get("source_nat"), MutableMapping)
+                and isinstance(firewall_nat.get("d_nat"), MutableMapping)
+                and isinstance(firewall_nat.get("one_to_one"), MutableMapping)
+                and isinstance(firewall_nat.get("npt"), MutableMapping)
+            ):
+                reconciliation_complete = False
         else:
             reconciliation_complete = False
     if config.get(CONF_SYNC_SERVICES, DEFAULT_SYNC_OPTION_VALUE):
@@ -585,6 +596,8 @@ async def async_setup_entry(
         if not (has_openvpn_inventory and has_wireguard_inventory):
             reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
+        if not isinstance(dict_get(state, "carp.status_summary"), MutableMapping):
+            reconciliation_complete = False
         entities.extend(await _compile_carp_maintenance_switch(config_entry, coordinator, state))
     if config.get(CONF_SYNC_UNBOUND, DEFAULT_SYNC_OPTION_VALUE):
         if ATTR_UNBOUND_BLOCKLIST in state and isinstance(

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -581,9 +581,8 @@ async def async_setup_entry(
         has_wireguard_inventory = "wireguard" in state and isinstance(
             state.get("wireguard"), MutableMapping
         )
-        if has_openvpn_inventory or has_wireguard_inventory:
-            entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
-        else:
+        entities.extend(await _compile_vpn_switches(config_entry, coordinator, state))
+        if not (has_openvpn_inventory and has_wireguard_inventory):
             reconciliation_complete = False
     if config.get(CONF_SYNC_CARP, DEFAULT_SYNC_OPTION_VALUE):
         entities.extend(await _compile_carp_maintenance_switch(config_entry, coordinator, state))

--- a/custom_components/opnsense/switch.py
+++ b/custom_components/opnsense/switch.py
@@ -1246,7 +1246,7 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         for service in services:
             if not isinstance(service, MutableMapping):
                 continue
-            if service.get("id", None) == service_id:
+            if _service_identity(service) == service_id:
                 return service
         return None
 
@@ -1282,9 +1282,11 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         if not isinstance(self._service, MutableMapping) or not self._client:
             return
 
-        result: bool = await self._client.start_service(
-            self._service.get("id", self._service.get("name", None))
-        )
+        service_id = _service_identity(self._service)
+        if service_id is None:
+            return
+
+        result: bool = await self._client.start_service(service_id)
         if result:
             _LOGGER.info("Turned on service: %s", self.name)
             self._attr_is_on = True
@@ -1302,9 +1304,11 @@ class OPNsenseServiceSwitch(OPNsenseSwitch):
         if not isinstance(self._service, MutableMapping) or not self._client:
             return
 
-        result: bool = await self._client.stop_service(
-            self._service.get("id", self._service.get("name", None))
-        )
+        service_id = _service_identity(self._service)
+        if service_id is None:
+            return
+
+        result: bool = await self._client.stop_service(service_id)
         if result:
             _LOGGER.info("Turned off service: %s", self.name)
             self._attr_is_on = False

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -169,8 +169,8 @@
       "fix_flow": {
         "step": {
           "confirm": {
-            "title": "Rebuild entities for replacement hardware",
-            "description": "This destructive repair will remove all current entities and devices for {entry_title}, including disabled entities, then rebuild entities from device ID {new_device_id}. The URL, credentials, and options will be preserved. Entity registry names, enabled/disabled selections, areas, and other customizations will be discarded. Recreated entity IDs may differ, so dashboards and automations may need updates. The previous device ID was {old_device_id}."
+            "title": "Reconcile replacement hardware inventory",
+            "description": "This repair will reconcile {entry_title} with replacement device ID {new_device_id}. Matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created. A retry marker makes the repair resumable if interrupted. Dashboards and automations remain intact for preserved entity IDs; review references to removed inventory. The previous device ID was {old_device_id}."
           }
         },
         "abort": {
@@ -179,7 +179,7 @@
           "cannot_connect": "The replacement hardware could not be confirmed. No changes were made.",
           "already_configured": "Another OPNsense device entry already uses the replacement device ID. No changes were made.",
           "cannot_unload": "The OPNsense device entry could not be unloaded safely. No registry changes were made.",
-          "repair_failed": "The replacement hardware repair did not finish. Some registry cleanup may already have occurred; review entities before retrying."
+          "repair_failed": "The replacement hardware repair did not finish. Retry to resume reconciliation from the saved marker."
         }
       }
     }

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -165,8 +165,23 @@
       "description": "Some hass-opnsense {version} functions require OPNsense firmware {ltd_firmware} or later. With firmware {firmware}, some functions may not work and there may be errors in the logs."
     },
     "device_id_mismatched": {
-      "title": "OPNsense Hardware Has Changed",
-      "description": "OPNsense Device ID has changed which indicates new or changed hardware. In order to accommodate this, hass-opnsense needs to be removed and reinstalled for this router. hass-opnsense is shutting down."
+      "title": "Replacement hardware detected",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Rebuild entities for replacement hardware",
+            "description": "This destructive repair will remove all current entities and devices for {entry_title}, including disabled entities, then rebuild entities from device ID {new_device_id}. The URL, credentials, and options will be preserved. Entity registry names, enabled/disabled selections, areas, and other customizations will be discarded. Recreated entity IDs may differ, so dashboards and automations may need updates. The previous device ID was {old_device_id}."
+          }
+        },
+        "abort": {
+          "entry_not_found": "The OPNsense device entry no longer exists.",
+          "entry_changed": "The OPNsense device entry changed while the repair was running. No registry changes were made.",
+          "cannot_connect": "The replacement hardware could not be confirmed. No changes were made.",
+          "already_configured": "Another OPNsense device entry already uses the replacement device ID. No changes were made.",
+          "cannot_unload": "The OPNsense device entry could not be unloaded safely. No registry changes were made.",
+          "repair_failed": "The replacement hardware repair did not finish. Some registry cleanup may already have occurred; review entities before retrying."
+        }
+      }
     }
   },
   "exceptions": {

--- a/custom_components/opnsense/translations/en.json
+++ b/custom_components/opnsense/translations/en.json
@@ -170,7 +170,7 @@
         "step": {
           "confirm": {
             "title": "Reconcile replacement hardware inventory",
-            "description": "This repair will reconcile {entry_title} with replacement device ID {new_device_id}. Matching entities and devices retain their registry identity and customizations, inventory absent from the replacement is removed, and new inventory is created. A retry marker makes the repair resumable if interrupted. Dashboards and automations remain intact for preserved entity IDs; review references to removed inventory. The previous device ID was {old_device_id}."
+            "description": "This repair will reconcile {entry_title} with replacement device ID {new_device_id}. Matching entities and devices retain their registry identity and customizations, entities absent from the replacement are removed, and new entities are created. A retry marker makes the repair resumable if interrupted. Dashboards and automations remain intact for preserved entity IDs; review references to removed entities. The previous device ID was {old_device_id}."
           }
         },
         "abort": {

--- a/custom_components/opnsense/update.py
+++ b/custom_components/opnsense/update.py
@@ -17,6 +17,7 @@ from .const import CONF_SYNC_FIRMWARE_UPDATES, COORDINATOR, DEFAULT_SYNC_OPTION_
 from .coordinator import OPNsenseDataUpdateCoordinator
 from .entity import OPNsenseEntity
 from .helpers import dict_get
+from .repair_reconciliation import record_desired_entities
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -119,6 +120,7 @@ async def async_setup_entry(
             )
         )
 
+    record_desired_entities(config_entry, "update", entities)
     async_add_entities(entities)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import contextlib
 from typing import Any
 from unittest.mock import MagicMock
 
+import aiohttp
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.aiohttp_client as _ha_aiohttp_client
 import pytest
@@ -112,7 +113,7 @@ def _patch_async_create_clientsession(monkeypatch: pytest.MonkeyPatch) -> None:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             """Ignore args and return a usable object for patch coverage."""
 
-    monkeypatch.setattr(_helpers_mod.aiohttp, "CookieJar", _FakeCookieJar, raising=True)
+    monkeypatch.setattr(aiohttp, "CookieJar", _FakeCookieJar, raising=True)
 
 
 @pytest.fixture

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -178,6 +178,53 @@ async def test_async_setup_entry_records_none_or_authoritative_empty_for_invento
     assert captured["entities"] == expected
 
 
+@pytest.mark.parametrize(
+    ("coordinator_data", "sync_interfaces", "sync_smart", "expected_key"),
+    [
+        (
+            {"interfaces": {None: {}, "wan": {"name": "WAN"}}},
+            True,
+            False,
+            "interface.wan.enabled",
+        ),
+        (
+            {"smart": [None, {"device": "  "}, {"device": "nvme0"}]},
+            False,
+            True,
+            "smart.nvme0.status",
+        ),
+    ],
+    ids=["interface", "smart"],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_marks_malformed_binary_sensor_rows_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    coordinator_data: dict[str, Any],
+    sync_interfaces: bool,
+    sync_smart: bool,
+    expected_key: str,
+) -> None:
+    """Malformed rows keep reconciliation incomplete while valid rows still compile."""
+    entry = setup_binary_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data=coordinator_data,
+        sync_interfaces=sync_interfaces,
+        sync_smart=sync_smart,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+    created: list[Any] = []
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: created.extend(entities)),
+    )
+
+    assert captured["entities"] is None
+    assert {entity.entity_description.key for entity in created} == {expected_key}
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_skips_when_coordinator_state_not_mapping(
     monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -39,6 +39,47 @@ from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from tests.utilities import stub_async_write_ha_state
 
 
+def capture_reconciled_desired_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    """Capture reconciliation desired entities during setup."""
+    captured: dict[str, Any] = {}
+
+    def capture(
+        _entry: MockConfigEntry,
+        _platform: str,
+        entities: Any | None = None,
+    ) -> None:
+        """Capture entities passed to ``record_desired_entities``."""
+        captured["entities"] = entities
+
+    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+    return captured
+
+
+def setup_binary_sensor_reconciliation_entry(
+    make_config_entry: Callable[..., MockConfigEntry],
+    *,
+    coordinator_data: dict[str, Any],
+    sync_interfaces: bool = False,
+    sync_smart: bool = False,
+    sync_notices: bool = False,
+) -> MockConfigEntry:
+    """Create a binary-sensor test entry with coordinator/runtime pre-wired."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: sync_interfaces,
+            CONF_SYNC_SMART: sync_smart,
+            CONF_SYNC_NOTICES: sync_notices,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = coordinator_data
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+    return entry
+
+
 def test_binary_sensor_description_builders_preserve_entity_contract() -> None:
     """Binary sensor description builders should preserve generated entity metadata."""
     interface_description = _build_interface_enabled_binary_sensor_description(
@@ -92,143 +133,47 @@ async def test_async_setup_entry_creates_entities_when_enabled(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_interface_inventory(
+@pytest.mark.parametrize(
+    ("coordinator_data", "sync_interfaces", "sync_smart", "sync_notices", "expected"),
+    [
+        ({}, True, False, False, None),
+        ({"interfaces": {}}, True, False, False, []),
+        ({}, False, True, False, None),
+        ({"smart": [], "smart_info": {}}, False, True, False, []),
+    ],
+    ids=[
+        "missing-interface",
+        "empty-interface",
+        "missing-smart",
+        "empty-smart",
+    ],
+)
+async def test_async_setup_entry_records_none_or_authoritative_empty_for_inventory(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
+    coordinator_data: dict[str, Any],
+    sync_interfaces: bool,
+    sync_smart: bool,
+    sync_notices: bool,
+    expected: Any,
 ) -> None:
-    """Missing interface payload keeps binary sensor platform reconciliation incomplete."""
-    entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_INTERFACES: True,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_NOTICES: False,
-        }
+    """Track missing and authoritative-empty reconciliation inventories."""
+    entry = setup_binary_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data=coordinator_data,
+        sync_interfaces=sync_interfaces,
+        sync_smart=sync_smart,
+        sync_notices=sync_notices,
     )
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {}
-    setattr(entry.runtime_data, COORDINATOR, coord)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+    captured = capture_reconciled_desired_entities(monkeypatch)
 
     await async_setup_entry(
         MagicMock(),
         entry,
         cast("AddEntitiesCallback", lambda ents, _=False: None),
     )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_interface_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty interface container is still authoritative."""
-    entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_INTERFACES: True,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_NOTICES: False,
-        }
-    )
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"interfaces": {}}
-    setattr(entry.runtime_data, COORDINATOR, coord)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(),
-        entry,
-        cast("AddEntitiesCallback", lambda ents, _=False: None),
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_smart_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing SMART payload keeps binary sensor platform reconciliation incomplete."""
-    entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_SMART: True,
-            CONF_SYNC_NOTICES: False,
-        }
-    )
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {}
-    setattr(entry.runtime_data, COORDINATOR, coord)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(),
-        entry,
-        cast("AddEntitiesCallback", lambda ents, _=False: None),
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_smart_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty SMART container is still authoritative."""
-    entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_SMART: True,
-            CONF_SYNC_NOTICES: False,
-        }
-    )
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"smart": [], "smart_info": {}}
-    setattr(entry.runtime_data, COORDINATOR, coord)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(),
-        entry,
-        cast("AddEntitiesCallback", lambda ents, _=False: None),
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
+    assert "entities" in captured
+    assert captured["entities"] == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -139,12 +139,14 @@ async def test_async_setup_entry_creates_entities_when_enabled(
         ({}, True, False, False, None),
         ({"interfaces": {}}, True, False, False, []),
         ({}, False, True, False, None),
+        ({"smart": []}, False, True, False, []),
         ({"smart": [], "smart_info": {}}, False, True, False, []),
     ],
     ids=[
         "missing-interface",
         "empty-interface",
         "missing-smart",
+        "empty-smart-without-smart-info",
         "empty-smart",
     ],
 )

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+import custom_components.opnsense.binary_sensor as binary_sensor_module
 from custom_components.opnsense.binary_sensor import (
     OPNsenseInterfaceEnabledBinarySensor,
     OPNsensePendingNoticesPresentBinarySensor,
@@ -88,6 +89,146 @@ async def test_async_setup_entry_creates_entities_when_enabled(
     await async_setup_entry(MagicMock(), entry, cast("AddEntitiesCallback", add_entities))
     assert len(created) == 1
     assert isinstance(created[0], OPNsensePendingNoticesPresentBinarySensor)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_interface_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing interface payload keeps binary sensor platform reconciliation incomplete."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: True,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_NOTICES: False,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {}
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda ents, _=False: None),
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_interface_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty interface container is still authoritative."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: True,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_NOTICES: False,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"interfaces": {}}
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda ents, _=False: None),
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_smart_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing SMART payload keeps binary sensor platform reconciliation incomplete."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_SMART: True,
+            CONF_SYNC_NOTICES: False,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {}
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda ents, _=False: None),
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_smart_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty SMART container is still authoritative."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_SMART: True,
+            CONF_SYNC_NOTICES: False,
+        }
+    )
+    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coord.data = {"smart": [], "smart_info": {}}
+    setattr(entry.runtime_data, COORDINATOR, coord)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(binary_sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda ents, _=False: None),
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -177,6 +177,35 @@ async def test_async_setup_entry_records_none_or_authoritative_empty_for_invento
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_skips_when_coordinator_state_not_mapping(
+    monkeypatch: pytest.MonkeyPatch, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Non-mapping coordinator state should skip setup bookkeeping and entity creation."""
+    entry = setup_binary_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data=cast("dict[str, Any]", ["not", "mapping"]),
+        sync_interfaces=True,
+        sync_smart=False,
+        sync_notices=False,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+    created: list[Any] = []
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture entities."""
+        created.extend(ents)
+
+    await async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", add_entities),
+    )
+
+    assert "entities" not in captured
+    assert created == []
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_when_disabled(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -5,28 +5,45 @@ and options flow behaviors such as device tracker handling.
 """
 
 from collections.abc import Callable
+import ipaddress
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
 from aiopnsense import exceptions as aiopnsense_exceptions
+from aiopnsense.exceptions import OPNsenseError, OPNsenseInvalidURL, OPNsenseMissingDeviceUniqueID
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import AbortFlow
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 import voluptuous as vol
 
-import custom_components.opnsense.config_flow as config_flow_mod
+import custom_components.opnsense.config_flow as cf_mod
+from custom_components.opnsense.config_flow import (
+    CONF_DEVICE_TRACKING_MODE,
+    DEVICE_TRACKING_MODE_ALL,
+    DEVICE_TRACKING_MODE_DISABLED,
+    DEVICE_TRACKING_MODE_SELECTED,
+    OPTIONS_INIT_NUMBER_BOUNDS,
+)
 from custom_components.opnsense.const import (
+    CONF_DEVICE_TRACKER_CONSIDER_HOME,
+    CONF_DEVICE_TRACKER_ENABLED,
+    CONF_DEVICE_TRACKER_SCAN_INTERVAL,
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_DEVICES,
     CONF_ENTRY_TYPE,
+    CONF_FIRMWARE_VERSION,
+    CONF_GRANULAR_SYNC_OPTIONS,
+    CONF_MANUAL_DEVICES,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_SYNC_SMART,
     CONF_SYNC_TELEMETRY,
     ENTRY_TYPE_CARP,
     ENTRY_TYPE_DEVICE,
+    GRANULAR_SYNC_ITEMS,
 )
 from tests.utilities import patch_opnsense_client
-
-cf_mod: Any = config_flow_mod
 
 
 def _make_options_flow(config_entry: Any) -> Any:
@@ -136,12 +153,12 @@ def test_device_tracking_mode_helper() -> None:
     """Map stored devices to the expected UI tracking mode."""
     assert (
         cf_mod._get_device_tracking_mode(False, ["aa:bb:cc:dd:ee:ff"])
-        == cf_mod.DEVICE_TRACKING_MODE_DISABLED
+        == DEVICE_TRACKING_MODE_DISABLED
     )
-    assert cf_mod._get_device_tracking_mode(True, []) == cf_mod.DEVICE_TRACKING_MODE_ALL
-    assert cf_mod._get_device_tracking_mode(True, None) == cf_mod.DEVICE_TRACKING_MODE_ALL
+    assert cf_mod._get_device_tracking_mode(True, []) == DEVICE_TRACKING_MODE_ALL
+    assert cf_mod._get_device_tracking_mode(True, None) == DEVICE_TRACKING_MODE_ALL
     assert cf_mod._get_device_tracking_mode(True, ["aa:bb:cc:dd:ee:ff"]) == (
-        cf_mod.DEVICE_TRACKING_MODE_SELECTED
+        DEVICE_TRACKING_MODE_SELECTED
     )
 
 
@@ -192,7 +209,7 @@ def test_device_entry_sort_key_numeric_ip_sorting() -> None:
         "host-d [192.168.1.10 | 33:44:55:66:77:88]",
         ip_by_mac,
     )
-    assert ip_key == (1, (4, int(cf_mod.ipaddress.ip_address("10.0.0.5"))))
+    assert ip_key == (1, (4, int(ipaddress.ip_address("10.0.0.5"))))
     assert label_key == (2, "host-b [11:22:33:44:55:66]")
     assert subnet_key_2 < subnet_key_10
 
@@ -353,7 +370,7 @@ async def test_validate_input_reraises_unmapped_opnsense_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """validate_input should re-raise OPNsense errors without form mappings."""
-    exc = cf_mod.OPNsenseError("unmapped")
+    exc = OPNsenseError("unmapped")
 
     async def _raiser(*args: object, **kwargs: object) -> Never:
         """Raise an unmapped OPNsense error.
@@ -369,7 +386,7 @@ async def test_validate_input_reraises_unmapped_opnsense_error(
 
     monkeypatch.setattr(cf_mod, "_validate_client_details", _raiser)
 
-    with pytest.raises(cf_mod.OPNsenseError) as err:
+    with pytest.raises(OPNsenseError) as err:
         await cf_mod.validate_input(hass=MagicMock(), user_input={}, errors={})
 
     assert err.value is exc
@@ -393,7 +410,7 @@ async def test_validate_input_timeout_uses_connect_timeout_error(
     with caplog.at_level("ERROR"):
         result = await cf_mod.validate_input(
             hass=MagicMock(),
-            user_input={cf_mod.CONF_USERNAME: username, cf_mod.CONF_PASSWORD: password},
+            user_input={CONF_USERNAME: username, CONF_PASSWORD: password},
             errors={},
         )
 
@@ -920,7 +937,7 @@ async def test_get_dt_entries_sorts_and_includes_selected(
     patch_opnsense_client(monkeypatch, cf_mod, client_cls)
 
     hass = MagicMock()
-    config = {cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"}
+    config = {CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"}
     selected = ["aa:bb:cc:00:00:01"]
     res = await cf_mod._get_dt_entries(hass=hass, config=config, selected_devices=selected)
 
@@ -966,7 +983,7 @@ async def test_get_dt_entries_passes_throw_errors_to_client(
 
     await cf_mod._get_dt_entries(
         hass=MagicMock(),
-        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        config={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         selected_devices=[],
     )
 
@@ -994,7 +1011,7 @@ async def test_get_dt_entries_preserves_missing_selected_devices(
 
     res = await cf_mod._get_dt_entries(
         hass=MagicMock(),
-        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        config={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         selected_devices=["AA-BB-CC-DD-EE-FF"],
     )
     assert res["aa:bb:cc:dd:ee:ff"] == "Not currently detected [aa:bb:cc:dd:ee:ff]"
@@ -1088,7 +1105,7 @@ async def test_get_dt_entries_closes_client(monkeypatch: pytest.MonkeyPatch) -> 
 
     await cf_mod._get_dt_entries(
         hass=MagicMock(),
-        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        config={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         selected_devices=[],
     )
     assert _Client.last_instance is not None
@@ -1148,10 +1165,10 @@ async def test_validate_client_details_closes_client(monkeypatch: pytest.MonkeyP
     patch_opnsense_client(monkeypatch, cf_mod, _Client)
 
     user_input = {
-        cf_mod.CONF_URL: "https://router.example",
-        cf_mod.CONF_USERNAME: "u",
-        cf_mod.CONF_PASSWORD: "p",
-        cf_mod.CONF_GRANULAR_SYNC_OPTIONS: False,
+        CONF_URL: "https://router.example",
+        CONF_USERNAME: "u",
+        CONF_PASSWORD: "p",
+        CONF_GRANULAR_SYNC_OPTIONS: False,
     }
     await cf_mod._validate_client_details(
         hass=MagicMock(),
@@ -1203,11 +1220,11 @@ async def test_validate_client_details_raises_when_device_id_missing(
     patch_opnsense_client(monkeypatch, cf_mod, _Client)
 
     user_input = {
-        cf_mod.CONF_URL: "https://router.example",
-        cf_mod.CONF_USERNAME: "u",
-        cf_mod.CONF_PASSWORD: "p",
+        CONF_URL: "https://router.example",
+        CONF_USERNAME: "u",
+        CONF_PASSWORD: "p",
     }
-    with pytest.raises(cf_mod.OPNsenseMissingDeviceUniqueID):
+    with pytest.raises(OPNsenseMissingDeviceUniqueID):
         await cf_mod._validate_client_details(hass=MagicMock(), user_input=user_input)
 
     assert _Client.last_instance is not None
@@ -1220,13 +1237,13 @@ def test_build_user_input_and_granular_and_options_schemas_defaults() -> None:
     # user input schema should provide keys and defaults
     schema = cf_mod._build_user_input_schema(user_input=uis)
     validated = schema({})
-    assert cf_mod.CONF_URL in validated
+    assert CONF_URL in validated
 
     # granular sync schema
     gschema = cf_mod._build_granular_sync_schema(user_input=None)
     gvalidated = gschema({})
     # every granular item should be present (defaults applied)
-    for item in cf_mod.GRANULAR_SYNC_ITEMS:
+    for item in GRANULAR_SYNC_ITEMS:
         assert item in gvalidated
     assert gvalidated[CONF_SYNC_SMART] is True
     assert gvalidated[CONF_SYNC_TELEMETRY] is True
@@ -1236,25 +1253,25 @@ def test_build_user_input_and_granular_and_options_schemas_defaults() -> None:
     # options init schema: test clamping/coercion for scan interval
     oschema = cf_mod._build_options_init_schema(user_input=None)
     out = oschema({})
-    assert cf_mod.CONF_SCAN_INTERVAL in out
-    assert cf_mod.CONF_DEVICE_TRACKING_MODE in out
+    assert CONF_SCAN_INTERVAL in out
+    assert CONF_DEVICE_TRACKING_MODE in out
 
 
 def test_schema_builders_preserve_submitted_values_before_stored_values() -> None:
     """Schema defaults should prefer submitted values, then stored values, then constants."""
     user_schema = cf_mod._build_user_input_schema(
         user_input={
-            cf_mod.CONF_URL: "https://submitted.example",
-            cf_mod.CONF_GRANULAR_SYNC_OPTIONS: False,
+            CONF_URL: "https://submitted.example",
+            CONF_GRANULAR_SYNC_OPTIONS: False,
         },
         stored_values={
-            cf_mod.CONF_URL: "https://stored.example",
-            cf_mod.CONF_GRANULAR_SYNC_OPTIONS: True,
+            CONF_URL: "https://stored.example",
+            CONF_GRANULAR_SYNC_OPTIONS: True,
         },
     )
     user_values = user_schema({})
-    assert user_values[cf_mod.CONF_URL] == "https://submitted.example"
-    assert user_values[cf_mod.CONF_GRANULAR_SYNC_OPTIONS] is False
+    assert user_values[CONF_URL] == "https://submitted.example"
+    assert user_values[CONF_GRANULAR_SYNC_OPTIONS] is False
 
     granular_schema = cf_mod._build_granular_sync_schema(
         user_input={CONF_SYNC_SMART: False},
@@ -1266,20 +1283,20 @@ def test_schema_builders_preserve_submitted_values_before_stored_values() -> Non
 
     options_schema = cf_mod._build_options_init_schema(
         user_input={
-            cf_mod.CONF_SCAN_INTERVAL: 45,
-            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+            CONF_SCAN_INTERVAL: 45,
+            CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_SELECTED,
         },
-        stored_config={cf_mod.CONF_GRANULAR_SYNC_OPTIONS: True},
+        stored_config={CONF_GRANULAR_SYNC_OPTIONS: True},
         stored_options={
-            cf_mod.CONF_SCAN_INTERVAL: 120,
-            cf_mod.CONF_DEVICE_TRACKER_ENABLED: True,
-            cf_mod.CONF_DEVICES: [],
+            CONF_SCAN_INTERVAL: 120,
+            CONF_DEVICE_TRACKER_ENABLED: True,
+            CONF_DEVICES: [],
         },
     )
     options_values = options_schema({})
-    assert options_values[cf_mod.CONF_SCAN_INTERVAL] == 45
-    assert options_values[cf_mod.CONF_DEVICE_TRACKING_MODE] == cf_mod.DEVICE_TRACKING_MODE_SELECTED
-    assert options_values[cf_mod.CONF_GRANULAR_SYNC_OPTIONS] is True
+    assert options_values[CONF_SCAN_INTERVAL] == 45
+    assert options_values[CONF_DEVICE_TRACKING_MODE] == DEVICE_TRACKING_MODE_SELECTED
+    assert options_values[CONF_GRANULAR_SYNC_OPTIONS] is True
 
 
 @pytest.mark.parametrize(
@@ -1294,8 +1311,8 @@ def test_options_scan_interval_accepts_native_selector_range(
     """_build_options_init_schema should accept CONF_SCAN_INTERVAL values in range."""
     oschema = cf_mod._build_options_init_schema(user_input=None)
     # pass a dict with the scan interval set to the test value
-    validated = oschema({cf_mod.CONF_SCAN_INTERVAL: input_value})
-    assert validated.get(cf_mod.CONF_SCAN_INTERVAL) == expected
+    validated = oschema({CONF_SCAN_INTERVAL: input_value})
+    assert validated.get(CONF_SCAN_INTERVAL) == expected
 
 
 @pytest.mark.parametrize("input_value", [5, 1000])
@@ -1304,25 +1321,25 @@ def test_options_scan_interval_rejects_values_outside_selector_range(input_value
     oschema = cf_mod._build_options_init_schema(user_input=None)
 
     with pytest.raises(vol.Invalid):
-        oschema({cf_mod.CONF_SCAN_INTERVAL: input_value})
+        oschema({CONF_SCAN_INTERVAL: input_value})
 
 
 @pytest.mark.parametrize(
     ("stored_options", "field", "expected"),
     [
         (
-            {cf_mod.CONF_SCAN_INTERVAL: 1000},
-            cf_mod.CONF_SCAN_INTERVAL,
+            {CONF_SCAN_INTERVAL: 1000},
+            CONF_SCAN_INTERVAL,
             300,
         ),
         (
-            {cf_mod.CONF_DEVICE_TRACKER_SCAN_INTERVAL: 5},
-            cf_mod.CONF_DEVICE_TRACKER_SCAN_INTERVAL,
+            {CONF_DEVICE_TRACKER_SCAN_INTERVAL: 5},
+            CONF_DEVICE_TRACKER_SCAN_INTERVAL,
             30,
         ),
         (
-            {cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: 5000},
-            cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME,
+            {CONF_DEVICE_TRACKER_CONSIDER_HOME: 5000},
+            CONF_DEVICE_TRACKER_CONSIDER_HOME,
             3600,
         ),
     ],
@@ -1342,12 +1359,12 @@ def test_options_schema_clamps_legacy_stored_defaults(
 
 @pytest.mark.parametrize(
     "option_key",
-    list(cf_mod.OPTIONS_INIT_NUMBER_BOUNDS),
+    list(OPTIONS_INIT_NUMBER_BOUNDS),
 )
 def test_options_init_schema_boundaries_match_keyed_lookup(option_key: str) -> None:
     """Selector bounds for options should come from keyed bounds lookup values."""
     oschema = cf_mod._build_options_init_schema(user_input=None)
-    minimum, maximum = cf_mod.OPTIONS_INIT_NUMBER_BOUNDS[option_key]
+    minimum, maximum = OPTIONS_INIT_NUMBER_BOUNDS[option_key]
 
     assert oschema({option_key: minimum}).get(option_key) == minimum
     assert oschema({option_key: maximum}).get(option_key) == maximum
@@ -1384,8 +1401,8 @@ def test_options_device_tracker_consider_home_accepts_native_selector_range(
     """_build_options_init_schema should accept consider_home values in range."""
     oschema = cf_mod._build_options_init_schema(user_input=None)
     # pass a dict with the consider_home value set to the test value
-    validated = oschema({cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
-    assert validated.get(cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME) == expected
+    validated = oschema({CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
+    assert validated.get(CONF_DEVICE_TRACKER_CONSIDER_HOME) == expected
 
 
 @pytest.mark.parametrize("input_value", [-10, 5000])
@@ -1396,7 +1413,7 @@ def test_options_device_tracker_consider_home_rejects_values_outside_selector_ra
     oschema = cf_mod._build_options_init_schema(user_input=None)
 
     with pytest.raises(vol.Invalid):
-        oschema({cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
+        oschema({CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
 
 
 def test_async_get_options_flow_returns_options_flow() -> None:
@@ -1472,8 +1489,8 @@ async def test_options_flow_init_for_carp_entry_saves_scan_interval(
 async def test_options_flow_init_with_user_triggers_update() -> None:
     """Submitting user input to async_step_init should update entry and create entry."""
     cfg = MagicMock()
-    cfg.data = {cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"}
-    cfg.options = {cf_mod.CONF_DEVICE_TRACKER_ENABLED: False}
+    cfg.data = {CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"}
+    cfg.options = {CONF_DEVICE_TRACKER_ENABLED: False}
 
     flow = _make_options_flow(cfg)
 
@@ -1481,14 +1498,14 @@ async def test_options_flow_init_with_user_triggers_update() -> None:
     flow._config = dict(cfg.data)
     flow._options = dict(cfg.options)
 
-    user_input = {cf_mod.CONF_SCAN_INTERVAL: 30}
+    user_input = {CONF_SCAN_INTERVAL: 30}
     res = await flow.async_step_init(user_input=user_input)
 
     # should have called update_entry and returned create_entry
     flow.hass.config_entries.async_update_entry.assert_called()
     assert res["type"] == "create_entry"
-    assert flow._options.get(cf_mod.CONF_SCAN_INTERVAL) == 30
-    assert isinstance(flow._options.get(cf_mod.CONF_SCAN_INTERVAL), int)
+    assert flow._options.get(CONF_SCAN_INTERVAL) == 30
+    assert isinstance(flow._options.get(CONF_SCAN_INTERVAL), int)
 
 
 @pytest.mark.asyncio
@@ -1517,16 +1534,16 @@ async def test_options_flow_init_for_device_shows_resolved_description_scope(
 @pytest.mark.parametrize(
     ("field", "value"),
     [
-        (cf_mod.CONF_SCAN_INTERVAL, 30.0),
-        (cf_mod.CONF_DEVICE_TRACKER_SCAN_INTERVAL, 150.0),
-        (cf_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME, 120.0),
+        (CONF_SCAN_INTERVAL, 30.0),
+        (CONF_DEVICE_TRACKER_SCAN_INTERVAL, 150.0),
+        (CONF_DEVICE_TRACKER_CONSIDER_HOME, 120.0),
     ],
 )
 async def test_options_flow_init_normalizes_numeric_values(field: str, value: float) -> None:
     """Submitting numeric options should persist integer values."""
     cfg = MagicMock()
-    cfg.data = {cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"}
-    cfg.options = {cf_mod.CONF_DEVICE_TRACKER_ENABLED: False}
+    cfg.data = {CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"}
+    cfg.options = {CONF_DEVICE_TRACKER_ENABLED: False}
 
     flow = _make_options_flow(cfg)
     flow._config = dict(cfg.data)
@@ -1546,8 +1563,8 @@ async def test_options_flow_granular_sync_calls_validate_and_updates(
 ) -> None:
     """async_step_granular_sync should call validate_input and update entry when no errors."""
     cfg = MagicMock()
-    cfg.data = {cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"}
-    cfg.options = {cf_mod.CONF_DEVICE_TRACKER_ENABLED: False}
+    cfg.data = {CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"}
+    cfg.options = {CONF_DEVICE_TRACKER_ENABLED: False}
 
     flow = _make_options_flow(cfg)
 
@@ -1566,7 +1583,7 @@ async def test_options_flow_granular_sync_calls_validate_and_updates(
     monkeypatch.setattr(cf_mod, "validate_input", fake_validate)
 
     # use an actual granular sync key present in the module
-    gkey = next(iter(cf_mod.GRANULAR_SYNC_ITEMS))
+    gkey = next(iter(GRANULAR_SYNC_ITEMS))
     # populate internals so the flow method doesn't access Home Assistant internals
     flow._config = dict(cfg.data)
     flow._options = dict(cfg.options)
@@ -1582,8 +1599,8 @@ async def test_device_tracker_shows_form_when_no_user_input(
 ) -> None:
     """async_step_device_tracker should show form containing data_schema when called without user_input."""
     cfg = make_config_entry(
-        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
-        options={cf_mod.CONF_DEVICES: ["11:22:33:44:55:66"]},
+        data={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+        options={CONF_DEVICES: ["11:22:33:44:55:66"]},
     )
 
     flow = _make_options_flow(cfg)
@@ -1608,7 +1625,7 @@ async def test_device_tracker_shows_form_when_no_user_input(
     assert res["type"] == "form"
     assert "data_schema" in res
     validated = res["data_schema"]({})
-    assert cf_mod.CONF_DEVICES in validated
+    assert CONF_DEVICES in validated
 
 
 @pytest.mark.parametrize(
@@ -1638,8 +1655,8 @@ async def test_device_tracker_handles_arp_lookup_failure(
     """ARP lookup failures should not abort device tracker form rendering."""
     exc = exception_factory("boom")
     cfg = make_config_entry(
-        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
-        options={cf_mod.CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
+        data={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+        options={CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
     )
     flow = _make_options_flow(cfg)
     flow._config = dict(cfg.data)
@@ -1663,7 +1680,33 @@ async def test_device_tracker_handles_arp_lookup_failure(
     assert res["type"] == "form"
     assert res["errors"]["base"] == expected_base_error
     validated = res["data_schema"]({})
-    assert validated[cf_mod.CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
+    assert validated[CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
+
+
+@pytest.mark.asyncio
+async def test_device_tracker_handles_opnsense_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """OPNsense timeouts should keep picker rendering with the saved MAC fallback."""
+    cfg = make_config_entry(
+        data={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+        options={CONF_DEVICES: ["AA-BB-CC-DD-EE-FF"]},
+    )
+    flow = _make_options_flow(cfg)
+    flow._config = dict(cfg.data)
+    flow._options = dict(cfg.options)
+
+    async def _raise_timeout(*args: object, **kwargs: object) -> Never:
+        """Raise an OPNsense timeout to exercise connect_timeout mapping."""
+        raise aiopnsense_exceptions.OPNsenseTimeoutError("request timed out")
+
+    monkeypatch.setattr(cf_mod, "_get_dt_entries", _raise_timeout)
+    res_timeout = await flow.async_step_device_tracker(user_input=None)
+    assert res_timeout["type"] == "form"
+    assert res_timeout["errors"]["base"] == "connect_timeout"
+    validated_timeout = res_timeout["data_schema"]({})
+    assert validated_timeout[CONF_DEVICES] == ["aa:bb:cc:dd:ee:ff"]
 
 
 @pytest.mark.asyncio
@@ -1674,11 +1717,11 @@ async def test_options_flow_device_tracker_user_input(
     # Build a fake config_entry using shared factory
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
         },
-        options={cf_mod.CONF_DEVICE_TRACKER_ENABLED: True, cf_mod.CONF_DEVICES: []},
+        options={CONF_DEVICE_TRACKER_ENABLED: True, CONF_DEVICES: []},
     )
 
     flow = _make_options_flow(config_entry)
@@ -1688,8 +1731,8 @@ async def test_options_flow_device_tracker_user_input(
     flow._options = dict(config_entry.options)
 
     user_input = {
-        cf_mod.CONF_MANUAL_DEVICES: "aa:bb:cc:dd:ee:ff\nbad\n11:22:33:44:55:66",
-        cf_mod.CONF_DEVICES: ["11:22:33:44:55:66"],
+        CONF_MANUAL_DEVICES: "aa:bb:cc:dd:ee:ff\nbad\n11:22:33:44:55:66",
+        CONF_DEVICES: ["11:22:33:44:55:66"],
     }
 
     result = await flow.async_step_device_tracker(user_input=user_input)
@@ -1698,10 +1741,10 @@ async def test_options_flow_device_tracker_user_input(
     assert result["type"] == "create_entry"
 
     # The flow should have parsed manual devices into _options
-    assert cf_mod.CONF_DEVICES in flow._options
-    assert "aa:bb:cc:dd:ee:ff" in flow._options[cf_mod.CONF_DEVICES]
-    assert "11:22:33:44:55:66" in flow._options[cf_mod.CONF_DEVICES]
-    assert flow._options[cf_mod.CONF_DEVICES] == ["11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"]
+    assert CONF_DEVICES in flow._options
+    assert "aa:bb:cc:dd:ee:ff" in flow._options[CONF_DEVICES]
+    assert "11:22:33:44:55:66" in flow._options[CONF_DEVICES]
+    assert flow._options[CONF_DEVICES] == ["11:22:33:44:55:66", "aa:bb:cc:dd:ee:ff"]
 
 
 @pytest.mark.asyncio
@@ -1711,13 +1754,13 @@ async def test_options_flow_device_tracker_track_all_clears_device_list(
     """Track-all mode from init should persist the legacy empty-device-list behavior."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
         },
         options={
-            cf_mod.CONF_DEVICE_TRACKER_ENABLED: True,
-            cf_mod.CONF_DEVICES: ["aa:bb:cc:dd:ee:ff"],
+            CONF_DEVICE_TRACKER_ENABLED: True,
+            CONF_DEVICES: ["aa:bb:cc:dd:ee:ff"],
         },
     )
 
@@ -1727,13 +1770,13 @@ async def test_options_flow_device_tracker_track_all_clears_device_list(
 
     result = await flow.async_step_init(
         user_input={
-            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_ALL,
-            cf_mod.CONF_GRANULAR_SYNC_OPTIONS: False,
+            CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_ALL,
+            CONF_GRANULAR_SYNC_OPTIONS: False,
         }
     )
 
     assert result["type"] == "create_entry"
-    assert flow._options[cf_mod.CONF_DEVICES] == []
+    assert flow._options[CONF_DEVICES] == []
 
 
 @pytest.mark.asyncio
@@ -1743,19 +1786,19 @@ async def test_options_flow_init_selected_mode_shows_picker_step(
     """Selected-only mode should continue to the device picker step."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
         },
-        options={cf_mod.CONF_DEVICE_TRACKER_ENABLED: False, cf_mod.CONF_DEVICES: []},
+        options={CONF_DEVICE_TRACKER_ENABLED: False, CONF_DEVICES: []},
     )
     flow = _make_options_flow(config_entry)
     monkeypatch.setattr(cf_mod, "_get_dt_entries", AsyncMock(return_value={}))
 
     result = await flow.async_step_init(
         user_input={
-            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
-            cf_mod.CONF_GRANULAR_SYNC_OPTIONS: False,
+            CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_SELECTED,
+            CONF_GRANULAR_SYNC_OPTIONS: False,
         }
     )
     assert result["type"] == "form"
@@ -1769,10 +1812,10 @@ async def test_reconfigure_updates_entry_when_validation_succeeds(
     """Successful reconfigure submissions should update and abort the flow."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_DEVICE_UNIQUE_ID: "device-1",
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_DEVICE_UNIQUE_ID: "device-1",
         },
         options={},
         unique_id="device-1",
@@ -1791,9 +1834,9 @@ async def test_reconfigure_updates_entry_when_validation_succeeds(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
         }
     )
 
@@ -1806,10 +1849,10 @@ async def test_reconfigure_updates_entry_when_validation_succeeds(
     update_and_abort.assert_called_once_with(
         entry=config_entry,
         data={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_DEVICE_UNIQUE_ID: "device-1",
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_DEVICE_UNIQUE_ID: "device-1",
         },
     )
 
@@ -2317,10 +2360,10 @@ async def test_validate_input_granular_sync_uses_native_validation_only(
     monkeypatch.setattr(cf_mod, "create_opnsense_client", lambda **_kwargs: client)
 
     user_input = {
-        cf_mod.CONF_URL: "https://host.example",
-        cf_mod.CONF_USERNAME: "user",
-        cf_mod.CONF_PASSWORD: "pass",
-        cf_mod.CONF_GRANULAR_SYNC_OPTIONS: True,
+        CONF_URL: "https://host.example",
+        CONF_USERNAME: "user",
+        CONF_PASSWORD: "pass",
+        CONF_GRANULAR_SYNC_OPTIONS: True,
         CONF_SYNC_FIREWALL_AND_NAT: True,
     }
     errors: dict[str, Any] = {}
@@ -2332,7 +2375,7 @@ async def test_validate_input_granular_sync_uses_native_validation_only(
     )
 
     assert res == {}
-    assert user_input[cf_mod.CONF_FIRMWARE_VERSION] == "25.1"
+    assert user_input[CONF_FIRMWARE_VERSION] == "25.1"
     client.validate.assert_awaited_once()
     client.is_plugin_installed.assert_not_awaited()
     client.set_use_snake_case.assert_not_awaited()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1306,31 +1306,6 @@ def test_schema_builders_preserve_submitted_values_before_stored_values() -> Non
 
 
 @pytest.mark.parametrize(
-    ("input_value", "expected"),
-    [
-        (150, 150),  # within range -> unchanged
-    ],
-)
-def test_options_scan_interval_accepts_native_selector_range(
-    input_value: Any, expected: Any
-) -> None:
-    """_build_options_init_schema should accept CONF_SCAN_INTERVAL values in range."""
-    oschema = cf_mod._build_options_init_schema(user_input=None)
-    # pass a dict with the scan interval set to the test value
-    validated = oschema({CONF_SCAN_INTERVAL: input_value})
-    assert validated.get(CONF_SCAN_INTERVAL) == expected
-
-
-@pytest.mark.parametrize("input_value", [5, 1000])
-def test_options_scan_interval_rejects_values_outside_selector_range(input_value: Any) -> None:
-    """_build_options_init_schema should reject CONF_SCAN_INTERVAL values outside range."""
-    oschema = cf_mod._build_options_init_schema(user_input=None)
-
-    with pytest.raises(vol.Invalid):
-        oschema({CONF_SCAN_INTERVAL: input_value})
-
-
-@pytest.mark.parametrize(
     ("stored_options", "field", "expected"),
     [
         (
@@ -1391,35 +1366,6 @@ def test_options_init_schema_boundaries_match_keyed_lookup(option_key: str) -> N
 def test_normalize_int_option_invalid_values_fall_back_to_minimum(value: Any) -> None:
     """Invalid persisted numeric options should fall back to the selector minimum."""
     assert cf_mod._normalize_int_option(value, 5, 3600) == 5
-
-
-@pytest.mark.parametrize(
-    ("input_value", "expected"),
-    [
-        (300, 300),  # within range -> unchanged
-        (1200, 1200),  # within new range (20 minutes) -> unchanged
-        (3600, 3600),  # at maximum (1 hour) -> unchanged
-    ],
-)
-def test_options_device_tracker_consider_home_accepts_native_selector_range(
-    input_value: Any, expected: Any
-) -> None:
-    """_build_options_init_schema should accept consider_home values in range."""
-    oschema = cf_mod._build_options_init_schema(user_input=None)
-    # pass a dict with the consider_home value set to the test value
-    validated = oschema({CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
-    assert validated.get(CONF_DEVICE_TRACKER_CONSIDER_HOME) == expected
-
-
-@pytest.mark.parametrize("input_value", [-10, 5000])
-def test_options_device_tracker_consider_home_rejects_values_outside_selector_range(
-    input_value: Any,
-) -> None:
-    """_build_options_init_schema should reject consider_home values outside range."""
-    oschema = cf_mod._build_options_init_schema(user_input=None)
-
-    with pytest.raises(vol.Invalid):
-        oschema({CONF_DEVICE_TRACKER_CONSIDER_HOME: input_value})
 
 
 def test_async_get_options_flow_returns_options_flow() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -395,11 +395,12 @@ async def test_validate_input_reraises_unmapped_opnsense_error(
 
 @pytest.mark.asyncio
 async def test_validate_input_timeout_uses_connect_timeout_error(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """OPNsense timeout should map to connect_timeout and redact credentials in logs."""
     username = "admin"
     password = "supersecret"
+    log_error = MagicMock()
 
     async def _raiser(*args: object, **kwargs: object) -> Never:
         """Raise an OPNsense timeout that includes secrets in the message."""
@@ -408,17 +409,20 @@ async def test_validate_input_timeout_uses_connect_timeout_error(
         )
 
     monkeypatch.setattr(cf_mod, "_validate_client_details", _raiser)
-    with caplog.at_level("ERROR"):
-        result = await cf_mod.validate_input(
-            hass=MagicMock(),
-            user_input={CONF_USERNAME: username, CONF_PASSWORD: password},
-            errors={},
-        )
+    monkeypatch.setattr(cf_mod._LOGGER, "error", log_error)
+    result = await cf_mod.validate_input(
+        hass=MagicMock(),
+        user_input={CONF_USERNAME: username, CONF_PASSWORD: password},
+        errors={},
+    )
 
     assert result.get("base") == "connect_timeout"
-    assert "[redacted]" in caplog.text
-    assert username not in caplog.text
-    assert password not in caplog.text
+    log_error.assert_called_once()
+    log_message = log_error.call_args.args[0]
+    assert isinstance(log_message, str)
+    assert "[redacted]" in log_message
+    assert username not in log_message
+    assert password not in log_message
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1166,7 +1166,7 @@ async def test_validate_client_details_closes_client(monkeypatch: pytest.MonkeyP
 async def test_validate_client_details_raises_when_device_id_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """_validate_client_details should reject clients that return no device id."""
+    """_validate_client_details should reject clients that return no Device ID."""
 
     class _Client:
         """Fake client that returns no device ID for validation tests."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -877,12 +877,11 @@ async def test_validate_input_can_map_carp_not_configured_error(
     assert result["base"] == "carp_not_configured"
 
 
-def test_record_validation_error_sets_base(caplog: pytest.LogCaptureFixture) -> None:
-    """_record_validation_error should log the message and set errors['base']."""
+def test_record_validation_error_sets_base() -> None:
+    """_record_validation_error should set errors['base']."""
     errors: dict[str, str] = {}
     cf_mod._record_validation_error(errors=errors, key="test_key", message="an msg")
     assert errors.get("base") == "test_key"
-    assert "an msg" in caplog.text
 
 
 def test_build_carp_input_schema_defaults_and_rejects_unknown_fields() -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,8 +10,20 @@ from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
 from aiopnsense import exceptions as aiopnsense_exceptions
-from aiopnsense.exceptions import OPNsenseError, OPNsenseMissingDeviceUniqueID
-from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_URL, CONF_USERNAME
+from aiopnsense.exceptions import (
+    OPNsenseError,
+    OPNsenseInvalidURL,
+    OPNsenseMissingDeviceUniqueID,
+    OPNsenseSSLError,
+)
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_URL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import AbortFlow
 import pytest
@@ -39,6 +51,8 @@ from custom_components.opnsense.const import (
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_SYNC_SMART,
     CONF_SYNC_TELEMETRY,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
     ENTRY_TYPE_CARP,
     ENTRY_TYPE_DEVICE,
     GRANULAR_SYNC_ITEMS,
@@ -216,28 +230,28 @@ def test_device_entry_sort_key_numeric_ip_sorting() -> None:
 
 def test_clean_and_parse_url_success_and_failure() -> None:
     """Clean and parse URL, fix missing scheme and handle invalid URL."""
-    ui = {cf_mod.CONF_URL: "router.example"}
+    ui = {CONF_URL: "router.example"}
     cf_mod._clean_and_parse_url(ui)
-    assert ui[cf_mod.CONF_URL] == "https://router.example"
+    assert ui[CONF_URL] == "https://router.example"
 
-    auth_ui = {cf_mod.CONF_URL: "https://user:pass@router.example:8443"}
+    auth_ui = {CONF_URL: "https://user:pass@router.example:8443"}
     cf_mod._clean_and_parse_url(auth_ui)
-    assert auth_ui[cf_mod.CONF_URL] == "https://router.example:8443"
+    assert auth_ui[CONF_URL] == "https://router.example:8443"
 
-    ipv6_ui = {cf_mod.CONF_URL: "https://user:pass@[2001:db8::1]:8443"}
+    ipv6_ui = {CONF_URL: "https://user:pass@[2001:db8::1]:8443"}
     cf_mod._clean_and_parse_url(ipv6_ui)
-    assert ipv6_ui[cf_mod.CONF_URL] == "https://[2001:db8::1]:8443"
+    assert ipv6_ui[CONF_URL] == "https://[2001:db8::1]:8443"
 
-    invalid_port_ui = {cf_mod.CONF_URL: "https://router.example:abc"}
-    with pytest.raises(cf_mod.OPNsenseInvalidURL):
+    invalid_port_ui = {CONF_URL: "https://router.example:abc"}
+    with pytest.raises(OPNsenseInvalidURL):
         cf_mod._clean_and_parse_url(invalid_port_ui)
 
     # invalid netloc -> raise OPNsenseInvalidURL
-    with pytest.raises(cf_mod.OPNsenseInvalidURL):
-        cf_mod._clean_and_parse_url({cf_mod.CONF_URL: ""})
+    with pytest.raises(OPNsenseInvalidURL):
+        cf_mod._clean_and_parse_url({CONF_URL: ""})
 
-    missing_host_ui = {cf_mod.CONF_URL: "https://:8443"}
-    with pytest.raises(cf_mod.OPNsenseInvalidURL):
+    missing_host_ui = {CONF_URL: "https://:8443"}
+    with pytest.raises(OPNsenseInvalidURL):
         cf_mod._clean_and_parse_url(missing_host_ui)
 
 
@@ -264,11 +278,11 @@ def test_clean_and_parse_url_success_and_failure() -> None:
 )
 def test_clean_and_parse_url_normalizes_scheme_and_ports(input_url: str, expected_url: str) -> None:
     """Normalize URL schemes and ports into their canonical form."""
-    user_input = {cf_mod.CONF_URL: input_url}
+    user_input = {CONF_URL: input_url}
 
     cf_mod._clean_and_parse_url(user_input)
 
-    assert user_input[cf_mod.CONF_URL] == expected_url
+    assert user_input[CONF_URL] == expected_url
 
 
 @pytest.mark.parametrize(
@@ -284,10 +298,10 @@ def test_url_conflict_matches_persisted_default_ports(
     """Opposite-kind URL conflicts should match legacy explicit default ports."""
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: stored_url,
-            cf_mod.CONF_USERNAME: "carp-user",
-            cf_mod.CONF_PASSWORD: "carp-pass",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: stored_url,
+            CONF_USERNAME: "carp-user",
+            CONF_PASSWORD: "carp-pass",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
@@ -306,12 +320,12 @@ def test_url_conflict_matches_persisted_default_ports(
 def test_url_conflict_skips_invalid_stored_urls_and_continues_scanning() -> None:
     """Ignore unusable stored URLs and continue until a normalized match is found."""
     entries = [
-        MagicMock(entry_id="non-string", data={cf_mod.CONF_URL: 123}),
-        MagicMock(entry_id="malformed", data={cf_mod.CONF_URL: "https://"}),
-        MagicMock(entry_id="mismatch", data={cf_mod.CONF_URL: "other.example"}),
+        MagicMock(entry_id="non-string", data={CONF_URL: 123}),
+        MagicMock(entry_id="malformed", data={CONF_URL: "https://"}),
+        MagicMock(entry_id="mismatch", data={CONF_URL: "other.example"}),
         MagicMock(
             entry_id="match",
-            data={cf_mod.CONF_URL: "https://router.example", CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
+            data={CONF_URL: "https://router.example", CONF_ENTRY_TYPE: ENTRY_TYPE_CARP},
         ),
     ]
     flow = cf_mod.OPNsenseConfigFlow()
@@ -461,8 +475,8 @@ async def test_async_step_device_creates_entry_and_sets_entry_type(
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_DEVICE
-    assert result["data"][cf_mod.CONF_DEVICE_UNIQUE_ID] == "dev-id"
-    assert not result["data"][cf_mod.CONF_GRANULAR_SYNC_OPTIONS]
+    assert result["data"][CONF_DEVICE_UNIQUE_ID] == "dev-id"
+    assert not result["data"][CONF_GRANULAR_SYNC_OPTIONS]
 
 
 @pytest.mark.asyncio
@@ -485,7 +499,7 @@ async def test_async_step_device_routes_to_granular_sync(
     flow.hass.config_entries.async_entries = MagicMock(return_value=[])
 
     ui = _make_basic_device_input()
-    ui[cf_mod.CONF_GRANULAR_SYNC_OPTIONS] = True
+    ui[CONF_GRANULAR_SYNC_OPTIONS] = True
     result = await flow.async_step_device(user_input=ui)
 
     assert result["type"] == "form"
@@ -502,14 +516,14 @@ async def test_async_step_device_aborts_on_duplicate_carp_url(
 
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_USERNAME: "carp-user",
-            cf_mod.CONF_PASSWORD: "carp-pass",
+            CONF_URL: "https://router.example",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_USERNAME: "carp-user",
+            CONF_PASSWORD: "carp-pass",
         },
         options={},
     )
-    assert existing_entry.data[cf_mod.CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
+    assert existing_entry.data[CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
 
     flow = cf_mod.OPNsenseConfigFlow()
     flow.hass = MagicMock()
@@ -521,12 +535,12 @@ async def test_async_step_device_aborts_on_duplicate_carp_url(
     object.__setattr__(flow, "_abort_if_unique_id_configured", abort_if_configured)
 
     user_input = _make_basic_device_input()
-    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    user_input[CONF_URL] = "https://router.example/"
     result = await flow.async_step_device(user_input=user_input)
 
     assert result["type"] == "abort"
     assert result["reason"] == "carp_device_url_conflict"
-    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    flow.hass.config_entries.async_entries.assert_called_once_with(DOMAIN)
     set_unique_id.assert_not_awaited()
     abort_if_configured.assert_not_called()
 
@@ -541,9 +555,9 @@ async def test_async_step_carp_aborts_on_device_url_conflict(
 
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "device-user",
-            cf_mod.CONF_PASSWORD: "device-pass",
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "device-user",
+            CONF_PASSWORD: "device-pass",
         },
         options={},
     )
@@ -556,12 +570,12 @@ async def test_async_step_carp_aborts_on_device_url_conflict(
     object.__setattr__(flow, "_async_abort_entries_match", abort_match)
 
     user_input = _make_basic_carp_input()
-    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    user_input[CONF_URL] = "https://router.example/"
     result = await flow.async_step_carp(user_input=user_input)
 
     assert result["type"] == "abort"
     assert result["reason"] == "carp_device_url_conflict"
-    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    flow.hass.config_entries.async_entries.assert_called_once_with(DOMAIN)
     abort_match.assert_not_called()
 
 
@@ -584,10 +598,10 @@ async def test_async_step_carp_aborts_on_legacy_default_port_duplicate(
     patch_opnsense_client(monkeypatch, cf_mod, lambda **_kwargs: client)
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: stored_url,
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_USERNAME: "carp-user",
-            cf_mod.CONF_PASSWORD: "carp-pass",
+            CONF_URL: stored_url,
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_USERNAME: "carp-user",
+            CONF_PASSWORD: "carp-pass",
         },
         options={},
     )
@@ -598,7 +612,7 @@ async def test_async_step_carp_aborts_on_legacy_default_port_duplicate(
     abort_match = MagicMock()
     object.__setattr__(flow, "_async_abort_entries_match", abort_match)
     user_input = _make_basic_carp_input()
-    user_input[cf_mod.CONF_URL] = normalized_url
+    user_input[CONF_URL] = normalized_url
 
     result = await flow.async_step_carp(user_input=user_input)
 
@@ -617,13 +631,13 @@ async def test_async_step_device_allows_same_url_for_non_carp_entry(
 
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "device-user",
-            cf_mod.CONF_PASSWORD: "device-pass",
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "device-user",
+            CONF_PASSWORD: "device-pass",
         },
         options={},
     )
-    assert existing_entry.data.get(cf_mod.CONF_ENTRY_TYPE, ENTRY_TYPE_DEVICE) == ENTRY_TYPE_DEVICE
+    assert existing_entry.data.get(CONF_ENTRY_TYPE, ENTRY_TYPE_DEVICE) == ENTRY_TYPE_DEVICE
 
     flow = cf_mod.OPNsenseConfigFlow()
     flow.hass = MagicMock()
@@ -640,12 +654,12 @@ async def test_async_step_device_allows_same_url_for_non_carp_entry(
     object.__setattr__(flow, "_abort_if_unique_id_configured", abort_if_configured)
 
     user_input = _make_basic_device_input()
-    user_input[cf_mod.CONF_URL] = "https://router.example/"
+    user_input[CONF_URL] = "https://router.example/"
     result = await flow.async_step_device(user_input=user_input)
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_DEVICE
-    assert result["data"][cf_mod.CONF_URL] == "https://router.example"
+    assert result["data"][CONF_URL] == "https://router.example"
     set_unique_id.assert_awaited_once_with("dev-id")
     abort_if_configured.assert_called_once_with()
 
@@ -665,10 +679,10 @@ async def test_async_step_carp_validates_without_device_id_and_sets_entry_type(
 
     assert result["type"] == "create_entry"
     assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
-    assert result["data"][cf_mod.CONF_FIRMWARE_VERSION] == client.firmware_version
-    assert result["data"][cf_mod.CONF_NAME] == f"{client.system_name} CARP VIP"
-    assert result["data"].get(cf_mod.CONF_DEVICE_UNIQUE_ID) is None
-    assert result["data"].get(cf_mod.CONF_GRANULAR_SYNC_OPTIONS) is None
+    assert result["data"][CONF_FIRMWARE_VERSION] == client.firmware_version
+    assert result["data"][CONF_NAME] == f"{client.system_name} CARP VIP"
+    assert result["data"].get(CONF_DEVICE_UNIQUE_ID) is None
+    assert result["data"].get(CONF_GRANULAR_SYNC_OPTIONS) is None
     client.validate.assert_awaited_once_with(require_device_id=False)
     client.get_device_unique_id.assert_not_awaited()
 
@@ -761,7 +775,7 @@ async def test_async_step_carp_accepts_vip_identity_without_physical_interface(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "create_entry"
-    assert result["data"][cf_mod.CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
+    assert result["data"][CONF_ENTRY_TYPE] == ENTRY_TYPE_CARP
 
 
 @pytest.mark.asyncio
@@ -800,7 +814,7 @@ async def test_async_step_carp_custom_name_does_not_waive_responder_validation(
     flow = cf_mod.OPNsenseConfigFlow()
     flow.hass = MagicMock()
     user_input = _make_basic_carp_input()
-    user_input[cf_mod.CONF_NAME] = "Custom CARP"
+    user_input[CONF_NAME] = "Custom CARP"
 
     result = await flow.async_step_carp(user_input=user_input)
 
@@ -893,31 +907,31 @@ def test_build_carp_input_schema_defaults_and_rejects_unknown_fields() -> None:
     schema = cf_mod._build_carp_input_schema(
         user_input=None,
         stored_values={
-            cf_mod.CONF_URL: "https://stored.example",
-            cf_mod.CONF_VERIFY_SSL: False,
-            cf_mod.CONF_USERNAME: "stored-user",
-            cf_mod.CONF_PASSWORD: "stored-pass",
-            cf_mod.CONF_NAME: "Stored Router",
+            CONF_URL: "https://stored.example",
+            CONF_VERIFY_SSL: False,
+            CONF_USERNAME: "stored-user",
+            CONF_PASSWORD: "stored-pass",
+            CONF_NAME: "Stored Router",
         },
     )
     values = schema({})
-    assert values[cf_mod.CONF_URL] == "https://stored.example"
-    assert values[cf_mod.CONF_VERIFY_SSL] is False
-    assert values[cf_mod.CONF_USERNAME] == "stored-user"
-    assert values[cf_mod.CONF_PASSWORD] == "stored-pass"
-    assert values[cf_mod.CONF_NAME] == "Stored Router"
+    assert values[CONF_URL] == "https://stored.example"
+    assert values[CONF_VERIFY_SSL] is False
+    assert values[CONF_USERNAME] == "stored-user"
+    assert values[CONF_PASSWORD] == "stored-pass"
+    assert values[CONF_NAME] == "Stored Router"
     with pytest.raises(vol.Invalid):
-        schema({cf_mod.CONF_GRANULAR_SYNC_OPTIONS: True})
+        schema({CONF_GRANULAR_SYNC_OPTIONS: True})
 
 
 def test_build_carp_options_schema_exposes_scan_interval_only() -> None:
     """CARP options schema should only contain scan interval."""
     schema = cf_mod._build_carp_options_schema(user_input=None, stored_options=None)
     values = schema({})
-    assert values == {cf_mod.CONF_SCAN_INTERVAL: cf_mod.DEFAULT_SCAN_INTERVAL}
+    assert values == {CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL}
 
     with pytest.raises(vol.Invalid):
-        schema({cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_ALL})
+        schema({CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_ALL})
 
 
 @pytest.mark.asyncio
@@ -1041,7 +1055,7 @@ async def test_get_dt_entries_supports_raw_arp_keys(
 
     res = await cf_mod._get_dt_entries(
         hass=MagicMock(),
-        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        config={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         selected_devices=[],
     )
 
@@ -1067,7 +1081,7 @@ async def test_get_dt_entries_skips_non_mapping_arp_rows(
 
     res = await cf_mod._get_dt_entries(
         hass=MagicMock(),
-        config={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        config={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         selected_devices=["AA-BB-CC-DD-EE-FF"],
     )
 
@@ -1386,12 +1400,12 @@ async def test_options_flow_init_for_carp_entry_only_allows_scan_interval(
     """CARP options init should render scan interval form and skip device-tracker fields."""
     cfg = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
-        options={cf_mod.CONF_SCAN_INTERVAL: 45},
+        options={CONF_SCAN_INTERVAL: 45},
     )
     flow = _make_options_flow(cfg)
     flow._config = dict(cfg.data)
@@ -1405,7 +1419,7 @@ async def test_options_flow_init_for_carp_entry_only_allows_scan_interval(
         "scan interval only for this CARP VIP entry"
     )
     data = res["data_schema"]({})
-    assert data == {cf_mod.CONF_SCAN_INTERVAL: 45}
+    assert data == {CONF_SCAN_INTERVAL: 45}
 
 
 @pytest.mark.asyncio
@@ -1415,28 +1429,28 @@ async def test_options_flow_init_for_carp_entry_saves_scan_interval(
     """Submitting CARP options should normalize scan interval and preserve unrelated options."""
     cfg = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={
-            cf_mod.CONF_SCAN_INTERVAL: 60,
-            cf_mod.CONF_DEVICE_TRACKER_ENABLED: False,
-            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+            CONF_SCAN_INTERVAL: 60,
+            CONF_DEVICE_TRACKER_ENABLED: False,
+            CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_SELECTED,
         },
     )
     flow = _make_options_flow(cfg)
     flow._config = dict(cfg.data)
     flow._options = dict(cfg.options)
 
-    res = await flow.async_step_init(user_input={cf_mod.CONF_SCAN_INTERVAL: 120})
+    res = await flow.async_step_init(user_input={CONF_SCAN_INTERVAL: 120})
 
     assert res["type"] == "create_entry"
     assert flow._options == {
-        cf_mod.CONF_SCAN_INTERVAL: 120,
-        cf_mod.CONF_DEVICE_TRACKER_ENABLED: False,
-        cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+        CONF_SCAN_INTERVAL: 120,
+        CONF_DEVICE_TRACKER_ENABLED: False,
+        CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_SELECTED,
     }
 
 
@@ -1469,7 +1483,7 @@ async def test_options_flow_init_for_device_shows_resolved_description_scope(
 ) -> None:
     """Device options form render should include normal options-scope description placeholders."""
     cfg = make_config_entry(
-        data={cf_mod.CONF_URL: "https://x", cf_mod.CONF_USERNAME: "u", cf_mod.CONF_PASSWORD: "p"},
+        data={CONF_URL: "https://x", CONF_USERNAME: "u", CONF_PASSWORD: "p"},
         options={},
     )
     flow = _make_options_flow(cfg)
@@ -1588,7 +1602,7 @@ async def test_device_tracker_shows_form_when_no_user_input(
     [
         (aiopnsense_exceptions.OPNsenseConnectionError, "cannot_connect"),
         (aiopnsense_exceptions.OPNsenseInvalidAuth, "invalid_auth"),
-        (cf_mod.OPNsenseSSLError, "cannot_connect_ssl"),
+        (OPNsenseSSLError, "cannot_connect_ssl"),
         (aiopnsense_exceptions.OPNsensePrivilegeMissing, "privilege_missing"),
         (aiopnsense_exceptions.OPNsenseTimeoutError, "connect_timeout"),
     ],
@@ -1819,20 +1833,20 @@ async def test_reconfigure_device_aborts_on_carp_url_conflict(
     """Device reconfigure should reject a changed URL used by a CARP entry."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://old.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_DEVICE_UNIQUE_ID: "device-1",
+            CONF_URL: "https://old.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_DEVICE_UNIQUE_ID: "device-1",
         },
         options={},
         unique_id="device-1",
     )
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://router.example:443",
-            cf_mod.CONF_USERNAME: "carp-user",
-            cf_mod.CONF_PASSWORD: "carp-pass",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://router.example:443",
+            CONF_USERNAME: "carp-user",
+            CONF_PASSWORD: "carp-pass",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
@@ -1852,16 +1866,16 @@ async def test_reconfigure_device_aborts_on_carp_url_conflict(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
         }
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "carp_device_url_conflict"
     validate.assert_awaited_once()
-    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    flow.hass.config_entries.async_entries.assert_called_once_with(DOMAIN)
     set_unique_id.assert_not_awaited()
     update_and_abort.assert_not_called()
 
@@ -1873,12 +1887,12 @@ async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
     """CARP reconfigure should validate with CARP mode and skip unique-id checks."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_FIRMWARE_VERSION: "26.1.11",
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_FIRMWARE_VERSION: "26.1.11",
+            CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
@@ -1896,11 +1910,11 @@ async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_NAME: "Renamed CARP VIP",
-            cf_mod.CONF_URL: "https://carp-router.example",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_NAME: "Renamed CARP VIP",
+            CONF_URL: "https://carp-router.example",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
         }
     )
 
@@ -1915,13 +1929,13 @@ async def test_reconfigure_carp_updates_entry_without_unique_id_checks(
         entry=config_entry,
         title="Renamed CARP VIP",
         data={
-            cf_mod.CONF_URL: "https://carp-router.example",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_FIRMWARE_VERSION: "26.1.11",
-            cf_mod.CONF_NAME: "Renamed CARP VIP",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_URL: "https://carp-router.example",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_FIRMWARE_VERSION: "26.1.11",
+            CONF_NAME: "Renamed CARP VIP",
+            CONF_VERIFY_SSL: True,
         },
     )
 
@@ -1933,18 +1947,18 @@ async def test_reconfigure_carp_aborts_on_device_url_conflict(
     """CARP reconfigure should reject a changed URL used by a device entry."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://old-carp.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://old-carp.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
     existing_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "http://router.example:80",
-            cf_mod.CONF_USERNAME: "device-user",
-            cf_mod.CONF_PASSWORD: "device-pass",
+            CONF_URL: "http://router.example:80",
+            CONF_USERNAME: "device-user",
+            CONF_PASSWORD: "device-pass",
         },
         options={},
     )
@@ -1963,17 +1977,17 @@ async def test_reconfigure_carp_aborts_on_device_url_conflict(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "http://router.example",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_URL: "http://router.example",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
         }
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "carp_device_url_conflict"
     validate.assert_awaited_once()
-    flow.hass.config_entries.async_entries.assert_called_once_with(cf_mod.DOMAIN)
+    flow.hass.config_entries.async_entries.assert_called_once_with(DOMAIN)
     abort_match.assert_not_called()
     update_and_abort.assert_not_called()
 
@@ -1985,10 +1999,10 @@ async def test_reconfigure_carp_returns_form_on_validation_error(
     """CARP reconfigure validation errors should return form and not update."""
     config_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: "https://x",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://x",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
@@ -2005,10 +2019,10 @@ async def test_reconfigure_carp_returns_form_on_validation_error(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "https://router.example",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_URL: "https://router.example",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
         }
     )
 
@@ -2027,11 +2041,11 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
     config_entry = make_config_entry(
         entry_id="carp-entry",
         data={
-            cf_mod.CONF_URL: "https://carp-router.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: "https://carp-router.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
@@ -2039,7 +2053,7 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
     flow.hass = MagicMock()
     validate = AsyncMock(
         side_effect=lambda **kwargs: kwargs["user_input"].update(
-            {cf_mod.CONF_URL: "https://carp-router.example"}
+            {CONF_URL: "https://carp-router.example"}
         )
     )
     monkeypatch.setattr(cf_mod, "validate_input", validate)
@@ -2051,10 +2065,10 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "https://carp-router.example/",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_URL: "https://carp-router.example/",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
         }
     )
 
@@ -2065,12 +2079,12 @@ async def test_reconfigure_carp_skips_duplicate_check_when_url_unchanged(
         entry=config_entry,
         title="Router CARP VIP",
         data={
-            cf_mod.CONF_URL: "https://carp-router.example",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: "https://carp-router.example",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_NAME: "Router CARP VIP",
         },
     )
 
@@ -2083,10 +2097,10 @@ async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
     config_entry = make_config_entry(
         entry_id="carp-entry",
         data={
-            cf_mod.CONF_URL: "https://old.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: "https://old.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
@@ -2094,7 +2108,7 @@ async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
     flow.hass = MagicMock()
     validate = AsyncMock(
         side_effect=lambda **kwargs: kwargs["user_input"].update(
-            {cf_mod.CONF_URL: "https://carp-router.example"}
+            {CONF_URL: "https://carp-router.example"}
         )
     )
     monkeypatch.setattr(cf_mod, "validate_input", validate)
@@ -2107,14 +2121,14 @@ async def test_reconfigure_carp_aborts_on_normalized_duplicate_url(
     with pytest.raises(AbortFlow, match="already_configured"):
         await flow.async_step_reconfigure(
             user_input={
-                cf_mod.CONF_URL: "https://carp-router.example/",
-                cf_mod.CONF_USERNAME: "admin",
-                cf_mod.CONF_PASSWORD: "secret",
-                cf_mod.CONF_VERIFY_SSL: True,
+                CONF_URL: "https://carp-router.example/",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "secret",
+                CONF_VERIFY_SSL: True,
             }
         )
 
-    abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
+    abort_match.assert_called_once_with({CONF_URL: "https://carp-router.example"})
     update_and_abort.assert_not_called()
 
 
@@ -2136,20 +2150,20 @@ async def test_reconfigure_carp_aborts_on_legacy_default_port_duplicate(
     config_entry = make_config_entry(
         entry_id="carp-entry",
         data={
-            cf_mod.CONF_URL: "https://old.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: "https://old.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
     duplicate_entry = make_config_entry(
         data={
-            cf_mod.CONF_URL: stored_url,
-            cf_mod.CONF_USERNAME: "other-user",
-            cf_mod.CONF_PASSWORD: "other-password",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_URL: stored_url,
+            CONF_USERNAME: "other-user",
+            CONF_PASSWORD: "other-password",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
         },
         options={},
     )
@@ -2166,11 +2180,11 @@ async def test_reconfigure_carp_aborts_on_legacy_default_port_duplicate(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_NAME: "Router CARP VIP",
-            cf_mod.CONF_URL: normalized_url,
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_NAME: "Router CARP VIP",
+            CONF_URL: normalized_url,
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_VERIFY_SSL: True,
         }
     )
 
@@ -2198,11 +2212,11 @@ async def test_reconfigure_carp_ignores_own_legacy_default_port_url(
     config_entry = make_config_entry(
         entry_id="carp-entry",
         data={
-            cf_mod.CONF_URL: stored_url,
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: stored_url,
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
@@ -2219,16 +2233,16 @@ async def test_reconfigure_carp_ignores_own_legacy_default_port_url(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_NAME: "Router CARP VIP",
-            cf_mod.CONF_URL: normalized_url,
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_NAME: "Router CARP VIP",
+            CONF_URL: normalized_url,
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_VERIFY_SSL: True,
         }
     )
 
     assert result == {"type": "abort", "reason": "reconfigure_successful"}
-    abort_match.assert_called_once_with({cf_mod.CONF_URL: normalized_url})
+    abort_match.assert_called_once_with({CONF_URL: normalized_url})
     update_and_abort.assert_called_once()
 
 
@@ -2240,11 +2254,11 @@ async def test_reconfigure_carp_preserves_self_url_when_no_duplicate(
     config_entry = make_config_entry(
         entry_id="carp-entry",
         data={
-            cf_mod.CONF_URL: "https://old.example",
-            cf_mod.CONF_USERNAME: "u",
-            cf_mod.CONF_PASSWORD: "p",
-            cf_mod.CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
-            cf_mod.CONF_NAME: "Router CARP VIP",
+            CONF_URL: "https://old.example",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+            CONF_NAME: "Router CARP VIP",
         },
         options={},
     )
@@ -2252,7 +2266,7 @@ async def test_reconfigure_carp_preserves_self_url_when_no_duplicate(
     flow.hass = MagicMock()
     validate = AsyncMock(
         side_effect=lambda **kwargs: kwargs["user_input"].update(
-            {cf_mod.CONF_URL: "https://carp-router.example"}
+            {CONF_URL: "https://carp-router.example"}
         )
     )
     monkeypatch.setattr(cf_mod, "validate_input", validate)
@@ -2264,15 +2278,15 @@ async def test_reconfigure_carp_preserves_self_url_when_no_duplicate(
 
     result = await flow.async_step_reconfigure(
         user_input={
-            cf_mod.CONF_URL: "https://carp-router.example/",
-            cf_mod.CONF_USERNAME: "admin",
-            cf_mod.CONF_PASSWORD: "secret",
-            cf_mod.CONF_VERIFY_SSL: True,
+            CONF_URL: "https://carp-router.example/",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
         }
     )
 
     assert result == {"type": "abort", "reason": "reconfigure_successful"}
-    abort_match.assert_called_once_with({cf_mod.CONF_URL: "https://carp-router.example"})
+    abort_match.assert_called_once_with({CONF_URL: "https://carp-router.example"})
     update_and_abort.assert_called_once()
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,7 +10,7 @@ from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
 
 from aiopnsense import exceptions as aiopnsense_exceptions
-from aiopnsense.exceptions import OPNsenseError, OPNsenseInvalidURL, OPNsenseMissingDeviceUniqueID
+from aiopnsense.exceptions import OPNsenseError, OPNsenseMissingDeviceUniqueID
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import AbortFlow
@@ -298,6 +298,7 @@ def test_url_conflict_matches_persisted_default_ports(
 
     result = flow._async_abort_if_url_conflict(url=normalized_url, carp=False)
 
+    assert result is not None
     assert result["type"] == "abort"
     assert result["reason"] == "carp_device_url_conflict"
 
@@ -679,6 +680,7 @@ async def test_async_step_carp_without_input_shows_empty_form() -> None:
     assert result["type"] == "form"
     assert result["step_id"] == "carp"
     assert result["errors"] == {}
+    assert result["description_placeholders"] is not None
     assert result["description_placeholders"]["firmware"] == "Unknown"
 
 
@@ -727,6 +729,7 @@ async def test_async_step_carp_rejects_malformed_or_blank_vip_rows(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "form"
+    assert result["errors"] is not None
     assert result["errors"]["base"] == "carp_not_configured"
     client.get_device_unique_id.assert_not_awaited()
 
@@ -777,6 +780,7 @@ async def test_async_step_carp_rejects_missing_or_blank_responder_name(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "form"
+    assert result["errors"] is not None
     assert result["errors"]["base"] == "carp_responder_unavailable"
 
 
@@ -797,6 +801,7 @@ async def test_async_step_carp_custom_name_does_not_waive_responder_validation(
     result = await flow.async_step_carp(user_input=user_input)
 
     assert result["type"] == "form"
+    assert result["errors"] is not None
     assert result["errors"]["base"] == "carp_responder_unavailable"
 
 
@@ -828,6 +833,7 @@ async def test_async_step_carp_rejects_below_min_firmware(
     result = await flow.async_step_carp(user_input=_make_basic_carp_input())
 
     assert result["type"] == "form"
+    assert result["errors"] is not None
     assert result["errors"]["base"] == "below_min_firmware"
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -155,10 +155,14 @@ async def test_get_states_fetches_smart_info_for_each_smart_device(
         "nvme0": {"temperature": {"current": 71}},
         "ada0": {"temperature": {"current": 42}},
     }
-    assert client.get_smart_info.await_args_list == [
-        call(device="nvme0", info_type="A"),
-        call(device="ada0", info_type="A"),
-    ]
+    client.get_smart_info.assert_has_awaits(
+        [
+            call(device="nvme0", info_type="A"),
+            call(device="ada0", info_type="A"),
+        ],
+        any_order=True,
+    )
+    assert client.get_smart_info.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -195,10 +199,14 @@ async def test_get_states_uses_smart_ident_when_device_missing(
         "serial-1": {"temperature": {"current": 37}},
         "nvme0": {"temperature": {"current": 37}},
     }
-    assert client.get_smart_info.await_args_list == [
-        call(device="serial-1", info_type="A"),
-        call(device="nvme0", info_type="A"),
-    ]
+    client.get_smart_info.assert_has_awaits(
+        [
+            call(device="serial-1", info_type="A"),
+            call(device="nvme0", info_type="A"),
+        ],
+        any_order=True,
+    )
+    assert client.get_smart_info.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import coordinator as coordinator_module
+from custom_components.opnsense import coordinator as coordinator_module, repairs as repairs_module
 from custom_components.opnsense.const import (
     ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
@@ -419,8 +419,10 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Mismatched device_unique_id should create an issue and shutdown after threshold."""
+    caplog.set_level(logging.ERROR, logger=coordinator_module.__name__)
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
     client = fake_client()()
     coord = OPNsenseDataUpdateCoordinator(
@@ -457,7 +459,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
         called["issue"] += 1
         called["issue_kwargs"] = kwargs
 
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
 
     # call 3 times -> should call issue once and shutdown once
@@ -469,10 +471,21 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     assert called["shutdown"] == 1
     # validate the issue was created for the integration domain and expected id
     assert isinstance(called["issue_kwargs"], MutableMapping)
-    assert called["issue_kwargs"].get("domain") == coordinator_module.DOMAIN
-    assert (
-        called["issue_kwargs"].get("issue_id") == f"{coord._device_unique_id}_device_id_mismatched"
-    )
+    assert called["issue_kwargs"].get("domain") == repairs_module.DOMAIN
+    assert called["issue_kwargs"].get("issue_id") == f"{entry.entry_id}_device_id_mismatched"
+    assert called["issue_kwargs"].get("is_fixable") is True
+    assert called["issue_kwargs"].get("data") == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "expected",
+        "new_device_id": "other",
+    }
+    assert called["issue_kwargs"].get("translation_placeholders") == {
+        "entry_title": entry.title,
+        "old_device_id": "expected",
+        "new_device_id": "other",
+    }
+    assert "fixable repair issue" in caplog.text
+    assert "rebuild entities" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1567,7 +1580,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
             "arp_table": [],
         }
 
-    called: dict[str, Any] = {"issue": 0, "shutdown": 0}
+    called: dict[str, Any] = {"issue": 0, "shutdown": 0, "issue_kwargs": None}
 
     async def fake_shutdown() -> None:
         """Record coordinator shutdown requests."""
@@ -1576,9 +1589,10 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
     def fake_async_create_issue(**kwargs: Any) -> None:
         """Record repair issue creation requests."""
         called["issue"] += 1
+        called["issue_kwargs"] = kwargs
 
     monkeypatch.setattr(coord, "_get_states", fake_get_states)
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     object.__setattr__(client, "get_query_counts", AsyncMock(return_value=3))
 
@@ -1587,5 +1601,18 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
     assert await coord._async_update_dt_data() == {}
 
     assert coord._mismatched_count == 3
-    assert called == {"issue": 1, "shutdown": 1}
+    assert called["issue"] == 1
+    assert called["shutdown"] == 1
+    assert called["issue_kwargs"]["is_fixable"] is True
+    assert called["issue_kwargs"]["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert called["issue_kwargs"]["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "id",
+        "new_device_id": "other",
+    }
+    assert called["issue_kwargs"]["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "id",
+        "new_device_id": "other",
+    }
     client.get_query_counts.assert_not_awaited()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, call
 
 from aiopnsense.exceptions import OPNsenseTimeoutError
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers import issue_registry as ir
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -463,7 +464,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
         called["issue"] += 1
         called["issue_kwargs"] = kwargs
 
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
 
     # call 3 times -> should call issue once and shutdown once
@@ -509,7 +510,7 @@ async def test_check_device_unique_id_clears_stale_issue_without_repair_marker(
     )
     coord._state = {"device_unique_id": "expected"}
     create_issue_delete = MagicMock()
-    monkeypatch.setattr(coordinator_module.ir, "async_delete_issue", create_issue_delete)
+    monkeypatch.setattr(ir, "async_delete_issue", create_issue_delete)
     build_issue_id = MagicMock(return_value="stable-issue-id")
     monkeypatch.setattr(
         coordinator_module,
@@ -550,7 +551,7 @@ async def test_check_device_unique_id_keeps_stale_issue_when_repair_marker_prese
     )
     coord._state = {"device_unique_id": "expected"}
     create_issue_delete = MagicMock()
-    monkeypatch.setattr(coordinator_module.ir, "async_delete_issue", create_issue_delete)
+    monkeypatch.setattr(ir, "async_delete_issue", create_issue_delete)
 
     res = await coord._check_device_unique_id()
 
@@ -1663,7 +1664,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         called["issue_kwargs"] = kwargs
 
     monkeypatch.setattr(coord, "_get_states", fake_get_states)
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     object.__setattr__(client, "get_query_counts", AsyncMock(return_value=3))
 
@@ -1772,7 +1773,7 @@ async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
         del kwargs
         called["issue"] += 1
 
-    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     coord._state = state
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,7 +7,6 @@ calculations, and update flow.
 
 from collections.abc import Callable, MutableMapping
 from datetime import timedelta
-import logging
 import time
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call
@@ -300,10 +299,8 @@ async def test_build_categories_includes_smart_without_smart_info_when_client_la
 @pytest.mark.asyncio
 async def test_build_categories_skips_smart_when_client_lacks_support(
     make_config_entry: Callable[..., MockConfigEntry],
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """SMART sync should not call unsupported runtime clients."""
-    caplog.set_level(logging.DEBUG, logger=coordinator_module.__name__)
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id", CONF_SYNC_SMART: True})
     client = MagicMock()
     del client.get_smart
@@ -318,7 +315,6 @@ async def test_build_categories_skips_smart_when_client_lacks_support(
     )
 
     assert "smart" not in [category["state_key"] for category in coord._categories]
-    assert "does not support it" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -421,10 +417,8 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Mismatched device_unique_id should create an issue and shutdown after threshold."""
-    caplog.set_level(logging.ERROR, logger=coordinator_module.__name__)
     entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
     client = fake_client()()
     coord = OPNsenseDataUpdateCoordinator(
@@ -486,8 +480,6 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
         "old_device_id": "expected",
         "new_device_id": "other",
     }
-    assert "fixable repair issue" in caplog.text
-    assert "rebuild entities" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -509,14 +509,21 @@ async def test_check_device_unique_id_clears_stale_issue_without_repair_marker(
     coord._state = {"device_unique_id": "expected"}
     create_issue_delete = MagicMock()
     monkeypatch.setattr(coordinator_module.ir, "async_delete_issue", create_issue_delete)
+    build_issue_id = MagicMock(return_value="stable-issue-id")
+    monkeypatch.setattr(
+        coordinator_module,
+        "build_device_id_mismatch_issue_id",
+        build_issue_id,
+    )
 
     res = await coord._check_device_unique_id()
 
     assert res is True
+    build_issue_id.assert_called_once_with(entry.entry_id)
     create_issue_delete.assert_called_once_with(
         coord.hass,
         coordinator_module.DOMAIN,
-        f"{entry.entry_id}_device_id_mismatched",
+        "stable-issue-id",
     )
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -41,6 +41,7 @@ from custom_components.opnsense.const import (
     ENTRY_TYPE_CARP,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
+from custom_components.opnsense.repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker
 
 
 @pytest.mark.asyncio
@@ -459,7 +460,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
         called["issue"] += 1
         called["issue_kwargs"] = kwargs
 
-    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
 
     # call 3 times -> should call issue once and shutdown once
@@ -486,6 +487,67 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     }
     assert "fixable repair issue" in caplog.text
     assert "rebuild entities" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_check_device_unique_id_clears_stale_issue_without_repair_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+) -> None:
+    """Matching IDs should clear stale mismatch issues when no repair marker exists."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="expected",
+        config_entry=entry,
+    )
+    coord._state = {"device_unique_id": "expected"}
+    create_issue_delete = MagicMock()
+    monkeypatch.setattr(coordinator_module.ir, "async_delete_issue", create_issue_delete)
+
+    res = await coord._check_device_unique_id()
+
+    assert res is True
+    create_issue_delete.assert_called_once_with(
+        coord.hass,
+        coordinator_module.DOMAIN,
+        f"{entry.entry_id}_device_id_mismatched",
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_device_unique_id_keeps_stale_issue_when_repair_marker_present(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+) -> None:
+    """Matching IDs should keep stale issues while a repair marker is still active."""
+    marker = build_repair_marker("old-dev", "expected")
+    entry = make_config_entry(
+        {CONF_DEVICE_UNIQUE_ID: "expected", REPAIR_MARKER_KEY: marker},
+    )
+    client = fake_client()()
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=client,
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="expected",
+        config_entry=entry,
+    )
+    coord._state = {"device_unique_id": "expected"}
+    create_issue_delete = MagicMock()
+    monkeypatch.setattr(coordinator_module.ir, "async_delete_issue", create_issue_delete)
+
+    res = await coord._check_device_unique_id()
+
+    assert res is True
+    create_issue_delete.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1593,7 +1655,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         called["issue_kwargs"] = kwargs
 
     monkeypatch.setattr(coord, "_get_states", fake_get_states)
-    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     object.__setattr__(client, "get_query_counts", AsyncMock(return_value=3))
 
@@ -1666,7 +1728,7 @@ async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
         del kwargs
         called["issue"] += 1
 
-    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    monkeypatch.setattr(coordinator_module.ir, "async_create_issue", fake_async_create_issue)
     object.__setattr__(coord, "async_shutdown", fake_shutdown)
     coord._state = state
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1621,23 +1621,29 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "state",
+    ("expected_device_id", "state"),
     [
-        pytest.param({}, id="missing"),
-        pytest.param({"device_unique_id": ""}, id="blank"),
-        pytest.param({"device_unique_id": None}, id="none"),
-        pytest.param({"device_unique_id": 123}, id="number"),
-        pytest.param({"device_unique_id": "   "}, id="whitespace"),
+        pytest.param("expected", {}, id="missing-runtime-id"),
+        pytest.param("expected", {"device_unique_id": ""}, id="blank-runtime-id"),
+        pytest.param("expected", {"device_unique_id": None}, id="none-runtime-id"),
+        pytest.param("expected", {"device_unique_id": 123}, id="number-runtime-id"),
+        pytest.param("expected", {"device_unique_id": "   "}, id="whitespace-runtime-id"),
+        pytest.param("", {"device_unique_id": "valid-runtime-id"}, id="blank-configured-id"),
+        pytest.param(
+            "   ", {"device_unique_id": "valid-runtime-id"}, id="whitespace-configured-id"
+        ),
+        pytest.param(123, {"device_unique_id": "valid-runtime-id"}, id="number-configured-id"),
     ],
 )
 async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
+    expected_device_id: object,
     state: dict[str, object],
 ) -> None:
-    """Non-string and blank runtime IDs should reset mismatch count and fail fast."""
-    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
+    """Malformed configured or runtime IDs should reset mismatch count and fail fast."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: expected_device_id})
     coord = OPNsenseDataUpdateCoordinator(
         hass=MagicMock(),
         client=fake_client()(),
@@ -1646,6 +1652,7 @@ async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
         device_unique_id="expected",
         config_entry=entry,
     )
+    object.__setattr__(coord, "_device_unique_id", expected_device_id)
 
     called: dict[str, int] = {"issue": 0, "shutdown": 0}
     coord._mismatched_count = 2
@@ -1669,50 +1676,3 @@ async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
     assert coord._mismatched_count == 0
     assert called["issue"] == 0
     assert called["shutdown"] == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "expected_device_id",
-    [
-        pytest.param("", id="blank"),
-        pytest.param("   ", id="whitespace"),
-        pytest.param(123, id="number"),
-    ],
-)
-async def test_check_device_unique_id_invalid_expected_id_is_not_counted(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-    fake_client: Any,
-    expected_device_id: object,
-) -> None:
-    """Malformed configured IDs should not count valid observed IDs as mismatches."""
-    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: expected_device_id})
-    coord = OPNsenseDataUpdateCoordinator(
-        hass=MagicMock(),
-        client=fake_client()(),
-        name="n",
-        update_interval=timedelta(seconds=1),
-        device_unique_id="valid-configured-id",
-        config_entry=entry,
-    )
-    object.__setattr__(coord, "_device_unique_id", expected_device_id)
-    called: dict[str, int] = {"issue": 0, "shutdown": 0}
-    coord._mismatched_count = 2
-
-    async def fake_shutdown() -> None:
-        """Record shutdown calls for invalid configured IDs."""
-        called["shutdown"] += 1
-
-    def fake_async_create_issue(**kwargs: Any) -> None:
-        """Record issue creation calls."""
-        del kwargs
-        called["issue"] += 1
-
-    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
-    object.__setattr__(coord, "async_shutdown", fake_shutdown)
-    coord._state = {"device_unique_id": "valid-observed-id"}
-
-    assert await coord._check_device_unique_id() is False
-    assert coord._mismatched_count == 0
-    assert called == {"issue": 0, "shutdown": 0}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1669,3 +1669,50 @@ async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
     assert coord._mismatched_count == 0
     assert called["issue"] == 0
     assert called["shutdown"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_device_id",
+    [
+        pytest.param("", id="blank"),
+        pytest.param("   ", id="whitespace"),
+        pytest.param(123, id="number"),
+    ],
+)
+async def test_check_device_unique_id_invalid_expected_id_is_not_counted(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+    expected_device_id: object,
+) -> None:
+    """Malformed configured IDs should not count valid observed IDs as mismatches."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: expected_device_id})
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=fake_client()(),
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="valid-configured-id",
+        config_entry=entry,
+    )
+    object.__setattr__(coord, "_device_unique_id", expected_device_id)
+    called: dict[str, int] = {"issue": 0, "shutdown": 0}
+    coord._mismatched_count = 2
+
+    async def fake_shutdown() -> None:
+        """Record shutdown calls for invalid configured IDs."""
+        called["shutdown"] += 1
+
+    def fake_async_create_issue(**kwargs: Any) -> None:
+        """Record issue creation calls."""
+        del kwargs
+        called["issue"] += 1
+
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    object.__setattr__(coord, "async_shutdown", fake_shutdown)
+    coord._state = {"device_unique_id": "valid-observed-id"}
+
+    assert await coord._check_device_unique_id() is False
+    assert coord._mismatched_count == 0
+    assert called == {"issue": 0, "shutdown": 0}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1690,6 +1690,42 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
 
 
 @pytest.mark.asyncio
+async def test_check_device_unique_id_mismatch_issue_retries_until_success(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+) -> None:
+    """Retry mismatch issue creation and shut down only after it succeeds."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "id"})
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=fake_client()(),
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="id",
+        config_entry=entry,
+    )
+    coord._state = {"device_unique_id": "other"}
+    create_issue = MagicMock(side_effect=[False, True])
+    shutdown = AsyncMock()
+
+    monkeypatch.setattr(coordinator_module, "async_create_device_id_mismatch_issue", create_issue)
+    object.__setattr__(coord, "async_shutdown", shutdown)
+
+    assert await coord._check_device_unique_id() is False
+    assert await coord._check_device_unique_id() is False
+    assert await coord._check_device_unique_id() is False
+    assert await coord._check_device_unique_id() is False
+
+    assert coord._mismatched_count == 4
+    assert create_issue.call_args_list == [
+        call(coord.hass, entry, "other"),
+        call(coord.hass, entry, "other"),
+    ]
+    shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("expected_device_id", "state"),
     [

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import ConfigEntry
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import coordinator as coordinator_module, repairs as repairs_module
+from custom_components.opnsense import coordinator as coordinator_module
 from custom_components.opnsense.const import (
     ATTR_UNBOUND_BLOCKLIST,
     CONF_DEVICE_UNIQUE_ID,
@@ -38,6 +38,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_UNBOUND,
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
+    DOMAIN,
     ENTRY_TYPE_CARP,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
@@ -472,7 +473,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
     assert called["shutdown"] == 1
     # validate the issue was created for the integration domain and expected id
     assert isinstance(called["issue_kwargs"], MutableMapping)
-    assert called["issue_kwargs"].get("domain") == repairs_module.DOMAIN
+    assert called["issue_kwargs"].get("domain") == DOMAIN
     assert called["issue_kwargs"].get("issue_id") == f"{entry.entry_id}_device_id_mismatched"
     assert called["issue_kwargs"].get("is_fixable") is True
     assert called["issue_kwargs"].get("data") == {
@@ -522,7 +523,7 @@ async def test_check_device_unique_id_clears_stale_issue_without_repair_marker(
     build_issue_id.assert_called_once_with(entry.entry_id)
     create_issue_delete.assert_called_once_with(
         coord.hass,
-        coordinator_module.DOMAIN,
+        DOMAIN,
         "stable-issue-id",
     )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1496,6 +1496,7 @@ async def test_calculate_entity_speeds_returns_early_when_missing(
     [
         (None, False),
         ("other", False),
+        (" ", False),
         ("id", True),
     ],
 )
@@ -1626,6 +1627,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         pytest.param({"device_unique_id": ""}, id="blank"),
         pytest.param({"device_unique_id": None}, id="none"),
         pytest.param({"device_unique_id": 123}, id="number"),
+        pytest.param({"device_unique_id": "   "}, id="whitespace"),
     ],
 )
 async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -452,7 +452,7 @@ async def test_check_device_unique_id_mismatch_triggers_issue(
 
     def fake_async_create_issue(**kwargs: Any) -> None:
         # record the kwargs so tests can validate domain and issue_id
-        """Capture the issue payload emitted for a device-ID mismatch.
+        """Capture the issue payload emitted for a Device ID mismatch.
 
         Args:
             **kwargs: Issue fields passed to ``issue_registry.async_create_issue``.
@@ -853,7 +853,7 @@ async def test_async_update_data_reentrancy_and_full_flow(
 
     # full flow: monkeypatch _check_device_unique_id to True and ensure functions called
     async def true_check() -> bool:
-        """Force the device-ID validation step to succeed."""
+        """Force the Device ID validation step to succeed."""
         return True
 
     monkeypatch.setattr(coord, "_check_device_unique_id", true_check)
@@ -946,7 +946,7 @@ async def test_async_update_data_enables_firewall_polling_when_runtime_firmware_
     )
 
     async def true_check() -> bool:
-        """Force the device-id validation step to succeed."""
+        """Force the Device ID validation step to succeed."""
         return True
 
     monkeypatch.setattr(coord, "_check_device_unique_id", true_check)
@@ -1028,7 +1028,7 @@ async def test_build_categories_and_refresh_queue_firewall_for_legacy_firmware(
     assert "firewall" in [category["state_key"] for category in coord._categories]
 
     async def true_check() -> bool:
-        """Force the device-id validation step to succeed."""
+        """Force the Device ID validation step to succeed."""
         return True
 
     monkeypatch.setattr(coord, "_check_device_unique_id", true_check)
@@ -1109,7 +1109,7 @@ async def test_async_update_data_continues_firewall_polling_after_runtime_downgr
     )
 
     async def true_check() -> bool:
-        """Force the device-id validation step to succeed."""
+        """Force the Device ID validation step to succeed."""
         return True
 
     monkeypatch.setattr(coord, "_check_device_unique_id", true_check)
@@ -1195,7 +1195,7 @@ async def test_async_update_data_fetches_firewall_on_first_refresh_if_firmware_i
     )
 
     async def true_check() -> bool:
-        """Force the device-id validation step to succeed."""
+        """Force the Device ID validation step to succeed."""
         return True
 
     monkeypatch.setattr(coord, "_check_device_unique_id", true_check)
@@ -1409,7 +1409,7 @@ async def test_async_update_data_preserves_only_counter_snapshot(
     }
 
     async def true_check() -> bool:
-        """Force device-ID validation to pass for previous-state assertions."""
+        """Force Device ID validation to pass for previous-state assertions."""
         return True
 
     async def noop_calc() -> None:
@@ -1495,10 +1495,10 @@ async def test_async_update_data_returns_empty_when_device_id_check_fails(
     )
 
     async def false_check() -> bool:
-        """Force device-ID validation to fail for the early-return branch."""
+        """Force Device ID validation to fail for the early-return branch."""
         return False
 
-    # make the device id check return False
+    # make the Device ID check return False
     monkeypatch.setattr(coord, "_check_device_unique_id", false_check)
 
     # spy on reset_query_counts
@@ -1628,7 +1628,7 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
     make_config_entry: Callable[..., MockConfigEntry],
     fake_client: Any,
 ) -> None:
-    """Device-tracker refreshes should use the shared device-ID mismatch policy."""
+    """Device-tracker refreshes should use the shared Device ID mismatch policy."""
     entry = make_config_entry({"device_unique_id": "id"})
     client = fake_client()()
     coord = OPNsenseDataUpdateCoordinator(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1616,3 +1616,54 @@ async def test_async_update_dt_data_uses_shared_device_id_mismatch_policy(
         "new_device_id": "other",
     }
     client.get_query_counts.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        pytest.param({}, id="missing"),
+        pytest.param({"device_unique_id": ""}, id="blank"),
+        pytest.param({"device_unique_id": None}, id="none"),
+        pytest.param({"device_unique_id": 123}, id="number"),
+    ],
+)
+async def test_check_device_unique_id_invalid_runtime_id_is_not_counted(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_client: Any,
+    state: dict[str, object],
+) -> None:
+    """Non-string and blank runtime IDs should reset mismatch count and fail fast."""
+    entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "expected"})
+    coord = OPNsenseDataUpdateCoordinator(
+        hass=MagicMock(),
+        client=fake_client()(),
+        name="n",
+        update_interval=timedelta(seconds=1),
+        device_unique_id="expected",
+        config_entry=entry,
+    )
+
+    called: dict[str, int] = {"issue": 0, "shutdown": 0}
+    coord._mismatched_count = 2
+
+    async def fake_shutdown() -> None:
+        """Record shutdown calls for invalid runtime IDs."""
+        called["shutdown"] += 1
+
+    def fake_async_create_issue(**kwargs: Any) -> None:
+        """Record issue creation calls."""
+        del kwargs
+        called["issue"] += 1
+
+    monkeypatch.setattr(repairs_module.ir, "async_create_issue", fake_async_create_issue)
+    object.__setattr__(coord, "async_shutdown", fake_shutdown)
+    coord._state = state
+
+    result = await coord._check_device_unique_id()
+
+    assert result is False
+    assert coord._mismatched_count == 0
+    assert called["issue"] == 0
+    assert called["shutdown"] == 0

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -10,19 +10,25 @@ from types import MappingProxyType
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call
 
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.const import Platform
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-import custom_components.opnsense as opnsense_pkg
-import custom_components.opnsense.device_tracker as device_tracker_mod
+from custom_components.opnsense.const import (
+    CONF_DEVICE_TRACKER_CONSIDER_HOME,
+    CONF_DEVICE_TRACKER_ENABLED,
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_DEVICES,
+    DEVICE_TRACKER_COORDINATOR,
+    DOMAIN,
+    TRACKED_MACS,
+)
+import custom_components.opnsense.device_tracker as dt_mod
 from custom_components.opnsense.device_tracker import OPNsenseScannerEntity
-import custom_components.opnsense.entity as entity_mod
-
-base_entity_mod = entity_mod
-dt_mod = device_tracker_mod
-pkg = opnsense_pkg
+from custom_components.opnsense.entity import OPNsenseBaseEntity
 
 
 def _make_scanner_entity(
@@ -46,9 +52,9 @@ def _make_scanner_entity(
         A scanner entity for the requested MAC address.
     """
     coordinator.data = {"arp_table": []} if coordinator_data is None else coordinator_data
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-    return dt_mod.OPNsenseScannerEntity(
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    return OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=enabled_default,
@@ -105,8 +111,8 @@ def test_compile_tracked_devices_normalizes_and_deduplicates_configured_macs(
     """Configured MACs should be normalized and deduplicated before entity creation."""
     config_entry = make_config_entry(
         options={
-            dt_mod.CONF_DEVICE_TRACKER_ENABLED: True,
-            dt_mod.CONF_DEVICES: [
+            CONF_DEVICE_TRACKER_ENABLED: True,
+            CONF_DEVICES: [
                 "AA-BB-CC-DD-EE-FF",
                 "aa:bb:cc:dd:ee:ff",
                 "11:22:33:44:55:66",
@@ -167,11 +173,11 @@ async def test_async_setup_entry_configured_devices(
     }
 
     entry = make_config_entry(
-        data={dt_mod.TRACKED_MACS: [], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICES: ["aa:bb:cc"], dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        data={TRACKED_MACS: [], CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICES: ["aa:bb:cc"], CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="eid",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     entry.add_update_listener = lambda _listener: lambda: None
     entry.async_on_unload = lambda _unload: None
     hass = ph_hass
@@ -197,7 +203,7 @@ async def test_async_setup_entry_configured_devices(
 
     assert len(added) == 1
     created = added[0]
-    assert isinstance(created, dt_mod.OPNsenseScannerEntity)
+    assert isinstance(created, OPNsenseScannerEntity)
     uid = getattr(created, "unique_id", None)
     assert uid is not None
     assert uid.startswith("dev1_")
@@ -213,7 +219,7 @@ async def test_async_setup_entry_configured_devices(
     updated_data = kwargs.get("data", args[1] if len(args) > 1 else None)
 
     assert target_entry is entry
-    assert updated_data.get(dt_mod.TRACKED_MACS) == ["aa:bb:cc"]
+    assert updated_data.get(TRACKED_MACS) == ["aa:bb:cc"]
 
 
 @pytest.mark.asyncio
@@ -232,11 +238,11 @@ async def test_async_setup_entry_skips_malformed_arp_rows(
         ]
     }
     entry = make_config_entry(
-        data={dt_mod.TRACKED_MACS: [], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        data={TRACKED_MACS: [], CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="eid",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     hass = ph_hass
     hass.config_entries.async_update_entry = MagicMock()
     fake = fake_reg_factory(device_exists=False)
@@ -263,11 +269,11 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     }
 
     entry = make_config_entry(
-        data={dt_mod.TRACKED_MACS: ["aa:bb:cc", "ff:ee:dd"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICES: ["aa:bb:cc"], dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        data={TRACKED_MACS: ["aa:bb:cc", "ff:ee:dd"], CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICES: ["aa:bb:cc"], CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="eid_remove",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     entry.add_update_listener = lambda _listener: lambda: None
     entry.async_on_unload = lambda _unload: None
 
@@ -299,8 +305,8 @@ async def test_async_setup_entry_removes_nonmatching_tracked_macs(
     updated_data = kwargs.get("data", args[1] if len(args) > 1 else None)
 
     assert updated_data is not None
-    assert "ff:ee:dd" not in updated_data.get(dt_mod.TRACKED_MACS, [])
-    assert "aa:bb:cc" in updated_data.get(dt_mod.TRACKED_MACS, [])
+    assert "ff:ee:dd" not in updated_data.get(TRACKED_MACS, [])
+    assert "aa:bb:cc" in updated_data.get(TRACKED_MACS, [])
 
 
 def test_handle_coordinator_update_unavailable(
@@ -308,10 +314,10 @@ def test_handle_coordinator_update_unavailable(
 ) -> None:
     """Coordinator with invalid data should mark entity unavailable."""
     coordinator.data = None
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -346,10 +352,10 @@ def test_handle_coordinator_update_entry_present(
         "update_time": float(int(datetime.now(UTC).timestamp())),
     }
 
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -370,7 +376,25 @@ def test_handle_coordinator_update_entry_present(
     assert attributes.get("interface") == "lan0"
     assert attributes.get("type") == "arp"
     assert ent.icon == "mdi:lan-connect"
-    assert ent.source_type == dt_mod.SourceType.ROUTER
+    assert ent.source_type == SourceType.ROUTER
+
+
+def test_scanner_entity_uses_attr_backed_home_assistant_properties() -> None:
+    """Scanner entity should rely on Home Assistant attr-backed properties."""
+    locally_defined_properties = {
+        name for name, value in vars(OPNsenseScannerEntity).items() if isinstance(value, property)
+    }
+
+    assert "unique_id" in locally_defined_properties
+    assert "device_info" in locally_defined_properties
+    assert "entity_registry_enabled_default" in locally_defined_properties
+    assert "is_connected" in locally_defined_properties
+    assert {
+        "hostname",
+        "ip_address",
+        "mac_address",
+        "source_type",
+    }.isdisjoint(locally_defined_properties)
 
 
 def test_entity_registry_enabled_default_uses_existing_mac_device(
@@ -402,8 +426,8 @@ def test_suggested_object_id_prefers_hostname_when_matching_enabled_mac_device(
     fake_reg_factory: Any,
 ) -> None:
     """Hostnames should drive suggested_object_id for existing enabled MAC matches."""
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}),
+    ent = OPNsenseScannerEntity(
+        config_entry=make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}),
         coordinator=coordinator,
         enabled_default=False,
         mac="aa:bb:cc",
@@ -426,8 +450,8 @@ def test_suggested_object_id_falls_back_to_mac_for_existing_enabled_mac_match(
     fake_reg_factory: Any,
 ) -> None:
     """Use MAC as suggested_object_id when hostname is unavailable."""
-    ent = dt_mod.OPNsenseScannerEntity(
-        config_entry=make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}),
+    ent = OPNsenseScannerEntity(
+        config_entry=make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}),
         coordinator=coordinator,
         enabled_default=False,
         mac="aa:bb:cc",
@@ -717,10 +741,10 @@ def test_handle_coordinator_update_skips_malformed_arp_rows(
             },
         ]
     }
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -745,12 +769,12 @@ def test_handle_coordinator_update_missing_entry_consider_home(
     """If missing entry and within consider_home, entity remains connected."""
     coordinator.data = {"arp_table": []}
     entry = make_config_entry(
-        data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: 3600},
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_CONSIDER_HOME: 3600},
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -770,12 +794,12 @@ def test_handle_coordinator_update_expired_entry_outside_consider_home(
 ) -> None:
     """Expired ARP entries outside consider_home should stay disconnected."""
     entry = make_config_entry(
-        data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICE_TRACKER_CONSIDER_HOME: 1},
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_CONSIDER_HOME: 1},
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     coordinator.data = {"arp_table": [{"mac": "aa:bb:cc", "expired": True}]}
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -813,10 +837,10 @@ async def test_restore_last_state_and_device_info(
 ) -> None:
     """Restoring last state merges saved attributes into the entity."""
     coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -866,8 +890,8 @@ async def test_restore_last_state_and_device_info(
     assert any(t[1] == "aa:bb:cc" for t in connections)
     assert default_name == "dev"
     assert via is not None
-    assert via[0] == dt_mod.DOMAIN
-    assert via[1] == entry.data[pkg.CONF_DEVICE_UNIQUE_ID]
+    assert via[0] == DOMAIN
+    assert via[1] == entry.data[CONF_DEVICE_UNIQUE_ID]
 
 
 @pytest.mark.asyncio
@@ -974,10 +998,10 @@ async def test_async_added_to_hass_calls_restore(
 ) -> None:
     """Entity.async_added_to_hass should call state restoration."""
     coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -988,7 +1012,7 @@ async def test_async_added_to_hass_calls_restore(
 
     restore_last_state = AsyncMock()
     object.__setattr__(ent, "_restore_last_state", restore_last_state)
-    monkeypatch.setattr(base_entity_mod.OPNsenseBaseEntity, "async_added_to_hass", AsyncMock())
+    monkeypatch.setattr(OPNsenseBaseEntity, "async_added_to_hass", AsyncMock())
 
     await ent.async_added_to_hass()
     assert restore_last_state.called
@@ -1002,14 +1026,14 @@ async def test_async_internal_added_to_hass_links_existing_mac_device(
 ) -> None:
     """Scanner entity should link to an existing registry device with the same MAC."""
     coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
     entry.add_to_hass(ph_hass)
     existing_entry = make_config_entry(
-        data={pkg.CONF_DEVICE_UNIQUE_ID: "other"}, entry_id="existing-entry"
+        data={CONF_DEVICE_UNIQUE_ID: "other"}, entry_id="existing-entry"
     )
     existing_entry.add_to_hass(ph_hass)
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-    ent = dt_mod.OPNsenseScannerEntity(
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1018,7 +1042,7 @@ async def test_async_internal_added_to_hass_links_existing_mac_device(
         hostname=None,
     )
     ent.hass = ph_hass
-    ent.platform = MagicMock(config_entry=entry, platform_name=dt_mod.DOMAIN)
+    ent.platform = MagicMock(config_entry=entry, platform_name=DOMAIN)
 
     device_reg = dr.async_get(ph_hass)
     existing_device = device_reg.async_get_or_create(
@@ -1030,7 +1054,7 @@ async def test_async_internal_added_to_hass_links_existing_mac_device(
     assert unique_id is not None
     ent.registry_entry = entity_reg.async_get_or_create(
         "device_tracker",
-        dt_mod.DOMAIN,
+        DOMAIN,
         unique_id,
         config_entry=entry,
     )
@@ -1052,10 +1076,10 @@ async def test_async_internal_added_to_hass_keeps_fallback_device_info_without_m
 ) -> None:
     """Scanner entity should keep its fallback device info when no MAC device exists."""
     coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}, entry_id="entry-1")
     entry.add_to_hass(ph_hass)
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
-    ent = dt_mod.OPNsenseScannerEntity(
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1064,13 +1088,13 @@ async def test_async_internal_added_to_hass_keeps_fallback_device_info_without_m
         hostname=None,
     )
     ent.hass = ph_hass
-    ent.platform = MagicMock(config_entry=entry, platform_name=dt_mod.DOMAIN)
+    ent.platform = MagicMock(config_entry=entry, platform_name=DOMAIN)
     entity_reg = er.async_get(ph_hass)
     unique_id = ent.unique_id
     assert unique_id is not None
     ent.registry_entry = entity_reg.async_get_or_create(
         "device_tracker",
-        dt_mod.DOMAIN,
+        DOMAIN,
         unique_id,
         config_entry=entry,
     )
@@ -1092,8 +1116,8 @@ async def test_async_setup_entry_state_not_mapping(
 ) -> None:
     """Setup exits early when coordinator state is not a mapping."""
     coordinator.data = "not-a-mapping"
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     added: list[Any] = []
 
     hass = ph_hass
@@ -1115,8 +1139,8 @@ async def test_async_setup_entry_records_none_for_missing_arp_inventory(
 ) -> None:
     """Missing ARP payload should keep device tracker reconciliation incomplete."""
     coordinator.data = {}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
     recorded: dict[str, Any] = {}
 
@@ -1144,8 +1168,8 @@ async def test_async_setup_entry_records_empty_authoritative_arp_inventory(
 ) -> None:
     """An explicit empty ARP table is still authoritative for tracker reconciliation."""
     coordinator.data = {"arp_table": []}
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
     recorded: dict[str, Any] = {}
 
@@ -1176,10 +1200,10 @@ async def test_async_setup_entry_removes_previous_mac(
     """Setup removes previously tracked MAC addresses when reconfiguring."""
     coordinator.data = {"arp_table": []}
     entry = make_config_entry(
-        data={dt_mod.TRACKED_MACS: ["old:mac:1"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        data={TRACKED_MACS: ["old:mac:1"], CONF_DEVICE_UNIQUE_ID: "dev1"},
         entry_id="e_rm",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     hass = ph_hass
     hass.data = {}
 
@@ -1207,10 +1231,10 @@ async def test_async_setup_entry_preserves_previous_device_during_reconciliation
     """Active reconciliation owns stale deletion, including tracker devices."""
     coordinator.data = {"arp_table": []}
     entry = make_config_entry(
-        data={dt_mod.TRACKED_MACS: ["old:mac:1"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        data={TRACKED_MACS: ["old:mac:1"], CONF_DEVICE_UNIQUE_ID: "dev1"},
         entry_id="e_reconcile",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     fake = fake_reg_factory(device_exists=True, device_id="dev_to_preserve")
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
     monkeypatch.setattr(dt_mod, "is_reconciliation_active", lambda _entry: True)
@@ -1245,10 +1269,10 @@ def test_handle_coordinator_update_expires_positive(
         "update_time": float(int(datetime.now(UTC).timestamp())),
     }
 
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1281,10 +1305,10 @@ def test_handle_coordinator_update_skips_malformed_expires(
         "update_time": float(int(datetime.now(UTC).timestamp())),
     }
 
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1309,10 +1333,10 @@ def test_handle_coordinator_update_ip_typeerror(
     """Handle TypeError when entry IP is None and avoid crashing."""
     coordinator.data = {"arp_table": [{"mac": "aa:bb:cc", "ip": None}]}
 
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1332,10 +1356,10 @@ def test_handle_coordinator_update_expired_preserve_last_known_ip(
     """Expired entries preserve last_known_ip when no IP present."""
     coordinator.data = {"arp_table": [{"mac": "aa:bb:cc", "expired": True}]}
 
-    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
-    ent = dt_mod.OPNsenseScannerEntity(
+    ent = OPNsenseScannerEntity(
         config_entry=entry,
         coordinator=coordinator,
         enabled_default=False,
@@ -1365,11 +1389,11 @@ async def test_async_setup_entry_from_arp_entries(
     """Setup from ARP entries creates device trackers for present ARP rows."""
     coordinator.data = {"arp_table": [{"mac": "m1"}, {"mac": "m2", "hostname": "h2"}]}
     entry = make_config_entry(
-        data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="eid2",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
     hass = ph_hass
     hass.data = {}
     hass.config_entries.async_update_entry = MagicMock()
@@ -1380,7 +1404,7 @@ async def test_async_setup_entry_from_arp_entries(
 
     await dt_mod.async_setup_entry(hass, entry, cast("AddEntitiesCallback", added.extend))
     assert len(added) == 2
-    assert all(isinstance(e, dt_mod.OPNsenseScannerEntity) for e in added)
+    assert all(isinstance(e, OPNsenseScannerEntity) for e in added)
     assert {e.unique_id for e in added} == {"dev1_mac_m1", "dev1_mac_m2"}
 
 
@@ -1398,18 +1422,18 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
     stale_non_opnsense_mac = "stale:mac:nonopnsense"
     entry = make_config_entry(
         data={
-            dt_mod.TRACKED_MACS: [
+            TRACKED_MACS: [
                 stale_router_mac,
                 stale_other_mac,
                 stale_non_opnsense_mac,
                 "keep:mac",
             ],
-            pkg.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="entity-rm",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
     entity_registry = MagicMock()
     entity_ids = {
@@ -1427,22 +1451,22 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
 
     router_device = MagicMock(
         id="router-device-id",
-        identifiers={(dt_mod.DOMAIN, entry.data[dt_mod.CONF_DEVICE_UNIQUE_ID])},
+        identifiers={(DOMAIN, entry.data[CONF_DEVICE_UNIQUE_ID])},
     )
     surviving_entry_a = MagicMock(
         entry_id="survive-entry-b",
-        domain=dt_mod.DOMAIN,
-        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "survive-b"},
+        domain=DOMAIN,
+        data={CONF_DEVICE_UNIQUE_ID: "survive-b"},
     )
     surviving_entry_b = MagicMock(
         entry_id="survive-entry-a",
-        domain=dt_mod.DOMAIN,
-        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "survive-a"},
+        domain=DOMAIN,
+        data={CONF_DEVICE_UNIQUE_ID: "survive-a"},
     )
     non_opnsense_entry = MagicMock(
         entry_id="non-opnsense-entry",
         domain="other",
-        data={dt_mod.CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
+        data={CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
     )
     async_get_entry_map = {
         entry.entry_id: entry,
@@ -1454,9 +1478,9 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
     surviving_router_a = MagicMock(id="survivor-a-router")
     surviving_router_b = MagicMock(id="survivor-b-router")
     identifier_router_map = {
-        (dt_mod.DOMAIN, entry.data[dt_mod.CONF_DEVICE_UNIQUE_ID]): router_device,
-        (dt_mod.DOMAIN, "survive-b"): surviving_router_b,
-        (dt_mod.DOMAIN, "survive-a"): surviving_router_a,
+        (DOMAIN, entry.data[CONF_DEVICE_UNIQUE_ID]): router_device,
+        (DOMAIN, "survive-b"): surviving_router_b,
+        (DOMAIN, "survive-a"): surviving_router_a,
     }
     devices = {
         stale_router_mac: MagicMock(
@@ -1503,11 +1527,11 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
 
     entity_registry.async_get_entity_id.assert_has_calls(
         [
-            call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_router"),
-            call(dt_mod.Platform.DEVICE_TRACKER, dt_mod.DOMAIN, "dev1_mac_stale_mac_other"),
+            call(Platform.DEVICE_TRACKER, DOMAIN, "dev1_mac_stale_mac_router"),
+            call(Platform.DEVICE_TRACKER, DOMAIN, "dev1_mac_stale_mac_other"),
             call(
-                dt_mod.Platform.DEVICE_TRACKER,
-                dt_mod.DOMAIN,
+                Platform.DEVICE_TRACKER,
+                DOMAIN,
                 "dev1_mac_stale_mac_nonopnsense",
             ),
         ],
@@ -1553,13 +1577,13 @@ async def test_async_setup_entry_removes_stale_tracker_entities_clears_missing_p
     stale_router_mac = "stale:mac:router"
     entry = make_config_entry(
         data={
-            dt_mod.TRACKED_MACS: [stale_router_mac, "keep:mac"],
-            pkg.CONF_DEVICE_UNIQUE_ID: "dev1",
+            TRACKED_MACS: [stale_router_mac, "keep:mac"],
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={dt_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         entry_id="entity-rm-missing-parent",
     )
-    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
 
     entity_registry = MagicMock()
     entity_registry.async_get_entity_id = MagicMock(return_value=None)

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1190,6 +1190,131 @@ async def test_async_setup_entry_records_empty_authoritative_arp_inventory(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_malformed_arp_rows_in_track_all(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Track-all mode should fail reconciliation if any ARP row cannot compile."""
+    coordinator.data = {
+        "arp_table": [
+            "not-an-arp-row",
+            {},
+            {"mac": "", "hostname": "malformed"},
+            {"mac": "AA-BB-CC-DD-EE-FF", "hostname": "good"},
+        ]
+    }
+    entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
+    )
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    recorded: dict[str, Any] = {}
+    added: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: added.extend(entities)),
+    )
+
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+    assert len(added) == 1
+    assert added[0].mac_address == "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_duplicate_macs_in_track_all(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Track-all mode should fail reconciliation if duplicate normalized MAC rows exist."""
+    coordinator.data = {
+        "arp_table": [
+            {"mac": "AA-BB-CC-DD-EE-FF", "hostname": "first"},
+            {"mac": "aa:bb:cc:dd:ee:ff", "hostname": "duplicate"},
+            {"mac": "11:22:33:44:55:66", "hostname": "good"},
+        ]
+    }
+    entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
+    )
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    recorded: dict[str, Any] = {}
+    added: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: added.extend(entities)),
+    )
+
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+    assert len(added) == 2
+    assert added[0].mac_address == "aa:bb:cc:dd:ee:ff"
+    assert added[1].mac_address == "11:22:33:44:55:66"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_track_all_completeness_ignored_in_explicit_mac_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Explicit configured-MAC mode should ignore track-all completeness failures."""
+    coordinator.data = {
+        "arp_table": [
+            "not-an-arp-row",
+            {"mac": "", "hostname": "malformed"},
+            {"mac": "AA-BB-CC-DD-EE-FF", "hostname": "good"},
+        ]
+    }
+    entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={
+            CONF_DEVICE_TRACKER_ENABLED: True,
+            CONF_DEVICES: ["aa:bb:cc:dd:ee:ff"],
+        },
+    )
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    recorded: dict[str, Any] = {}
+    added: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: added.extend(entities)),
+    )
+
+    assert "entities" in recorded
+    assert isinstance(recorded["entities"], list)
+    assert len(added) == 1
+    assert added[0].mac_address == "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_removes_previous_mac(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1543,7 +1543,7 @@ async def test_async_setup_entry_removes_stale_tracker_entities_and_reparents_sh
         return entity_ids.get(unique_id)
 
     entity_registry.async_get_entity_id.side_effect = get_entity_id
-    monkeypatch.setattr(dt_mod.er, "async_get", MagicMock(return_value=entity_registry))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=entity_registry))
 
     router_device = MagicMock(
         id="router-device-id",
@@ -1683,7 +1683,7 @@ async def test_async_setup_entry_removes_stale_tracker_entities_clears_missing_p
 
     entity_registry = MagicMock()
     entity_registry.async_get_entity_id = MagicMock(return_value=None)
-    monkeypatch.setattr(dt_mod.er, "async_get", MagicMock(return_value=entity_registry))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=entity_registry))
 
     missing_parent_id = "missing-router-device-id"
     stale_device = MagicMock(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -418,52 +418,37 @@ def test_entity_registry_enabled_default_uses_existing_mac_device(
     assert ent.device_info is None
 
 
-def test_suggested_object_id_prefers_hostname_when_matching_enabled_mac_device(
+@pytest.mark.parametrize(
+    ("hostname", "expected_object_id"),
+    [
+        pytest.param("MyDevice", "MyDevice", id="hostname"),
+        pytest.param(None, "aa:bb:cc", id="mac-fallback"),
+    ],
+)
+def test_suggested_object_id_for_matching_enabled_mac_device(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
     fake_reg_factory: Any,
+    hostname: str | None,
+    expected_object_id: str,
 ) -> None:
-    """Hostnames should drive suggested_object_id for existing enabled MAC matches."""
+    """Suggested object IDs should prefer hostnames and otherwise use the MAC."""
     ent = OPNsenseScannerEntity(
         config_entry=make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}),
         coordinator=coordinator,
         enabled_default=False,
         mac="aa:bb:cc",
         mac_vendor=None,
-        hostname="MyDevice",
+        hostname=hostname,
     )
     ent.hass = ph_hass
     device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
     monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
 
     assert ent.device_info is None
-    assert ent.suggested_object_id == "MyDevice"
-
-
-def test_suggested_object_id_falls_back_to_mac_for_existing_enabled_mac_match(
-    monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
-    coordinator: MagicMock,
-    make_config_entry: Callable[..., MockConfigEntry],
-    fake_reg_factory: Any,
-) -> None:
-    """Use MAC as suggested_object_id when hostname is unavailable."""
-    ent = OPNsenseScannerEntity(
-        config_entry=make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1"}),
-        coordinator=coordinator,
-        enabled_default=False,
-        mac="aa:bb:cc",
-        mac_vendor=None,
-        hostname=None,
-    )
-    ent.hass = ph_hass
-    device_reg = fake_reg_factory(device_exists=True, device_id="existing-device")
-    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: device_reg)
-
-    assert ent.device_info is None
-    assert ent.suggested_object_id == "aa:bb:cc"
+    assert ent.suggested_object_id == expected_object_id
 
 
 def test_entity_registry_enabled_default_respects_configured_enabled_default(

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -379,24 +379,6 @@ def test_handle_coordinator_update_entry_present(
     assert ent.source_type == SourceType.ROUTER
 
 
-def test_scanner_entity_uses_attr_backed_home_assistant_properties() -> None:
-    """Scanner entity should rely on Home Assistant attr-backed properties."""
-    locally_defined_properties = {
-        name for name, value in vars(OPNsenseScannerEntity).items() if isinstance(value, property)
-    }
-
-    assert "unique_id" in locally_defined_properties
-    assert "device_info" in locally_defined_properties
-    assert "entity_registry_enabled_default" in locally_defined_properties
-    assert "is_connected" in locally_defined_properties
-    assert {
-        "hostname",
-        "ip_address",
-        "mac_address",
-        "source_type",
-    }.isdisjoint(locally_defined_properties)
-
-
 def test_entity_registry_enabled_default_uses_existing_mac_device(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1198,6 +1198,49 @@ async def test_async_setup_entry_records_none_for_malformed_arp_rows_in_track_al
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_records_entities_for_invalid_mapping_rows_in_track_all(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Track-all should ignore non-entity mapping rows with unusable MAC values."""
+    coordinator.data = {
+        "arp_table": [
+            {"mac": None},
+            {"mac": ""},
+            {"mac": 1234},
+            {"hostname": "invalid"},
+            {"mac": "AA-BB-CC-DD-EE-FF", "hostname": "good"},
+        ]
+    }
+    entry = make_config_entry(
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICES: [], CONF_DEVICE_TRACKER_ENABLED: True},
+    )
+    setattr(entry.runtime_data, DEVICE_TRACKER_COORDINATOR, coordinator)
+    recorded: dict[str, Any] = {}
+    added: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: added.extend(entities)),
+    )
+
+    assert "entities" in recorded
+    assert isinstance(recorded["entities"], list)
+    assert [entity.mac_address for entity in recorded["entities"]] == ["aa:bb:cc:dd:ee:ff"]
+    assert len(added) == 1
+    assert added[0].mac_address == "aa:bb:cc:dd:ee:ff"
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_records_entities_for_duplicate_macs_in_track_all(
     monkeypatch: pytest.MonkeyPatch,
     coordinator: MagicMock,

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1108,6 +1108,64 @@ async def test_async_setup_entry_state_not_mapping(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_arp_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing ARP payload should keep device tracker reconciliation incomplete."""
+    coordinator.data = {}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda _entities: None),
+    )
+
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_arp_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty ARP table is still authoritative for tracker reconciliation."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(data={pkg.CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(dt_mod, "record_desired_entities", capture)
+
+    await dt_mod.async_setup_entry(
+        MagicMock(),
+        entry,
+        cast("AddEntitiesCallback", lambda _entities: None),
+    )
+
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_removes_previous_mac(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1138,6 +1138,38 @@ async def test_async_setup_entry_removes_previous_mac(
     assert hass.config_entries.async_update_entry.called
 
 
+@pytest.mark.asyncio
+async def test_async_setup_entry_preserves_previous_device_during_reconciliation(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator: MagicMock,
+    make_config_entry: Callable[..., MockConfigEntry],
+    fake_reg_factory: Any,
+) -> None:
+    """Active reconciliation owns stale deletion, including tracker devices."""
+    coordinator.data = {"arp_table": []}
+    entry = make_config_entry(
+        data={dt_mod.TRACKED_MACS: ["old:mac:1"], pkg.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        entry_id="e_reconcile",
+    )
+    setattr(entry.runtime_data, dt_mod.DEVICE_TRACKER_COORDINATOR, coordinator)
+    fake = fake_reg_factory(device_exists=True, device_id="dev_to_preserve")
+    monkeypatch.setattr(dt_mod, "async_get_dev_reg", lambda _hass: fake, raising=False)
+    monkeypatch.setattr(dt_mod, "is_reconciliation_active", lambda _entry: True)
+    cleanup = MagicMock()
+    monkeypatch.setattr(dt_mod, "_cleanup_stale_tracked_devices", cleanup)
+    record = MagicMock()
+    monkeypatch.setattr(dt_mod, "record_desired_entities", record)
+    ph_hass.config_entries.async_update_entry = MagicMock()
+
+    await dt_mod.async_setup_entry(
+        ph_hass, entry, cast("AddEntitiesCallback", lambda _entities: None)
+    )
+
+    cleanup.assert_not_called()
+    record.assert_called_once_with(entry, "device_tracker", [])
+
+
 def test_handle_coordinator_update_expires_positive(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1231,12 +1231,12 @@ async def test_async_setup_entry_records_none_for_malformed_arp_rows_in_track_al
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_duplicate_macs_in_track_all(
+async def test_async_setup_entry_records_entities_for_duplicate_macs_in_track_all(
     monkeypatch: pytest.MonkeyPatch,
     coordinator: MagicMock,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
-    """Track-all mode should fail reconciliation if duplicate normalized MAC rows exist."""
+    """Track-all mode should treat duplicate normalized MAC rows as authoritative."""
     coordinator.data = {
         "arp_table": [
             {"mac": "AA-BB-CC-DD-EE-FF", "hostname": "first"},
@@ -1265,7 +1265,11 @@ async def test_async_setup_entry_records_none_for_duplicate_macs_in_track_all(
     )
 
     assert "entities" in recorded
-    assert recorded["entities"] is None
+    assert isinstance(recorded["entities"], list)
+    assert [entity.mac_address for entity in recorded["entities"]] == [
+        "aa:bb:cc:dd:ee:ff",
+        "11:22:33:44:55:66",
+    ]
     assert len(added) == 2
     assert added[0].mac_address == "aa:bb:cc:dd:ee:ff"
     assert added[1].mac_address == "11:22:33:44:55:66"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -238,7 +238,7 @@ def test_create_opnsense_client_builds_client_with_expected_options(
 
         def __init__(self, *, unsafe: bool) -> None:
             """Capture the unsafe flag without requiring a running event loop."""
-            self._unsafe = unsafe
+            created["cookie_jar_unsafe"] = unsafe
 
     monkeypatch.setattr(helpers_mod, "async_create_clientsession", _async_create_clientsession)
     monkeypatch.setattr(helpers_mod.aiohttp, "CookieJar", _CookieJar)
@@ -258,7 +258,7 @@ def test_create_opnsense_client_builds_client_with_expected_options(
     assert isinstance(client, MagicMock)
     assert created["hass"] is hass
     assert created["session_kwargs"]["raise_for_status"] is False
-    assert created["session_kwargs"]["cookie_jar"]._unsafe is True
+    assert created["cookie_jar_unsafe"] is True
     expected_client_kwargs = {
         "url": "http://10.0.0.1",
         "username": "user",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -241,7 +241,7 @@ def test_create_opnsense_client_builds_client_with_expected_options(
             created["cookie_jar_unsafe"] = unsafe
 
     monkeypatch.setattr(helpers_mod, "async_create_clientsession", _async_create_clientsession)
-    monkeypatch.setattr(helpers_mod.aiohttp, "CookieJar", _CookieJar)
+    monkeypatch.setattr(aiohttp, "CookieJar", _CookieJar)
     monkeypatch.setattr(helpers_mod, "OPNsenseClient", _client)
 
     password = "pass"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4493,6 +4493,7 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
         unique_id="dev1",
     )
     reconciliation = MagicMock()
+    reconciliation.marker = init_mod.parse_repair_marker(entry)
     reconciliation.prepare.side_effect = init_mod.RepairReconciliationError("prepare failed")
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4007,9 +4007,9 @@ async def test_async_setup_entry_with_device_tracker_enabled(
     hass.config_entries.async_reload = MagicMock()
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is True
-    # ensure a device-tracker coordinator was created and its initial refresh ran
-    assert any(getattr(inst, "_is_device_tracker", False) for inst in coordinator_capture.instances)
-    assert any(getattr(inst, "refreshed", False) for inst in coordinator_capture.instances)
+    device_tracker_coordinator = entry.runtime_data.device_tracker_coordinator
+    assert device_tracker_coordinator in coordinator_capture.instances
+    assert device_tracker_coordinator.refreshed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1085,14 +1085,12 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_client: Any,
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
-    caplog: pytest.LogCaptureFixture,
     stored_device_id: object,
     router_device_id: Any,
     should_create_issue: bool,
     setup_succeeds: bool,
 ) -> None:
     """async_setup_entry should handle malformed and mismatched device IDs safely."""
-    caplog.set_level(logging.ERROR, logger=init_mod.__name__)
     create_client = MagicMock(side_effect=fake_client(device_id=router_device_id))
     patch_opnsense_client(monkeypatch, init_mod, create_client)
     # use shared coordinator capture fixture
@@ -1141,8 +1139,6 @@ async def test_async_setup_entry_device_id_mismatch(
             "old_device_id": "dev1",
             "new_device_id": router_device_id,
         }
-        assert "fixable repair issue" in caplog.text
-        assert "rebuild entities" in caplog.text
     elif setup_succeeds:
         assert res is True
         assert not issue_kwargs

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,16 +23,19 @@ from aiopnsense.exceptions import (
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
+import awesomeversion
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er, issue_registry as ir
 from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.opnsense as init_mod
 from custom_components.opnsense.const import (
+    CARP_PLATFORMS,
     CONF_DEVICE_TRACKER_ENABLED,
     CONF_DEVICE_UNIQUE_ID,
     CONF_ENTRY_TYPE,
@@ -48,10 +51,17 @@ from custom_components.opnsense.const import (
     OPNSENSE_MIN_FIRMWARE,
     SHOULD_RELOAD,
 )
+from custom_components.opnsense.migrate import (
+    _is_firewall_sync_enabled,
+    _migrate_1_to_2,
+    _migrate_2_to_3,
+    _migrate_3_to_4,
+)
 from custom_components.opnsense.repair_reconciliation import (
     REPAIR_MARKER_KEY,
     RepairMarker,
     RepairReconciliationError,
+    parse_repair_marker,
 )
 from tests.utilities import patch_opnsense_client
 
@@ -316,7 +326,7 @@ async def test_async_setup_entry_carp_entry_uses_identity_less_runtime(
     client.get_host_firmware_version.assert_not_awaited()
 
     assert entry.runtime_data.device_unique_id is None
-    assert entry.runtime_data.loaded_platforms == init_mod.CARP_PLATFORMS
+    assert entry.runtime_data.loaded_platforms == CARP_PLATFORMS
     assert entry.runtime_data.device_tracker_coordinator is None
     assert hass.config_entries.async_forward_entry_setups.await_count == 1  # type: ignore[union-attr]
     hass.config_entries.async_forward_entry_setups.assert_awaited_with(entry, [Platform.SENSOR])  # type: ignore[union-attr]
@@ -480,7 +490,7 @@ async def test_async_setup_entry_carp_requires_usable_initial_vip_inventory(
         options={},
     )
     hass = ph_hass
-    hass.data = {init_mod.DOMAIN: {entry.entry_id: client}}
+    hass.data = {DOMAIN: {entry.entry_id: client}}
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
 
     with pytest.raises(ConfigEntryNotReady, match="usable CARP VIP"):
@@ -488,7 +498,7 @@ async def test_async_setup_entry_carp_requires_usable_initial_vip_inventory(
 
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
     hass.config_entries.async_forward_entry_setups.assert_not_awaited()
 
 
@@ -563,7 +573,7 @@ async def test_async_setup_entry_carp_first_refresh_failure_cleans_up(
         options={},
     )
     hass = ph_hass
-    hass.data = {init_mod.DOMAIN: {entry.entry_id: client}}
+    hass.data = {DOMAIN: {entry.entry_id: client}}
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
 
     with pytest.raises(RuntimeError, match="refresh failed"):
@@ -571,7 +581,7 @@ async def test_async_setup_entry_carp_first_refresh_failure_cleans_up(
 
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
     hass.config_entries.async_forward_entry_setups.assert_not_awaited()
 
 
@@ -616,7 +626,7 @@ async def test_async_setup_entry_carp_platform_forward_failure_cleans_up(
     entry.add_update_listener.assert_not_called()
     entry.async_on_unload.assert_not_called()
     remove_listener.assert_not_called()
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
     assert entry.runtime_data is None
 
 
@@ -743,7 +753,7 @@ async def test_async_setup_entry_does_not_catch_raw_validation_timeout(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -785,7 +795,7 @@ async def test_async_setup_entry_retries_on_transient_validation_failures(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -841,7 +851,7 @@ async def test_async_setup_entry_does_not_retry_non_transient_validation_failure
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -920,7 +930,7 @@ async def test_async_setup_entry_with_repair_marker_recreates_issue_on_early_pro
     ph_hass.config_entries.async_reload = MagicMock()
     ph_hass.data = {}
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     if failure_step == "validate":
         with pytest.raises(ConfigEntryNotReady, match="validation timed out"):
@@ -1119,7 +1129,7 @@ async def test_async_setup_entry_device_id_mismatch(
         """Capture the startup Device ID repair issue payload."""
         issue_kwargs.update(kwargs)
 
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
+    monkeypatch.setattr(ir, "async_create_issue", _capture_issue)
 
     res = await init_mod.async_setup_entry(hass, entry)
     if should_create_issue:
@@ -1191,9 +1201,9 @@ async def test_async_remove_config_entry_device_branches(
     # fake registry that returns one entity with matching device_id
     ent = MagicMock()
     ent.device_id = "d2"
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: object())
+    monkeypatch.setattr(er, "async_get", lambda hass: object())
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )
     res = await init_mod.async_remove_config_entry_device(hass, MagicMock(entry_id="x"), device)
     assert res is False
@@ -1211,10 +1221,8 @@ async def test_async_remove_config_entry_device_no_linked_entities(
 
     # fake entity registry returns no entities for the config entry
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     # call the removal helper with a dummy config entry
     res = await init_mod.async_remove_config_entry_device(
@@ -1255,7 +1263,7 @@ async def test_migrate_1_to_2_updates_entry(ph_hass: Any) -> None:
     # mock async_update_entry
     hass = ph_hass
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
-    res = await init_mod._migrate_1_to_2(hass, cfg)
+    res = await _migrate_1_to_2(hass, cfg)
     assert res is True
     # verify async_update_entry was called with the migrated data: tls_insecure removed
     # and verify_ssl derived as not tls_insecure, and version set to 2
@@ -1270,7 +1278,7 @@ async def test_migrate_1_to_2_updates_entry(ph_hass: Any) -> None:
     cfg2.version = 1
     # reset mock
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
-    res2 = await init_mod._migrate_1_to_2(hass, cfg2)
+    res2 = await _migrate_1_to_2(hass, cfg2)
     assert res2 is True
     expected_data2 = {CONF_VERIFY_SSL: True}
     hass.config_entries.async_update_entry.assert_called_once_with(
@@ -1331,9 +1339,9 @@ async def test_async_migrate_entry_uses_throw_errors_for_migration_client(
     client.async_close = AsyncMock()
     create_client = MagicMock(return_value=client)
     monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", create_client)
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [],
     )
@@ -1389,9 +1397,9 @@ async def test_migrate_4_to_5_removes_rule_switch_entities(
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             legacy_filter,
@@ -1459,9 +1467,9 @@ async def test_migrate_4_to_5_uses_rule_key_when_uuid_is_missing(
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             legacy_filter,
@@ -1522,9 +1530,9 @@ async def test_migrate_4_to_5_sync_disabled_skips_firewall_fetch_removes_native_
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             legacy_filter,
@@ -1592,9 +1600,9 @@ async def test_migrate_4_to_5_granular_entry_defaults_missing_category_key_to_en
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [stale_native_firewall],
     )
@@ -1659,9 +1667,9 @@ async def test_migrate_4_to_5_non_granular_entry_missing_category_key_preserves_
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             legacy_filter,
@@ -1719,7 +1727,7 @@ def test_is_firewall_sync_enabled_uses_category_then_default(
     entry = MagicMock()
     entry.data = data
 
-    assert init_mod._is_firewall_sync_enabled(entry) is expected
+    assert _is_firewall_sync_enabled(entry) is expected
 
 
 @pytest.mark.asyncio
@@ -1768,9 +1776,9 @@ async def test_migrate_4_to_5_defers_when_device_unique_id_is_missing(
     legacy_filter = _RegistryEntity("switch.filter", f"{entry_prefix}_filter_123")
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [legacy_filter],
     )
@@ -1827,9 +1835,9 @@ async def test_migrate_4_to_5_defers_when_firewall_rules_unavailable(
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [legacy_filter],
     )
@@ -1884,9 +1892,9 @@ async def test_migrate_4_to_5_skips_native_pruning_when_rules_payload_unavailabl
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [legacy_filter, stale_native_firewall, stale_native_nat],
     )
@@ -1933,9 +1941,9 @@ async def test_migrate_4_to_5_legacy_entity_remove_failure_aborts_migration(
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock(side_effect=[exc, None])
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [broken_ent, ok_ent],
     )
@@ -2020,9 +2028,9 @@ async def test_migrate_4_to_5_sync_enabled_prunes_stale_native_nat_rule_entities
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             stale_native_firewall,
@@ -2087,9 +2095,9 @@ async def test_migrate_4_to_5_version_bump_failure_aborts_migration(
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [legacy_filter],
     )
@@ -2138,7 +2146,7 @@ async def test_async_setup_calls_services_and_handles_exceptions(
     [
         (
             "device-entry",
-            {init_mod.CONF_DEVICE_UNIQUE_ID: "dev1", "sync_telemetry": False},
+            {CONF_DEVICE_UNIQUE_ID: "dev1", "sync_telemetry": False},
             "stale-device-id",
             "dev1",
         ),
@@ -2191,17 +2199,15 @@ async def test_async_update_listener_reload_and_remove(
     # monkeypatch entity registry functions
     er_reg = MagicMock()
     er_reg.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )
     # patch device registry to return no devices and provide async_remove_device
     dr_reg = MagicMock()
     dr_reg.async_remove_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
-    monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     # config option already provided via factory; no mutation needed
 
@@ -2253,18 +2259,18 @@ async def test_async_update_listener_handles_native_firewall_entities_by_sync_st
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [ent],
     )
 
     device_registry = MagicMock()
     device_registry.async_remove_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda hass: device_registry)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [],
     )
@@ -2312,18 +2318,18 @@ async def test_async_update_listener_skips_native_firewall_entities_when_firewal
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [ent],
     )
 
     device_registry = MagicMock()
     device_registry.async_remove_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda hass: device_registry)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [],
     )
@@ -2358,18 +2364,18 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [smart_entity, telemetry_entity],
     )
 
     device_registry = MagicMock()
     device_registry.async_remove_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda hass: device_registry)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [],
     )
@@ -2432,9 +2438,9 @@ async def test_async_update_listener_device_removal_param(
     dr_reg = MagicMock()
     dr_reg.async_remove_device = MagicMock()
     dr_reg.async_update_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(dr, "async_get", lambda hass: dr_reg)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [device],
     )
@@ -2442,9 +2448,9 @@ async def test_async_update_listener_device_removal_param(
     # ensure no entity registry removals interfere
     er_reg = MagicMock()
     er_reg.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [dt_ent] if dt_ent is not None else [],
     )
@@ -2492,9 +2498,9 @@ async def test_async_update_listener_detaches_no_parent_tracker_device(
         unique_id=f"{entry.unique_id}_system_uptime",
     )
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         MagicMock(return_value=[dt_ent, sensor_ent]),
     )
@@ -2503,9 +2509,9 @@ async def test_async_update_listener_detaches_no_parent_tracker_device(
     non_tracker_no_parent = MagicMock(id="nontracker-no-parent-device", via_device_id=None)
     dr_reg = MagicMock()
     dr_reg.async_update_device = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(dr, "async_get", lambda hass: dr_reg)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         MagicMock(return_value=[tracker_without_parent, non_tracker_no_parent]),
     )
@@ -2548,9 +2554,9 @@ async def test_async_update_listener_detaches_tracker_device_without_entity(
     ph_hass.data = {}
 
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         MagicMock(return_value=[]),
     )
@@ -2573,9 +2579,9 @@ async def test_async_update_listener_detaches_tracker_device_without_entity(
         config_entries={entry.entry_id},
     )
     dr_reg = MagicMock()
-    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         MagicMock(return_value=[router_device, tracker_without_entity, unrelated_device]),
     )
@@ -2606,9 +2612,9 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
     ph_hass.data = {}
 
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         MagicMock(return_value=[]),
     )
@@ -2616,7 +2622,7 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
     tracker_without_router_or_entity = MagicMock(
         id="tracker-without-router-or-entity",
         identifiers=set(),
-        connections={(init_mod.dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")},
         via_device_id="removed-router-device-id",
         config_entries={entry.entry_id},
     )
@@ -2629,9 +2635,9 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
     )
     dr_reg = MagicMock()
     dr_reg.async_get = MagicMock(return_value=None)
-    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         MagicMock(return_value=[tracker_without_router_or_entity, unrelated_device]),
     )
@@ -2670,9 +2676,9 @@ async def test_async_update_listener_preserves_existing_tracker_parent_when_pare
         device_id="shared-device",
     )
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         MagicMock(return_value=[dt_ent]),
     )
@@ -2687,9 +2693,9 @@ async def test_async_update_listener_preserves_existing_tracker_parent_when_pare
     dr_reg = MagicMock()
     dr_reg.async_update_device = MagicMock()
     dr_reg.async_get = MagicMock(return_value=shared_parent)
-    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         MagicMock(return_value=[shared_tracker]),
     )
@@ -2743,9 +2749,9 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
         unique_id=f"{entry.unique_id}_system_uptime",
     )
     er_reg = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", MagicMock(return_value=er_reg))
+    monkeypatch.setattr(er, "async_get", MagicMock(return_value=er_reg))
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         MagicMock(return_value=[dt_ent, dt_ent_non_router, sensor_ent]),
     )
@@ -2814,9 +2820,9 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
         return identifier_router_map.get(key)
 
     dr_reg.async_get_device = MagicMock(side_effect=get_device)
-    monkeypatch.setattr(init_mod.dr, "async_get", MagicMock(return_value=dr_reg))
+    monkeypatch.setattr(dr, "async_get", MagicMock(return_value=dr_reg))
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         MagicMock(
             return_value=[
@@ -2919,7 +2925,7 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
     )
     # capture calls to the issue registry to assert a warning issue is created
     create_issue_mock = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue_mock)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue_mock)
 
     entry = make_config_entry(
         data={
@@ -2947,7 +2953,7 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
         f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{OPNSENSE_LTD_FIRMWARE}"
     )
     assert call_args[0][2] == expected_issue_id
-    assert call_args[1].get("severity") == init_mod.ir.IssueSeverity.WARNING
+    assert call_args[1].get("severity") == ir.IssueSeverity.WARNING
 
 
 @pytest.mark.asyncio
@@ -2967,9 +2973,9 @@ async def test_migrate_2_to_3_missing_device_id(
     hass = MagicMock(spec=HomeAssistant)
     hass.data = {}
     # avoid touching real entity/device registry and aiohttp helpers
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: MagicMock())
-    res = await init_mod._migrate_2_to_3(hass, cfg, client)
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(dr, "async_get", lambda hass: MagicMock())
+    res = await _migrate_2_to_3(hass, cfg, client)
     assert res is False
 
 
@@ -2992,18 +2998,18 @@ async def test_migrate_2_to_3_success(monkeypatch: pytest.MonkeyPatch, fake_clie
     er_reg.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=ent.entity_id, unique_id="new")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )
 
     dr_reg = MagicMock()
     dr_reg.async_update_device = MagicMock(
         return_value=MagicMock(id=dev.id, identifiers={("opnsense", "newdev")})
     )
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: dr_reg)
+    monkeypatch.setattr(dr, "async_get", lambda hass: dr_reg)
     monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [dev]
+        dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [dev]
     )
 
     cfg = MagicMock()
@@ -3020,7 +3026,7 @@ async def test_migrate_2_to_3_success(monkeypatch: pytest.MonkeyPatch, fake_clie
     hass.data = {}
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
-    res = await init_mod._migrate_2_to_3(hass, cfg, client)
+    res = await _migrate_2_to_3(hass, cfg, client)
     assert res is True
     assert dr_reg.async_update_device.called, "device identifiers should be updated"
     assert er_reg.async_update_entity.called, "entity unique_ids should be updated"
@@ -3045,15 +3051,13 @@ async def test_migrate_2_to_3_normalizes_legacy_entity_unique_ids_with_slugify(
     er_reg.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=ent.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )
 
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(dr, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3070,7 +3074,7 @@ async def test_migrate_2_to_3_normalizes_legacy_entity_unique_ids_with_slugify(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    await init_mod._migrate_2_to_3(hass, cfg, client)
+    await _migrate_2_to_3(hass, cfg, client)
     expected_unique_id = slugify("newdev_mac_AA:BB:CC")
     er_reg.async_update_entity.assert_called_once_with(
         ent.entity_id, new_unique_id=expected_unique_id
@@ -3084,14 +3088,10 @@ async def test_migrate_2_to_3_returns_false_when_update_entry_fails(
     """_migrate_2_to_3 should fail when config entry update returns False."""
     client = fake_client(device_id="newdev")()
 
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
+    monkeypatch.setattr(dr, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3108,7 +3108,7 @@ async def test_migrate_2_to_3_returns_false_when_update_entry_fails(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=False)
 
-    res = await init_mod._migrate_2_to_3(hass, cfg, client)
+    res = await _migrate_2_to_3(hass, cfg, client)
     assert res is False
 
 
@@ -3134,13 +3134,13 @@ async def test_async_setup_entry_awesomeversion_exception(
 
         def __lt__(self, other: Any) -> None:
             """Raise a compare exception so setup falls back to the safe path."""
-            raise init_mod.awesomeversion.exceptions.AwesomeVersionCompareException
+            raise awesomeversion.exceptions.AwesomeVersionCompareException
 
     patch_opnsense_client(monkeypatch, init_mod, fake_client())
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
     )
-    monkeypatch.setattr(init_mod.awesomeversion, "AwesomeVersion", DummyAV)
+    monkeypatch.setattr(awesomeversion, "AwesomeVersion", DummyAV)
     entry = make_config_entry(
         data={
             CONF_URL: "http://1.2.3.4",
@@ -3201,9 +3201,9 @@ async def test_migrate_3_to_4_filesystem_and_remove(
         return_value=MagicMock(entity_id=e1.entity_id, unique_id="updated")
     )
     er_reg.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e1, e2]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e1, e2]
     )
 
     cfg = MagicMock()
@@ -3220,7 +3220,7 @@ async def test_migrate_3_to_4_filesystem_and_remove(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
     # avoid aiohttp connector creation
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
     assert res is True
     # Ensure the connected_client_count entity was removed (called with entity_id)
     er_reg.async_remove.assert_called_once_with(e2.entity_id)
@@ -3255,9 +3255,9 @@ async def test_migrate_3_to_4_preserves_mixed_marker_precedence(
     entity_registry.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=gateway_entity.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [gateway_entity, connected_entity, openvpn_entity],
     )
@@ -3267,7 +3267,7 @@ async def test_migrate_3_to_4_preserves_mixed_marker_precedence(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+    result = await _migrate_3_to_4(hass, config_entry, client)
 
     assert result is True
     assert entity_registry.async_update_entity.call_args_list == [
@@ -3296,9 +3296,9 @@ async def test_migrate_3_to_4_filesystem_preserves_unique_id_prefix(
         return_value=MagicMock(entity_id=e1.entity_id, unique_id="updated")
     )
     er_reg.async_remove = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [e1],
     )
@@ -3317,7 +3317,7 @@ async def test_migrate_3_to_4_filesystem_preserves_unique_id_prefix(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
     assert res is True
     er_reg.async_update_entity.assert_called_once_with(
         e1.entity_id,
@@ -3357,9 +3357,9 @@ async def test_migrate_3_to_4_filesystem_skips_and_non_root_mountpoint(
     er_reg.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=matched.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [
             matched,
@@ -3383,7 +3383,7 @@ async def test_migrate_3_to_4_filesystem_skips_and_non_root_mountpoint(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
 
     assert res is True
     er_reg.async_update_entity.assert_called_once_with(
@@ -3417,9 +3417,9 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
     entity_registry.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=interface_entity.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [interface_entity, filesystem_entity],
     )
@@ -3432,7 +3432,7 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    result = await init_mod._migrate_3_to_4(hass, config_entry, cast("OPNsenseClient", client))
+    result = await _migrate_3_to_4(hass, config_entry, cast("OPNsenseClient", client))
 
     assert result is False
     entity_registry.async_update_entity.assert_called_once_with(
@@ -3474,9 +3474,9 @@ async def test_migrate_3_to_4_defers_filesystems_when_payload_is_invalid(
     entity_registry.async_update_entity = MagicMock(
         return_value=MagicMock(entity_id=filesystem_entity.entity_id, unique_id="updated")
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: [filesystem_entity],
     )
@@ -3489,7 +3489,7 @@ async def test_migrate_3_to_4_defers_filesystems_when_payload_is_invalid(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+    result = await _migrate_3_to_4(hass, config_entry, client)
 
     assert result is False
     entity_registry.async_update_entity.assert_not_called()
@@ -3502,10 +3502,8 @@ async def test_migrate_3_to_4_returns_false_when_update_entry_fails(
 ) -> None:
     """_migrate_3_to_4 should fail when config entry update returns False."""
     client = fake_client(telemetry={})()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3521,7 +3519,7 @@ async def test_migrate_3_to_4_returns_false_when_update_entry_fails(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=False)
 
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
 
     assert res is False
 
@@ -3540,16 +3538,14 @@ async def test_migrate_2_to_3_handles_entity_update_value_error(
 
     er_reg = MagicMock()
     er_reg.async_update_entity = MagicMock(side_effect=ValueError("bad entity"))
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
     monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
+        er, "async_entries_for_config_entry", lambda registry, config_entry_id: [ent]
     )
 
     # no devices to update
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(dr, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3566,7 +3562,7 @@ async def test_migrate_2_to_3_handles_entity_update_value_error(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_2_to_3(hass, cfg, client)
+    res = await _migrate_2_to_3(hass, cfg, client)
     assert res is True
     # ensure we attempted to update the entity (which raised) and migration completed
     er_reg.async_update_entity.assert_called_once_with(ent.entity_id, new_unique_id=ANY)
@@ -3587,10 +3583,8 @@ async def test_migrate_3_to_4_handles_remove_exceptions(
 
     er_reg = MagicMock()
     er_reg.async_remove = MagicMock(side_effect=exc)
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e]
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3606,7 +3600,7 @@ async def test_migrate_3_to_4_handles_remove_exceptions(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
     assert res is False
     er_reg.async_remove.assert_called_once_with(e.entity_id)
     hass.config_entries.async_update_entry.assert_not_called()
@@ -3625,10 +3619,8 @@ async def test_migrate_3_to_4_handles_update_value_error(
 
     er_reg = MagicMock()
     er_reg.async_update_entity = MagicMock(side_effect=ValueError("bad update"))
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: er_reg)
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e]
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: er_reg)
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [e])
 
     cfg = MagicMock()
     cfg.data = {
@@ -3644,7 +3636,7 @@ async def test_migrate_3_to_4_handles_update_value_error(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_3_to_4(hass, cfg, client)
+    res = await _migrate_3_to_4(hass, cfg, client)
     assert res is False
     er_reg.async_update_entity.assert_called_once()
     hass.config_entries.async_update_entry.assert_not_called()
@@ -3818,7 +3810,7 @@ async def test_async_setup_entry_firmware_above_ltd_calls_delete(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
     )
     called = []
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", lambda *a, **k: called.append(True))
+    monkeypatch.setattr(ir, "async_delete_issue", lambda *a, **k: called.append(True))
 
     entry = make_config_entry(
         data={
@@ -3855,7 +3847,7 @@ async def test_async_setup_entry_firmware_at_or_above_ltd_deletes_previous_issue
 
     # capture delete_issue calls
     delete_issue_mock = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue_mock)
+    monkeypatch.setattr(ir, "async_delete_issue", delete_issue_mock)
 
     entry = make_config_entry(
         data={
@@ -3901,7 +3893,7 @@ async def test_async_setup_entry_delete_uses_actual_firmware_string(
     )
 
     calls = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", calls)
+    monkeypatch.setattr(ir, "async_delete_issue", calls)
 
     entry = make_config_entry(
         data={
@@ -3946,7 +3938,7 @@ async def test_async_setup_entry_delete_not_called_for_between_min_and_ltd(
     )
 
     delete_issue_mock = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue_mock)
+    monkeypatch.setattr(ir, "async_delete_issue", delete_issue_mock)
 
     entry = make_config_entry(
         data={
@@ -4048,7 +4040,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_main_refresh_fails(
     hass.config_entries.async_reload = MagicMock()
     hass.data = {}
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     with pytest.raises(ConfigEntryNotReady, match="main refresh failed"):
         await init_mod.async_setup_entry(hass, entry)
@@ -4176,7 +4168,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_device_tracker_refr
     hass.config_entries.async_reload = MagicMock()
     hass.data = {}
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     with pytest.raises(RuntimeError, match="device tracker refresh failed"):
         await init_mod.async_setup_entry(hass, entry)
@@ -4288,7 +4280,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
     ph_hass.config_entries.async_reload = MagicMock()
     ph_hass.data = {}
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     with pytest.raises(RuntimeError, match="platform forwarding failed"):
         await init_mod.async_setup_entry(ph_hass, entry)
@@ -4353,7 +4345,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
     ph_hass.config_entries.async_reload = MagicMock()
     ph_hass.data = {}
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     with pytest.raises(RuntimeError, match="platform forwarding failed"):
         await init_mod.async_setup_entry(ph_hass, entry)
@@ -4567,7 +4559,7 @@ async def test_cleanup_reconciliation_failure_returns_platform_unload_result(
     repair_marker.new_device_id = "new-dev"
     issue_create = MagicMock()
     issue_create.side_effect = lambda *args, **kwargs: events.append("create_issue")
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", issue_create)
+    monkeypatch.setattr(ir, "async_create_issue", issue_create)
 
     async def _unload_platforms(*args: Any, **kwargs: Any) -> bool:
         del args, kwargs
@@ -4703,7 +4695,7 @@ async def test_async_setup_entry_deletes_stale_device_id_mismatch_issue(
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     ph_hass.config_entries.async_reload = AsyncMock()
     delete_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(ir, "async_delete_issue", delete_issue)
     ph_hass.data = {}
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
@@ -4745,7 +4737,7 @@ async def test_async_setup_entry_preserves_marker_and_skips_stale_issue_delete(
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     ph_hass.config_entries.async_reload = AsyncMock()
     delete_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(ir, "async_delete_issue", delete_issue)
     ph_hass.data = {}
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
@@ -4805,7 +4797,7 @@ async def test_async_setup_entry_deletes_stale_mismatch_issue_only_on_matching_v
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     ph_hass.config_entries.async_reload = AsyncMock()
     delete_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    monkeypatch.setattr(ir, "async_delete_issue", delete_issue)
     ph_hass.data = {}
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
@@ -4845,7 +4837,7 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.marker = init_mod.parse_repair_marker(entry)
+    reconciliation.marker = parse_repair_marker(entry)
     reconciliation.prepare.side_effect = RepairReconciliationError("prepare failed")
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
@@ -4853,7 +4845,7 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
     ph_hass.data = {}
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
@@ -4921,7 +4913,7 @@ async def test_async_setup_entry_recreates_marker_issue_on_probe_mismatch_before
     ph_hass.config_entries.async_unload_platforms = AsyncMock()
     ph_hass.config_entries.async_reload = MagicMock()
     create_issue = MagicMock()
-    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    monkeypatch.setattr(ir, "async_create_issue", create_issue)
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
 
@@ -5217,16 +5209,14 @@ async def test_migrate_2_to_3_handles_identifier_collision(
         def async_update_device(self, *a, **k) -> Never:
             # DeviceIdentifierCollisionError requires an existing_device argument
             """Raise the collision error expected by the registry migration test."""
-            raise init_mod.dr.DeviceIdentifierCollisionError(dev.identifiers, MagicMock(id="other"))
+            raise dr.DeviceIdentifierCollisionError(dev.identifiers, MagicMock(id="other"))
 
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: DeviceRegistry())
+    monkeypatch.setattr(dr, "async_get", lambda hass: DeviceRegistry())
     monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [dev]
+        dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [dev]
     )
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
     cfg = MagicMock()
     cfg.data = {
         CONF_URL: "http://1.2.3.4",
@@ -5242,7 +5232,7 @@ async def test_migrate_2_to_3_handles_identifier_collision(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    res = await init_mod._migrate_2_to_3(hass, cfg, client)
+    res = await _migrate_2_to_3(hass, cfg, client)
     assert res is True
 
 
@@ -5284,14 +5274,14 @@ async def test_migrate_3_to_4_defers_without_updating_entities_when_later_filesy
         second_filesystem_entity,
     ]
     entity_registry.async_update_entity = MagicMock()
-    monkeypatch.setattr(init_mod.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda _hass: entity_registry)
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         entity_registry.async_entries_for_config_entry,
     )
 
-    res = await init_mod._migrate_3_to_4(hass, migration_entry, client)
+    res = await _migrate_3_to_4(hass, migration_entry, client)
 
     assert res is False
     entity_registry.async_update_entity.assert_not_called()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,13 +13,16 @@ from unittest.mock import ANY, AsyncMock, MagicMock, call
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
+    OPNsenseError,
     OPNsenseInvalidAuth,
     OPNsenseInvalidURL,
+    OPNsenseMissingDeviceUniqueID,
     OPNsensePrivilegeMissing,
     OPNsenseSSLError,
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
@@ -27,17 +30,29 @@ from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-import custom_components.opnsense as opnsense_mod
+import custom_components.opnsense as init_mod
 from custom_components.opnsense.const import (
+    CONF_DEVICE_TRACKER_ENABLED,
+    CONF_DEVICE_UNIQUE_ID,
     CONF_ENTRY_TYPE,
     CONF_GRANULAR_SYNC_OPTIONS,
     CONF_SYNC_FIREWALL_AND_NAT,
     CONF_TLS_INSECURE,
+    DOMAIN,
     ENTRY_TYPE_CARP,
+    GRANULAR_SYNC_PREFIX,
+    LOADED_PLATFORMS,
+    OPNSENSE_CLIENT,
+    OPNSENSE_LTD_FIRMWARE,
+    OPNSENSE_MIN_FIRMWARE,
+    SHOULD_RELOAD,
+)
+from custom_components.opnsense.repair_reconciliation import (
+    REPAIR_MARKER_KEY,
+    RepairMarker,
+    RepairReconciliationError,
 )
 from tests.utilities import patch_opnsense_client
-
-init_mod: Any = opnsense_mod
 
 
 @dataclass(slots=True)
@@ -143,7 +158,7 @@ async def test_async_setup_entry_success(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -158,7 +173,7 @@ async def test_async_setup_entry_success(
 
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is True
-    assert init_mod.DOMAIN in hass.data and entry.entry_id in hass.data[init_mod.DOMAIN]
+    assert DOMAIN in hass.data and entry.entry_id in hass.data[DOMAIN]
 
 
 @pytest.mark.asyncio
@@ -203,7 +218,7 @@ async def test_async_setup_entry_validates_client_before_probes(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -661,13 +676,20 @@ async def test_async_setup_entry_carp_registers_update_listener_after_forwarding
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(OPNsenseError("boom"), id="generic"),
+        pytest.param(OPNsenseTimeoutError("timed out"), id="timeout"),
+    ],
+)
 async def test_async_setup_entry_closes_client_when_validation_fails(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    error: OPNsenseError,
 ) -> None:
     """async_setup_entry should close a constructed client when validation fails."""
-    error = init_mod.OPNsenseError("boom")
     client = MagicMock()
     client.validate = AsyncMock(side_effect=error)
     client.async_close = AsyncMock(return_value=True)
@@ -683,7 +705,7 @@ async def test_async_setup_entry_closes_client_when_validation_fails(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -847,7 +869,7 @@ async def test_async_setup_entry_reraises_client_creation_error(
 
     def _create_client(**kwargs: Any) -> Any:
         """Raise a backend error before a client instance exists."""
-        raise init_mod.OPNsenseError("boom")
+        raise OPNsenseError("boom")
 
     monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
     entry = make_config_entry(
@@ -855,7 +877,7 @@ async def test_async_setup_entry_reraises_client_creation_error(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -865,7 +887,7 @@ async def test_async_setup_entry_reraises_client_creation_error(
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
 
-    with pytest.raises(init_mod.OPNsenseError):
+    with pytest.raises(OPNsenseError):
         await init_mod.async_setup_entry(hass, entry)
 
 
@@ -881,7 +903,7 @@ async def test_async_setup_entry_continues_after_firmware_validation_error(
     probe_calls: list[str] = []
     client = MagicMock()
     client.name = "test-router"
-    client.validate = AsyncMock(side_effect=init_mod.OPNsenseBelowMinFirmware("boom"))
+    client.validate = AsyncMock(side_effect=OPNsenseBelowMinFirmware("boom"))
     client.async_close = AsyncMock(return_value=True)
 
     async def _get_device_unique_id(expected_id: str | None = None) -> str:
@@ -911,7 +933,7 @@ async def test_async_setup_entry_continues_after_firmware_validation_error(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -943,7 +965,7 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
     client = MagicMock()
     client.name = "test-router"
     client.validate = AsyncMock(
-        side_effect=init_mod.OPNsenseMissingDeviceUniqueID("unable to determine Device ID")
+        side_effect=OPNsenseMissingDeviceUniqueID("unable to determine Device ID")
     )
     client.async_close = AsyncMock(return_value=True)
 
@@ -974,7 +996,7 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
         options={},
     )
@@ -1034,7 +1056,7 @@ async def test_async_setup_entry_device_id_mismatch(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: stored_device_id,
+            CONF_DEVICE_UNIQUE_ID: stored_device_id,
         },
         options={},
     )
@@ -1091,7 +1113,7 @@ async def test_async_update_listener_not_reload(
     """_async_update_listener should set SHOULD_RELOAD True and not call reload when flag False."""
     entry = make_config_entry(entry_id="e", unique_id="u")
     # ensure runtime_data exists and set SHOULD_RELOAD to False
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, False)
+    setattr(entry.runtime_data, SHOULD_RELOAD, False)
 
     # hass with config_entries.async_reload not called
     hass = MagicMock(spec=HomeAssistant)
@@ -1100,7 +1122,7 @@ async def test_async_update_listener_not_reload(
 
     # should set SHOULD_RELOAD back to True and not call reload
     await init_mod._async_update_listener(hass, entry)
-    assert getattr(entry.runtime_data, init_mod.SHOULD_RELOAD) is True
+    assert getattr(entry.runtime_data, SHOULD_RELOAD) is True
     hass.config_entries.async_reload.assert_not_called()
 
 
@@ -1112,7 +1134,7 @@ async def test_async_remove_config_entry_device_branches(
     device = MagicMock()
     device.via_device_id = True
     device.id = "d1"
-    res = await init_mod.async_remove_config_entry_device(hass, None, device)
+    res = await init_mod.async_remove_config_entry_device(hass, MagicMock(spec=ConfigEntry), device)
     assert res is False
 
     # device_entry with linked entity -> False
@@ -1149,7 +1171,9 @@ async def test_async_remove_config_entry_device_no_linked_entities(
     )
 
     # call the removal helper with a dummy config entry
-    res = await init_mod.async_remove_config_entry_device(None, MagicMock(entry_id="x"), device)
+    res = await init_mod.async_remove_config_entry_device(
+        MagicMock(spec=HomeAssistant), MagicMock(entry_id="x"), device
+    )
     assert res is True
 
 
@@ -1161,17 +1185,17 @@ async def test_async_unload_entry_and_pop(
     entry = make_config_entry(entry_id="e_unload")
     entry.as_dict = lambda: {"id": "x"}
     # use the constant names used by the integration
-    setattr(entry.runtime_data, init_mod.LOADED_PLATFORMS, ["p1"])
+    setattr(entry.runtime_data, LOADED_PLATFORMS, ["p1"])
     fake_client = MagicMock()
     fake_client.async_close = AsyncMock()
-    setattr(entry.runtime_data, init_mod.OPNSENSE_CLIENT, fake_client)
+    setattr(entry.runtime_data, OPNSENSE_CLIENT, fake_client)
 
     hass = ph_hass
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
-    hass.data = {init_mod.DOMAIN: {entry.entry_id: fake_client}}
+    hass.data = {DOMAIN: {entry.entry_id: fake_client}}
     res = await init_mod.async_unload_entry(hass, entry)
     assert res is True
-    assert entry.entry_id not in hass.data[init_mod.DOMAIN]
+    assert entry.entry_id not in hass.data[DOMAIN]
     fake_client.async_close.assert_awaited_once()
 
 
@@ -1244,9 +1268,9 @@ async def test_async_migrate_entry_uses_throw_errors_for_migration_client(
     """Migration should create the OPNsense client with throw_errors enabled."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_DEVICE_UNIQUE_ID: "device-id",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1285,9 +1309,9 @@ async def test_migrate_4_to_5_removes_rule_switch_entities(
     slugified_prefix: str = slugify("router unit")
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "router unit",
+            CONF_DEVICE_UNIQUE_ID: "router unit",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1362,9 +1386,9 @@ async def test_migrate_4_to_5_uses_rule_key_when_uuid_is_missing(
     """_migrate_4_to_5 should keep non-uuid rules by mapping key."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "deviceid",
+            CONF_DEVICE_UNIQUE_ID: "deviceid",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1423,14 +1447,14 @@ async def test_migrate_4_to_5_sync_disabled_skips_firewall_fetch_removes_native_
     """_migrate_4_to_5 should remove native firewall and NAT rules when sync is disabled."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     data: dict[str, Any] = {
-        init_mod.CONF_DEVICE_UNIQUE_ID: "deviceid",
+        CONF_DEVICE_UNIQUE_ID: "deviceid",
         CONF_URL: "http://1.2.3.4",
         CONF_USERNAME: "u",
         CONF_PASSWORD: "p",
     }
     data[CONF_SYNC_FIREWALL_AND_NAT] = False
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data=data,
         version=4,
     )
@@ -1496,9 +1520,9 @@ async def test_migrate_4_to_5_granular_entry_defaults_missing_category_key_to_en
     update_entry = MagicMock(return_value=True)
     monkeypatch.setattr(ph_hass.config_entries, "async_update_entry", update_entry)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "deviceid",
+            CONF_DEVICE_UNIQUE_ID: "deviceid",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1547,9 +1571,9 @@ async def test_migrate_4_to_5_non_granular_entry_missing_category_key_preserves_
     update_entry = MagicMock(return_value=True)
     monkeypatch.setattr(ph_hass.config_entries, "async_update_entry", update_entry)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "deviceid",
+            CONF_DEVICE_UNIQUE_ID: "deviceid",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1681,10 +1705,10 @@ async def test_migrate_4_to_5_defers_when_device_unique_id_is_missing(
     if not sync_firewall_and_nat:
         entry_data[CONF_SYNC_FIREWALL_AND_NAT] = False
     if device_unique_id is not None:
-        entry_data[init_mod.CONF_DEVICE_UNIQUE_ID] = device_unique_id
+        entry_data[CONF_DEVICE_UNIQUE_ID] = device_unique_id
     entry_prefix = slugify("device-id")
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data=entry_data,
         version=4,
     )
@@ -1723,7 +1747,7 @@ async def test_migrate_4_to_5_defers_when_device_unique_id_is_missing(
 @pytest.mark.parametrize(
     "firewall_result",
     [
-        pytest.param(init_mod.OPNsenseError("unavailable"), id="fetch-error"),
+        pytest.param(OPNsenseError("unavailable"), id="fetch-error"),
     ],
 )
 async def test_migrate_4_to_5_defers_when_firewall_rules_unavailable(
@@ -1732,9 +1756,9 @@ async def test_migrate_4_to_5_defers_when_firewall_rules_unavailable(
     """_migrate_4_to_5 should not version-bump when firewall rules cannot be fetched."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_DEVICE_UNIQUE_ID: "device-id",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1743,7 +1767,7 @@ async def test_migrate_4_to_5_defers_when_firewall_rules_unavailable(
     )
     entry.add_to_hass(ph_hass)
     client = MagicMock()
-    if isinstance(firewall_result, init_mod.OPNsenseError):
+    if isinstance(firewall_result, OPNsenseError):
         client.get_firewall = AsyncMock(side_effect=firewall_result)
     else:
         client.get_firewall = AsyncMock(return_value=firewall_result)
@@ -1786,9 +1810,9 @@ async def test_migrate_4_to_5_skips_native_pruning_when_rules_payload_unavailabl
     update_entry = MagicMock(return_value=True)
     monkeypatch.setattr(ph_hass.config_entries, "async_update_entry", update_entry)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_DEVICE_UNIQUE_ID: "device-id",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1840,9 +1864,9 @@ async def test_migrate_4_to_5_legacy_entity_remove_failure_aborts_migration(
     """_migrate_4_to_5 returns False when entity removal raises handled exceptions."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_DEVICE_UNIQUE_ID: "device-id",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1885,9 +1909,9 @@ async def test_migrate_4_to_5_sync_enabled_prunes_stale_native_nat_rule_entities
     update_entry = MagicMock(return_value=True)
     monkeypatch.setattr(ph_hass.config_entries, "async_update_entry", update_entry)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "deviceid",
+            CONF_DEVICE_UNIQUE_ID: "deviceid",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -1996,9 +2020,9 @@ async def test_migrate_4_to_5_version_bump_failure_aborts_migration(
     """_migrate_4_to_5 returns False when async_update_entry fails."""
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=False)
     entry = MockConfigEntry(
-        domain=init_mod.DOMAIN,
+        domain=DOMAIN,
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_DEVICE_UNIQUE_ID: "device-id",
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
@@ -2096,7 +2120,7 @@ async def test_async_update_listener_reload_and_remove(
         data=entry_data,
         unique_id=entry_unique_id,
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
     # config entries and hass async reload stub
     # use migration fixture which provides config_entries and async helpers
     hass = ph_hass
@@ -2111,10 +2135,10 @@ async def test_async_update_listener_reload_and_remove(
             """Store the entity and unique IDs used by the update-listener test."""
             self.entity_id = entity_id
             self.unique_id = unique_id
-            self.domain = init_mod.Platform.SENSOR
+            self.domain = Platform.SENSOR
 
     # explicitly use the 'sync_telemetry' prefix so the test targets the intended sync item
-    prefix = list(init_mod.GRANULAR_SYNC_PREFIX["sync_telemetry"])
+    prefix = list(GRANULAR_SYNC_PREFIX["sync_telemetry"])
     pre = prefix[0]
     ent = Ent("sensor.x", f"{entity_unique_id_prefix}_{pre}_suffix")
 
@@ -2157,12 +2181,12 @@ async def test_async_update_listener_handles_native_firewall_entities_by_sync_st
     """Remove native firewall entities only when Firewall/NAT sync is disabled."""
     entry = make_config_entry(
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
             CONF_SYNC_FIREWALL_AND_NAT: sync_enabled,
         },
         unique_id="unit two",
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     hass = ph_hass
     hass.config_entries.async_reload = AsyncMock()
@@ -2178,7 +2202,7 @@ async def test_async_update_listener_handles_native_firewall_entities_by_sync_st
 
     ent = Ent(
         "switch.native_firewall",
-        f"{slugify(entry.data[init_mod.CONF_DEVICE_UNIQUE_ID])}_firewall_rule_rule1",
+        f"{slugify(entry.data[CONF_DEVICE_UNIQUE_ID])}_firewall_rule_rule1",
     )
 
     entity_registry = MagicMock()
@@ -2216,12 +2240,12 @@ async def test_async_update_listener_skips_native_firewall_entities_when_firewal
     """Native entities should remain when sync is enabled for this entry."""
     entry = make_config_entry(
         data={
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
             CONF_SYNC_FIREWALL_AND_NAT: True,
         },
         unique_id="unit two",
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     hass = ph_hass
     hass.config_entries.async_reload = AsyncMock()
@@ -2237,7 +2261,7 @@ async def test_async_update_listener_skips_native_firewall_entities_when_firewal
 
     ent = Ent(
         "switch.native_firewall",
-        f"{slugify(entry.data[init_mod.CONF_DEVICE_UNIQUE_ID])}_firewall_rule_rule1",
+        f"{slugify(entry.data[CONF_DEVICE_UNIQUE_ID])}_firewall_rule_rule1",
     )
 
     entity_registry = MagicMock()
@@ -2271,20 +2295,20 @@ async def test_async_update_listener_uses_shared_default_for_smart_entity_prunin
 ) -> None:
     """Missing SMART sync config should preserve registered SMART entities."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "dev1"},
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
         unique_id="u123",
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
     hass = ph_hass
     hass.config_entries.async_reload = AsyncMock()
     hass.data = {}
 
     smart_entity = MagicMock()
     smart_entity.entity_id = "binary_sensor.opnsense_smart_nvme0_status"
-    smart_entity.unique_id = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_smart_nvme0_status"
+    smart_entity.unique_id = f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_smart_nvme0_status"
     telemetry_entity = MagicMock()
     telemetry_entity.entity_id = "sensor.opnsense_cpu"
-    telemetry_entity.unique_id = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_telemetry_cpu"
+    telemetry_entity.unique_id = f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_telemetry_cpu"
 
     entity_registry = MagicMock()
     entity_registry.async_remove = MagicMock()
@@ -2331,10 +2355,10 @@ async def test_async_update_listener_device_removal_param(
     """Remove only this config entry from tracked devices when tracking is disabled."""
     # create an entry with the device tracker option set per parameter
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "dev1"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: dt_enabled},
+        data={CONF_DEVICE_UNIQUE_ID: "dev1"},
+        options={CONF_DEVICE_TRACKER_ENABLED: dt_enabled},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     hass = ph_hass
     hass.config_entries.async_reload = AsyncMock()
@@ -2348,7 +2372,7 @@ async def test_async_update_listener_device_removal_param(
     if tracker_device_id is not None:
         dt_ent = MagicMock(
             entity_id=f"device_tracker.{tracker_device_id}",
-            domain=init_mod.Platform.DEVICE_TRACKER,
+            domain=Platform.DEVICE_TRACKER,
             unique_id=f"{entry.unique_id}_{tracker_device_id}",
             device_id=tracker_device_id,
         )
@@ -2400,10 +2424,10 @@ async def test_async_update_listener_detaches_no_parent_tracker_device(
 ) -> None:
     """Trackers with no parent remain detached from removed config entry."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        data={CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.data = {}
@@ -2412,13 +2436,13 @@ async def test_async_update_listener_detaches_no_parent_tracker_device(
 
     dt_ent = MagicMock(
         entity_id="device_tracker.tracked_device",
-        domain=init_mod.Platform.DEVICE_TRACKER,
+        domain=Platform.DEVICE_TRACKER,
         unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
         device_id="tracker-device-no-parent",
     )
     sensor_ent = MagicMock(
         entity_id="sensor.system_uptime",
-        domain=init_mod.Platform.SENSOR,
+        domain=Platform.SENSOR,
         unique_id=f"{entry.unique_id}_system_uptime",
     )
     er_reg = MagicMock()
@@ -2469,10 +2493,10 @@ async def test_async_update_listener_detaches_tracker_device_without_entity(
 ) -> None:
     """Detach a router-linked tracker device after its entity was already removed."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        data={CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.data = {}
@@ -2487,7 +2511,7 @@ async def test_async_update_listener_detaches_tracker_device_without_entity(
 
     router_device = MagicMock(
         id="router-device-id",
-        identifiers={(init_mod.DOMAIN, "router-mac")},
+        identifiers={(DOMAIN, "router-mac")},
         via_device_id=None,
     )
     tracker_without_entity = MagicMock(
@@ -2527,10 +2551,10 @@ async def test_async_update_listener_detaches_tracker_when_router_and_entity_are
 ) -> None:
     """Detach a MAC tracker whose removed router remains as a stale parent."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        data={CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.data = {}
@@ -2583,10 +2607,10 @@ async def test_async_update_listener_preserves_existing_tracker_parent_when_pare
 ) -> None:
     """Keep a shared tracker parent when disabling tracking if that parent still exists."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        data={CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.data = {}
@@ -2595,7 +2619,7 @@ async def test_async_update_listener_preserves_existing_tracker_parent_when_pare
 
     dt_ent = MagicMock(
         entity_id="device_tracker.shared_tracker",
-        domain=init_mod.Platform.DEVICE_TRACKER,
+        domain=Platform.DEVICE_TRACKER,
         unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
         device_id="shared-device",
     )
@@ -2645,10 +2669,10 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
 ) -> None:
     """Disabling tracking reassigns shared tracker parent to surviving OPNsense router."""
     entry = make_config_entry(
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "router-mac"},
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        data={CONF_DEVICE_UNIQUE_ID: "router-mac"},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
 
     ph_hass.config_entries.async_reload = AsyncMock()
     ph_hass.data = {}
@@ -2657,19 +2681,19 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
 
     dt_ent = MagicMock(
         entity_id="device_tracker.living_room_device",
-        domain=init_mod.Platform.DEVICE_TRACKER,
+        domain=Platform.DEVICE_TRACKER,
         unique_id=f"{entry.unique_id}_mac_aabbccddeeff",
         device_id="shared-device",
     )
     dt_ent_non_router = MagicMock(
         entity_id="device_tracker.kitchen_device",
-        domain=init_mod.Platform.DEVICE_TRACKER,
+        domain=Platform.DEVICE_TRACKER,
         unique_id=f"{entry.unique_id}_mac_cdddeeff0011",
         device_id="nonopnsense-device",
     )
     sensor_ent = MagicMock(
         entity_id="sensor.system_uptime",
-        domain=init_mod.Platform.SENSOR,
+        domain=Platform.SENSOR,
         unique_id=f"{entry.unique_id}_system_uptime",
     )
     er_reg = MagicMock()
@@ -2682,23 +2706,23 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
 
     router_device = MagicMock(
         id="router-device-id",
-        identifiers={(init_mod.DOMAIN, "router-mac")},
+        identifiers={(DOMAIN, "router-mac")},
         via_device_id=None,
     )
     surviving_opnsense_a = MagicMock(
         entry_id="survive-entry-b",
-        domain=init_mod.DOMAIN,
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "survive-b"},
+        domain=DOMAIN,
+        data={CONF_DEVICE_UNIQUE_ID: "survive-b"},
     )
     surviving_opnsense_b = MagicMock(
         entry_id="survive-entry-a",
-        domain=init_mod.DOMAIN,
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "survive-a"},
+        domain=DOMAIN,
+        data={CONF_DEVICE_UNIQUE_ID: "survive-a"},
     )
     non_opnsense_entry = MagicMock(
         entry_id="non-opnsense-entry",
         domain="other",
-        data={init_mod.CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
+        data={CONF_DEVICE_UNIQUE_ID: "non-opnsense"},
     )
     shared_router_b = MagicMock(id="survivor-b-router")
     shared_router_a = MagicMock(id="survivor-a-router")
@@ -2727,9 +2751,9 @@ async def test_async_update_listener_reparents_tracker_link_to_remaining_opnsens
     }
     ph_hass.config_entries.async_get_entry = MagicMock(side_effect=async_get_entry_map.get)
     identifier_router_map = {
-        (init_mod.DOMAIN, "router-mac"): router_device,
-        (init_mod.DOMAIN, "survive-b"): shared_router_b,
-        (init_mod.DOMAIN, "survive-a"): shared_router_a,
+        (DOMAIN, "router-mac"): router_device,
+        (DOMAIN, "survive-b"): shared_router_b,
+        (DOMAIN, "survive-a"): shared_router_a,
     }
     dr_reg = MagicMock()
 
@@ -2820,7 +2844,7 @@ async def test_async_setup_entry_firmware_below_min(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     # use hass fixture for aiohttp helpers
@@ -2856,7 +2880,7 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -2872,8 +2896,10 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
     )
     call_args = create_issue_mock.call_args
     # args: (hass, domain, issue_id, ...)
-    assert call_args[0][1] == init_mod.DOMAIN
-    expected_issue_id = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{init_mod.OPNSENSE_LTD_FIRMWARE}"
+    assert call_args[0][1] == DOMAIN
+    expected_issue_id = (
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{OPNSENSE_LTD_FIRMWARE}"
+    )
     assert call_args[0][2] == expected_issue_id
     assert call_args[1].get("severity") == init_mod.ir.IssueSeverity.WARNING
 
@@ -2956,7 +2982,7 @@ async def test_migrate_2_to_3_success(monkeypatch: pytest.MonkeyPatch, fake_clie
     kwargs = hass.config_entries.async_update_entry.call_args.kwargs
     assert kwargs["version"] == 3
     assert kwargs["unique_id"] == "newdev"
-    assert kwargs["data"][init_mod.CONF_DEVICE_UNIQUE_ID] == "newdev"
+    assert kwargs["data"][CONF_DEVICE_UNIQUE_ID] == "newdev"
 
 
 @pytest.mark.asyncio
@@ -3074,7 +3100,7 @@ async def test_async_setup_entry_awesomeversion_exception(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -3092,19 +3118,19 @@ async def test_async_unload_entry_unload_fails(
     """async_unload_entry returns False and keeps runtime resources when unload fails."""
     entry = make_config_entry(entry_id="e_unload_fail")
     entry.as_dict = lambda: {"id": "x"}
-    setattr(entry.runtime_data, init_mod.LOADED_PLATFORMS, ["p1"])
+    setattr(entry.runtime_data, LOADED_PLATFORMS, ["p1"])
     fake_client = MagicMock()
     fake_client.async_close = AsyncMock()
-    setattr(entry.runtime_data, init_mod.OPNSENSE_CLIENT, fake_client)
+    setattr(entry.runtime_data, OPNSENSE_CLIENT, fake_client)
 
     hass = ph_hass
     # unload_platforms returns False
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
-    hass.data = {init_mod.DOMAIN: {entry.entry_id: fake_client}}
+    hass.data = {DOMAIN: {entry.entry_id: fake_client}}
     res = await init_mod.async_unload_entry(hass, entry)
     assert res is False
     # hass.data should still have the entry
-    assert entry.entry_id in hass.data[init_mod.DOMAIN]
+    assert entry.entry_id in hass.data[DOMAIN]
     fake_client.async_close.assert_not_awaited()
 
 
@@ -3619,9 +3645,7 @@ async def test_async_migrate_entry_returns_false_when_submigration_fails(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "exc", [OPNsenseTimeoutError, OPNsenseConnectionError, init_mod.OPNsenseError]
-)
+@pytest.mark.parametrize("exc", [OPNsenseTimeoutError, OPNsenseConnectionError, OPNsenseError])
 async def test_async_migrate_entry_defers_when_migration_client_raises_opnsense_error(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any, exc: type[BaseException]
 ) -> None:
@@ -3648,9 +3672,7 @@ async def test_async_migrate_entry_defers_when_migration_client_raises_opnsense_
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "exc", [OPNsenseTimeoutError, OPNsenseConnectionError, init_mod.OPNsenseError]
-)
+@pytest.mark.parametrize("exc", [OPNsenseTimeoutError, OPNsenseConnectionError, OPNsenseError])
 async def test_async_migrate_entry_defers_when_v2_to_3_fails_with_opnsense_error(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any, exc: type[BaseException]
 ) -> None:
@@ -3680,9 +3702,7 @@ async def test_async_migrate_entry_defers_when_v2_to_3_fails_with_opnsense_error
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "exc", [OPNsenseTimeoutError, OPNsenseConnectionError, init_mod.OPNsenseError]
-)
+@pytest.mark.parametrize("exc", [OPNsenseTimeoutError, OPNsenseConnectionError, OPNsenseError])
 async def test_async_migrate_entry_defers_when_v3_to_4_fails_with_opnsense_error(
     monkeypatch: pytest.MonkeyPatch, ph_hass: Any, exc: type[BaseException]
 ) -> None:
@@ -3746,7 +3766,7 @@ async def test_async_setup_entry_firmware_above_ltd_calls_delete(
 ) -> None:
     """async_setup_entry deletes previous issues when firmware is at or above LTD."""
     patch_opnsense_client(
-        monkeypatch, init_mod, fake_client(firmware_version=init_mod.OPNSENSE_LTD_FIRMWARE)
+        monkeypatch, init_mod, fake_client(firmware_version=OPNSENSE_LTD_FIRMWARE)
     )
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -3759,7 +3779,7 @@ async def test_async_setup_entry_firmware_above_ltd_calls_delete(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -3781,7 +3801,7 @@ async def test_async_setup_entry_firmware_at_or_above_ltd_deletes_previous_issue
 ) -> None:
     """async_setup_entry cleans up previous firmware-related issues for LTD and min thresholds."""
     patch_opnsense_client(
-        monkeypatch, init_mod, fake_client(firmware_version=init_mod.OPNSENSE_LTD_FIRMWARE)
+        monkeypatch, init_mod, fake_client(firmware_version=OPNSENSE_LTD_FIRMWARE)
     )
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -3796,7 +3816,7 @@ async def test_async_setup_entry_firmware_at_or_above_ltd_deletes_previous_issue
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -3808,8 +3828,12 @@ async def test_async_setup_entry_firmware_at_or_above_ltd_deletes_previous_issue
     # Expect delete_issue to be called for the previous below-min and below-ltd issue ids
     assert delete_issue_mock.called, "async_delete_issue should have been called"
     called_issue_ids = [call[0][2] for call in delete_issue_mock.call_args_list if len(call[0]) > 2]
-    expected_min = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_{init_mod.OPNSENSE_MIN_FIRMWARE}"
-    expected_ltd = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{init_mod.OPNSENSE_LTD_FIRMWARE}"
+    expected_min = (
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_{OPNSENSE_MIN_FIRMWARE}"
+    )
+    expected_ltd = (
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{OPNSENSE_LTD_FIRMWARE}"
+    )
     assert expected_min in called_issue_ids
     assert expected_ltd in called_issue_ids
 
@@ -3838,7 +3862,7 @@ async def test_async_setup_entry_delete_uses_actual_firmware_string(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -3848,8 +3872,12 @@ async def test_async_setup_entry_delete_uses_actual_firmware_string(
     assert res is True
 
     # Confirm delete_issue was called for the expected issue ids
-    expected_min = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_{init_mod.OPNSENSE_MIN_FIRMWARE}"
-    expected_ltd = f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{init_mod.OPNSENSE_LTD_FIRMWARE}"
+    expected_min = (
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_{OPNSENSE_MIN_FIRMWARE}"
+    )
+    expected_ltd = (
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_{OPNSENSE_LTD_FIRMWARE}"
+    )
     assert calls.called, "async_delete_issue should have been called"
     issue_ids = [call[0][2] for call in calls.call_args_list if len(call[0]) > 2]
     assert expected_min in issue_ids
@@ -3879,7 +3907,7 @@ async def test_async_setup_entry_delete_not_called_for_between_min_and_ltd(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         }
     )
     hass = ph_hass
@@ -3894,12 +3922,12 @@ async def test_async_setup_entry_delete_not_called_for_between_min_and_ltd(
     assert issue_ids
     assert f"{entry.entry_id}_device_id_mismatched" in issue_ids
     assert (
-        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
-        f"{init_mod.OPNSENSE_MIN_FIRMWARE}" not in issue_ids
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
+        f"{OPNSENSE_MIN_FIRMWARE}" not in issue_ids
     )
     assert (
-        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
-        f"{init_mod.OPNSENSE_LTD_FIRMWARE}" not in issue_ids
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
+        f"{OPNSENSE_LTD_FIRMWARE}" not in issue_ids
     )
 
 
@@ -3923,9 +3951,9 @@ async def test_async_setup_entry_with_device_tracker_enabled(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
     )
 
     hass = ph_hass
@@ -3969,9 +3997,9 @@ async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
     )
 
     hass = ph_hass
@@ -3985,7 +4013,7 @@ async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
     main_coordinator.async_shutdown.assert_awaited_once()
     device_tracker_coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
 
 
 @pytest.mark.asyncio
@@ -4019,14 +4047,14 @@ async def test_async_setup_entry_recreates_marker_issue_when_device_tracker_refr
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.marker = init_mod.RepairMarker(
+    reconciliation.marker = RepairMarker(
         version=1,
         old_device_id="old-dev",
         new_device_id="dev1",
@@ -4060,7 +4088,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_device_tracker_refr
     device_tracker_coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
     assert entry.runtime_data is None
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
 
 
 @pytest.mark.asyncio
@@ -4083,9 +4111,9 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
     remove_listener = MagicMock()
     entry.add_update_listener = MagicMock(return_value=remove_listener)
@@ -4107,7 +4135,7 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
     entry.async_on_unload.assert_not_called()
     remove_listener.assert_not_called()
     assert entry.runtime_data is None
-    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
 
 
 @pytest.mark.asyncio
@@ -4130,14 +4158,14 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.marker = init_mod.RepairMarker(
+    reconciliation.marker = RepairMarker(
         version=1,
         old_device_id="old-dev",
         new_device_id="dev1",
@@ -4172,7 +4200,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
     assert entry.runtime_data is None
-    assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
+    assert entry.entry_id not in ph_hass.data.get(DOMAIN, {})
 
 
 @pytest.mark.asyncio
@@ -4195,14 +4223,14 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.marker = init_mod.RepairMarker(
+    reconciliation.marker = RepairMarker(
         version=1,
         old_device_id="old-dev",
         new_device_id="dev1",
@@ -4237,7 +4265,7 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
     assert entry.runtime_data.opnsense_client is client
     coordinator.async_shutdown.assert_not_awaited()
     client.async_close.assert_not_awaited()
-    assert ph_hass.data[init_mod.DOMAIN][entry.entry_id] is client
+    assert ph_hass.data[DOMAIN][entry.entry_id] is client
 
 
 @pytest.mark.asyncio
@@ -4259,14 +4287,14 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+    reconciliation.require_platforms_complete.side_effect = RepairReconciliationError(
         "platform discovery incomplete: sensor"
     )
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
@@ -4286,7 +4314,7 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
     ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
     assert ph_hass.config_entries.async_unload_platforms.await_args.args[0] is entry
     ph_hass.config_entries.async_update_entry.assert_not_called()
-    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+    assert entry.data[REPAIR_MARKER_KEY] == marker
 
 
 async def _run_reconciliation_cleanup_unload(
@@ -4316,14 +4344,14 @@ async def _run_reconciliation_cleanup_unload(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        options={CONF_DEVICE_TRACKER_ENABLED: True},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
-    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+    reconciliation.require_platforms_complete.side_effect = RepairReconciliationError(
         "platforms still loading"
     )
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
@@ -4343,17 +4371,17 @@ async def _run_reconciliation_cleanup_unload(
         assert entry.runtime_data.coordinator is coordinator
         assert entry.runtime_data.opnsense_client is client
         assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
-        assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+        assert entry.data[REPAIR_MARKER_KEY] == marker
         coordinator.async_shutdown.assert_not_awaited()
         tracker_coordinator.async_shutdown.assert_not_awaited()
         client.async_close.assert_not_awaited()
-        assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
+        assert ph_hass.data.get(DOMAIN, {}).get(entry.entry_id) is client
     else:
         coordinator.async_shutdown.assert_awaited_once()
         tracker_coordinator.async_shutdown.assert_awaited_once()
         client.async_close.assert_awaited_once()
         assert entry.runtime_data is None
-        assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
+        assert entry.entry_id not in ph_hass.data.get(DOMAIN, {})
 
 
 @pytest.mark.parametrize(
@@ -4393,7 +4421,7 @@ async def test_unload_setup_platforms_after_reconciliation_failure_returns_false
     ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
 
     result = await init_mod._unload_setup_platforms_after_reconciliation_failure(
-        ph_hass, entry, ["sensor"]
+        ph_hass, entry, [Platform.SENSOR]
     )
     assert result is False
 
@@ -4410,7 +4438,7 @@ async def test_unload_setup_platforms_after_reconciliation_failure_returns_false
     )
 
     result = await init_mod._unload_setup_platforms_after_reconciliation_failure(
-        ph_hass, entry, ["sensor"]
+        ph_hass, entry, [Platform.SENSOR]
     )
     assert result is False
 
@@ -4441,7 +4469,7 @@ async def test_cleanup_reconciliation_failure_returns_platform_unload_result(
     result = await init_mod._cleanup_reconciliation_failure(
         ph_hass,
         entry,
-        ["sensor"],
+        [Platform.SENSOR],
         repair_marker,
     )
 
@@ -4470,10 +4498,10 @@ async def test_reconciliation_marker_clear_false_retains_marker(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
@@ -4489,7 +4517,7 @@ async def test_reconciliation_marker_clear_false_retains_marker(
     reconciliation.finalize.assert_called_once_with()
     ph_hass.config_entries.async_update_entry.assert_called_once()
     reconciliation.mark_complete.assert_not_called()
-    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+    assert entry.data[REPAIR_MARKER_KEY] == marker
 
 
 @pytest.mark.asyncio
@@ -4516,10 +4544,10 @@ async def test_reconciliation_marker_clear_exception_retains_marker(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
@@ -4536,7 +4564,7 @@ async def test_reconciliation_marker_clear_exception_retains_marker(
     reconciliation.finalize.assert_called_once_with()
     ph_hass.config_entries.async_update_entry.assert_called_once()
     reconciliation.mark_complete.assert_not_called()
-    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+    assert entry.data[REPAIR_MARKER_KEY] == marker
 
 
 @pytest.mark.asyncio
@@ -4558,9 +4586,9 @@ async def test_async_setup_entry_deletes_stale_device_id_mismatch_issue(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     ph_hass.config_entries.async_reload = AsyncMock()
@@ -4595,10 +4623,10 @@ async def test_async_setup_entry_preserves_marker_and_skips_stale_issue_delete(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
@@ -4616,12 +4644,12 @@ async def test_async_setup_entry_preserves_marker_and_skips_stale_issue_delete(
     delete_issue_ids = [call[0][2] for call in delete_issue.call_args_list if len(call[0]) > 2]
     assert f"{entry.entry_id}_device_id_mismatched" not in delete_issue_ids
     assert (
-        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
-        f"{init_mod.OPNSENSE_MIN_FIRMWARE}" in delete_issue_ids
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
+        f"{OPNSENSE_MIN_FIRMWARE}" in delete_issue_ids
     )
     assert (
-        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
-        f"{init_mod.OPNSENSE_LTD_FIRMWARE}" in delete_issue_ids
+        f"{entry.data[CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
+        f"{OPNSENSE_LTD_FIRMWARE}" in delete_issue_ids
     )
     ph_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
     ph_hass.config_entries.async_update_entry.assert_called_once()
@@ -4660,9 +4688,9 @@ async def test_async_setup_entry_deletes_stale_mismatch_issue_only_on_matching_v
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     ph_hass.config_entries.async_reload = AsyncMock()
@@ -4700,15 +4728,15 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     reconciliation = MagicMock()
     reconciliation.marker = init_mod.parse_repair_marker(entry)
-    reconciliation.prepare.side_effect = init_mod.RepairReconciliationError("prepare failed")
+    reconciliation.prepare.side_effect = RepairReconciliationError("prepare failed")
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
@@ -4773,10 +4801,10 @@ async def test_async_setup_entry_recreates_marker_issue_on_probe_mismatch_before
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
         unique_id="dev1",
     )
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
@@ -4830,9 +4858,9 @@ async def test_async_setup_entry_rejects_entry_with_malformed_repair_marker(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
             # malformed marker is missing new_device_id (must be string)
-            init_mod.REPAIR_MARKER_KEY: {"version": 1, "old_device_id": "old-dev"},
+            REPAIR_MARKER_KEY: {"version": 1, "old_device_id": "old-dev"},
         },
         options={},
     )
@@ -4884,8 +4912,8 @@ async def test_async_setup_entry_rejects_entry_when_marker_and_entry_mismatch(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: config_device_id,
-            init_mod.REPAIR_MARKER_KEY: {
+            CONF_DEVICE_UNIQUE_ID: config_device_id,
+            REPAIR_MARKER_KEY: {
                 "version": 1,
                 "old_device_id": "old-dev",
                 "new_device_id": marker_device_id,
@@ -4933,8 +4961,8 @@ async def test_async_setup_entry_keeps_runtime_when_reconciliation_cleanup_raise
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: {
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: {
                 "version": 1,
                 "old_device_id": "old-dev",
                 "new_device_id": "dev1",
@@ -4945,13 +4973,13 @@ async def test_async_setup_entry_keeps_runtime_when_reconciliation_cleanup_raise
     )
 
     reconciliation = MagicMock()
-    reconciliation.marker = init_mod.RepairMarker(
+    reconciliation.marker = RepairMarker(
         version=1,
         old_device_id="old-dev",
         new_device_id="dev1",
     )
     reconciliation.require_platforms_complete = MagicMock(
-        side_effect=init_mod.RepairReconciliationError("platforms incomplete")
+        side_effect=RepairReconciliationError("platforms incomplete")
     )
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     monkeypatch.setattr(
@@ -4974,7 +5002,7 @@ async def test_async_setup_entry_keeps_runtime_when_reconciliation_cleanup_raise
     assert entry.runtime_data is not None
     assert entry.runtime_data.coordinator is coordinator
     assert entry.runtime_data.opnsense_client is client
-    assert ph_hass.data[init_mod.DOMAIN][entry.entry_id] is client
+    assert ph_hass.data[DOMAIN][entry.entry_id] is client
     coordinator.async_shutdown.assert_not_awaited()
     client.async_close.assert_not_awaited()
 
@@ -5001,9 +5029,9 @@ async def test_async_setup_entry_registers_update_listener_after_forwarding(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
         },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
     )
     remove_listener = MagicMock()
 
@@ -5079,7 +5107,7 @@ async def test_migrate_2_to_3_handles_identifier_collision(
         def async_update_device(self, *a, **k) -> Never:
             # DeviceIdentifierCollisionError requires an existing_device argument
             """Raise the collision error expected by the registry migration test."""
-            raise init_mod.dr.DeviceIdentifierCollisionError("collision", MagicMock(id="other"))
+            raise init_mod.dr.DeviceIdentifierCollisionError(dev.identifiers, MagicMock(id="other"))
 
     monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: DeviceRegistry())
     monkeypatch.setattr(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3989,6 +3989,81 @@ async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_recreates_marker_issue_when_device_tracker_refresh_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Marker-backed device-tracker setup failures should recreate the mismatch issue."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+
+    main_coordinator = _make_setup_coordinator()
+    device_tracker_coordinator = _make_setup_coordinator()
+    device_tracker_coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=RuntimeError("device tracker refresh failed")
+    )
+
+    coordinators = [main_coordinator, device_tracker_coordinator]
+
+    def _coordinator_factory(**_kwargs: Any) -> Any:
+        """Return setup coordinators in creation order."""
+        return coordinators.pop(0)
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.marker = init_mod.RepairMarker(
+        version=1,
+        old_device_id="old-dev",
+        new_device_id="dev1",
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = MagicMock()
+    hass.data = {}
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    with pytest.raises(RuntimeError, match="device tracker refresh failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    reconciliation.prepare.assert_not_called()
+    reconciliation.require_platforms_complete.assert_not_called()
+    reconciliation.finalize.assert_not_called()
+    assert create_issue.call_count == 1
+    issue_kwargs = create_issue.call_args.kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    main_coordinator.async_shutdown.assert_awaited_once()
+    device_tracker_coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.runtime_data is None
+    assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
@@ -4093,11 +4168,76 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
         "old_device_id": "old-dev",
         "new_device_id": "dev1",
     }
-    ph_hass.config_entries.async_unload_platforms.assert_not_awaited()
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
     coordinator.async_shutdown.assert_awaited_once()
     client.async_close.assert_awaited_once()
     assert entry.runtime_data is None
     assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Marker cleanup failures should keep runtime after forwarding exception."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.marker = init_mod.RepairMarker(
+        version=1,
+        old_device_id="old-dev",
+        new_device_id="dev1",
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(
+        side_effect=RuntimeError("platform forwarding failed")
+    )
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+    ph_hass.config_entries.async_reload = MagicMock()
+    ph_hass.data = {}
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    with pytest.raises(RuntimeError, match="platform forwarding failed"):
+        await init_mod.async_setup_entry(ph_hass, entry)
+
+    reconciliation.prepare.assert_called_once_with()
+    assert ph_hass.config_entries.async_unload_platforms.await_count == 1
+    assert create_issue.call_count == 1
+    issue_kwargs = create_issue.call_args.kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.coordinator is coordinator
+    assert entry.runtime_data.opnsense_client is client
+    coordinator.async_shutdown.assert_not_awaited()
+    client.async_close.assert_not_awaited()
+    assert ph_hass.data[init_mod.DOMAIN][entry.entry_id] is client
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -995,55 +995,15 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "stored_device_id",
+    ("stored_device_id", "router_device_id", "should_create_issue", "setup_succeeds"),
     [
-        pytest.param("", id="blank"),
-        pytest.param("   ", id="whitespace"),
-        pytest.param(123, id="number"),
-    ],
-)
-async def test_async_setup_entry_rejects_malformed_stored_device_id(
-    monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
-    coordinator_capture: Any,
-    fake_coordinator: Any,
-    make_config_entry: Callable[..., MockConfigEntry],
-    stored_device_id: object,
-) -> None:
-    """async_setup_entry should reject malformed stored IDs before probing a router."""
-    client = _make_valid_setup_client()
-    client.get_device_unique_id = AsyncMock(return_value="valid-observed-id")
-    create_client = MagicMock(return_value=client)
-    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", create_client)
-    monkeypatch.setattr(
-        init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
-    )
-    entry = make_config_entry(
-        data={
-            CONF_URL: "http://1.2.3.4",
-            CONF_USERNAME: "u",
-            CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: stored_device_id,
-        },
-        options={},
-    )
-
-    assert await init_mod.async_setup_entry(ph_hass, entry) is False
-    create_client.assert_not_called()
-    client.validate.assert_not_awaited()
-    client.get_device_unique_id.assert_not_awaited()
-    assert coordinator_capture.instances == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("router_device_id", "should_create_issue"),
-    [
-        ("other", True),
-        (None, False),
-        ("", False),
-        ("   ", False),
-        (123, False),
+        pytest.param("dev1", "other", True, False, id="mismatch"),
+        pytest.param("dev1", None, False, True, id="missing-router-id"),
+        pytest.param("dev1", "", False, True, id="blank-router-id"),
+        pytest.param("dev1", "   ", False, True, id="whitespace-router-id"),
+        pytest.param("dev1", 123, False, True, id="non-string-router-id"),
+        pytest.param("", "valid-router-id", False, False, id="blank-stored-id"),
+        pytest.param(123, "valid-router-id", False, False, id="non-string-stored-id"),
     ],
 )
 async def test_async_setup_entry_device_id_mismatch(
@@ -1054,12 +1014,15 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
     caplog: pytest.LogCaptureFixture,
+    stored_device_id: object,
     router_device_id: Any,
     should_create_issue: bool,
+    setup_succeeds: bool,
 ) -> None:
-    """async_setup_entry should fail when client reports mismatched device id."""
+    """async_setup_entry should handle malformed and mismatched device IDs safely."""
     caplog.set_level(logging.ERROR, logger=init_mod.__name__)
-    patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id=router_device_id))
+    create_client = MagicMock(side_effect=fake_client(device_id=router_device_id))
+    patch_opnsense_client(monkeypatch, init_mod, create_client)
     # use shared coordinator capture fixture
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -1071,7 +1034,7 @@ async def test_async_setup_entry_device_id_mismatch(
             CONF_URL: "http://1.2.3.4",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.CONF_DEVICE_UNIQUE_ID: stored_device_id,
         },
         options={},
     )
@@ -1108,11 +1071,17 @@ async def test_async_setup_entry_device_id_mismatch(
         }
         assert "fixable repair issue" in caplog.text
         assert "rebuild entities" in caplog.text
-    else:
+    elif setup_succeeds:
         assert res is True
         assert not issue_kwargs
         assert hass.config_entries.async_forward_entry_setups.await_count == 1
         assert not any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
+    else:
+        assert res is False
+        assert not issue_kwargs
+        create_client.assert_not_called()
+        assert coordinator_capture.instances == []
+        assert hass.config_entries.async_forward_entry_setups.await_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -992,18 +992,31 @@ async def test_async_setup_entry_reraises_client_creation_error(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_continues_after_firmware_validation_error(
+@pytest.mark.parametrize(
+    ("error_type", "message"),
+    [
+        pytest.param(OPNsenseBelowMinFirmware, "boom", id="below-minimum-firmware"),
+        pytest.param(
+            OPNsenseMissingDeviceUniqueID,
+            "unable to determine Device ID",
+            id="missing-device-id",
+        ),
+    ],
+)
+async def test_async_setup_entry_continues_after_ignored_validation_error(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     coordinator_capture: Any,
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    error_type: type[OPNsenseError],
+    message: str,
 ) -> None:
-    """async_setup_entry should keep probing after firmware validation exceptions."""
+    """async_setup_entry should keep probing after ignored validation exceptions."""
     probe_calls: list[str] = []
     client = MagicMock()
     client.name = "test-router"
-    client.validate = AsyncMock(side_effect=OPNsenseBelowMinFirmware("boom"))
+    client.validate = AsyncMock(side_effect=error_type(message))
     client.async_close = AsyncMock(return_value=True)
 
     async def _get_device_unique_id(expected_id: str | None = None) -> str:
@@ -1021,69 +1034,6 @@ async def test_async_setup_entry_continues_after_firmware_validation_error(
 
     def _create_client(**kwargs: Any) -> Any:
         """Return the firmware-failing client for this setup-entry test."""
-        return client
-
-    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)
-    monkeypatch.setattr(
-        init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
-    )
-
-    entry = make_config_entry(
-        data={
-            CONF_URL: "http://1.2.3.4",
-            CONF_USERNAME: "u",
-            CONF_PASSWORD: "p",
-            CONF_DEVICE_UNIQUE_ID: "dev1",
-        },
-        options={},
-    )
-
-    hass = ph_hass
-    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    hass.config_entries.async_reload = AsyncMock()
-    hass.data = {}
-
-    res = await init_mod.async_setup_entry(hass, entry)
-    assert res is True
-    assert probe_calls == [
-        "get_device_unique_id",
-        "get_host_firmware_version",
-    ]
-    client.async_close.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_continues_after_missing_device_unique_id_validation(
-    monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
-    coordinator_capture: Any,
-    fake_coordinator: Any,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """async_setup_entry should continue when unique-id validation is unavailable."""
-    probe_calls: list[str] = []
-    client = MagicMock()
-    client.name = "test-router"
-    client.validate = AsyncMock(
-        side_effect=OPNsenseMissingDeviceUniqueID("unable to determine Device ID")
-    )
-    client.async_close = AsyncMock(return_value=True)
-
-    async def _get_device_unique_id(expected_id: str | None = None) -> str:
-        """Return test router Device ID after recording probe ordering."""
-        probe_calls.append("get_device_unique_id")
-        return "dev1"
-
-    async def _get_host_firmware_version() -> str:
-        """Return test firmware after recording probe ordering."""
-        probe_calls.append("get_host_firmware_version")
-        return "99.0"
-
-    client.get_device_unique_id = _get_device_unique_id
-    client.get_host_firmware_version = _get_host_firmware_version
-
-    def _create_client(**kwargs: Any) -> Any:
-        """Return the unique-id-missing client for this setup-entry test."""
         return client
 
     monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", _create_client)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4263,6 +4263,57 @@ async def test_async_setup_entry_preserves_marker_and_skips_stale_issue_delete(
     reconciliation.mark_complete.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("router_device_id", "expects_delete_issue"),
+    [
+        pytest.param(None, False, id="missing-router-id"),
+        pytest.param("", False, id="blank-router-id"),
+        pytest.param("   ", False, id="whitespace-router-id"),
+        pytest.param(123, False, id="non-string-router-id"),
+        pytest.param("dev1", True, id="valid-matching-router-id"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_deletes_stale_mismatch_issue_only_on_matching_valid_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    fake_client: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    router_device_id: Any,
+    expects_delete_issue: bool,
+) -> None:
+    """Only delete stale mismatch issues when configured and observed IDs are both valid and equal."""
+    create_client = MagicMock(side_effect=fake_client(device_id=router_device_id))
+    patch_opnsense_client(monkeypatch, init_mod, create_client)
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_reload = AsyncMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+    assert result is True
+
+    expected_issue_id = f"{entry.entry_id}_device_id_mismatched"
+    delete_issue_ids = [call[0][2] for call in delete_issue.call_args_list if len(call[0]) > 2]
+    if expects_delete_issue:
+        assert expected_issue_id in delete_issue_ids
+    else:
+        assert expected_issue_id not in delete_issue_ids
+
+
 @pytest.mark.asyncio
 async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unloading_platforms(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4036,6 +4036,71 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Marker-backed reconciliation should recreate issue if forwarding fails."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.marker = init_mod.RepairMarker(
+        version=1,
+        old_device_id="old-dev",
+        new_device_id="dev1",
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(
+        side_effect=RuntimeError("platform forwarding failed")
+    )
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_reload = MagicMock()
+    ph_hass.data = {}
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    with pytest.raises(RuntimeError, match="platform forwarding failed"):
+        await init_mod.async_setup_entry(ph_hass, entry)
+
+    reconciliation.prepare.assert_called_once_with()
+    reconciliation.require_platforms_complete.assert_not_called()
+    reconciliation.finalize.assert_not_called()
+    assert create_issue.call_count == 1
+    issue_kwargs = create_issue.call_args.kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    ph_hass.config_entries.async_unload_platforms.assert_not_awaited()
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.runtime_data is None
+    assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
 async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_marker(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4599,6 +4599,80 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "router_device_id",
+    [
+        pytest.param(None, id="missing-router-id"),
+        pytest.param("", id="blank-router-id"),
+        pytest.param("   ", id="whitespace-router-id"),
+        pytest.param(123, id="non-string-router-id"),
+        pytest.param("other-dev", id="other-valid-router-id"),
+    ],
+)
+async def test_async_setup_entry_recreates_marker_issue_on_probe_mismatch_before_forwarding(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    router_device_id: Any,
+) -> None:
+    """Marker-backed mismatch should recreate the issue and stop before platform setup."""
+    client = _make_valid_setup_client()
+
+    async def _get_device_unique_id(expected_id: str | None = None) -> Any:
+        """Return a probe value that triggers marker-based probe mismatch."""
+        return router_device_id
+
+    client.get_device_unique_id = _get_device_unique_id
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock()
+    ph_hass.config_entries.async_reload = MagicMock()
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    assert ph_hass.config_entries.async_forward_entry_setups.await_count == 0
+    assert ph_hass.config_entries.async_unload_platforms.await_count == 0
+    assert create_issue.call_count == 1
+    issue_kwargs = create_issue.call_args.kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    assert issue_kwargs["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    coordinator.async_shutdown.assert_awaited_once()
+    coordinator.async_config_entry_first_refresh.assert_not_awaited()
+    client.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_registers_update_listener_after_forwarding(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -995,6 +995,48 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "stored_device_id",
+    [
+        pytest.param("", id="blank"),
+        pytest.param("   ", id="whitespace"),
+        pytest.param(123, id="number"),
+    ],
+)
+async def test_async_setup_entry_rejects_malformed_stored_device_id(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    coordinator_capture: Any,
+    fake_coordinator: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    stored_device_id: object,
+) -> None:
+    """async_setup_entry should reject malformed stored IDs before probing a router."""
+    client = _make_valid_setup_client()
+    client.get_device_unique_id = AsyncMock(return_value="valid-observed-id")
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(init_mod, "create_opnsense_client_from_config_entry", create_client)
+    monkeypatch.setattr(
+        init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
+    )
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: stored_device_id,
+        },
+        options={},
+    )
+
+    assert await init_mod.async_setup_entry(ph_hass, entry) is False
+    create_client.assert_not_called()
+    client.validate.assert_not_awaited()
+    client.get_device_unique_id.assert_not_awaited()
+    assert coordinator_capture.instances == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("router_device_id", "should_create_issue"),
     [
         ("other", True),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3967,6 +3967,70 @@ async def test_async_setup_entry_with_device_tracker_enabled(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_recreates_marker_issue_when_main_refresh_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Marker-backed main refresh failures should recreate the mismatch issue."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+
+    coordinator = _make_setup_coordinator()
+    coordinator.async_config_entry_first_refresh = AsyncMock(
+        side_effect=ConfigEntryNotReady("main refresh failed")
+    )
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: marker,
+        },
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+
+    hass = ph_hass
+    hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    hass.config_entries.async_reload = MagicMock()
+    hass.data = {}
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    with pytest.raises(ConfigEntryNotReady, match="main refresh failed"):
+        await init_mod.async_setup_entry(hass, entry)
+
+    hass.config_entries.async_forward_entry_setups.assert_not_awaited()
+    create_issue.assert_called_once()
+    issue_kwargs = create_issue.call_args.kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["translation_key"] == "device_id_mismatched"
+    assert issue_kwargs["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.runtime_data is None
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_cleans_up_when_device_tracker_refresh_fails(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3890,7 +3890,17 @@ async def test_async_setup_entry_delete_not_called_for_between_min_and_ltd(
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is True
     # delete should not be called for firmware between min and LTD
-    assert not delete_issue_mock.called
+    issue_ids = [call[0][2] for call in delete_issue_mock.call_args_list if len(call[0]) > 2]
+    assert issue_ids
+    assert f"{entry.entry_id}_device_id_mismatched" in issue_ids
+    assert (
+        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
+        f"{init_mod.OPNSENSE_MIN_FIRMWARE}" not in issue_ids
+    )
+    assert (
+        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
+        f"{init_mod.OPNSENSE_LTD_FIRMWARE}" not in issue_ids
+    )
 
 
 @pytest.mark.asyncio
@@ -4056,6 +4066,7 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
     )
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
     ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
     ph_hass.data = {}
 
@@ -4067,6 +4078,8 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
     reconciliation.require_platforms_complete.assert_called_once()
     reconciliation.finalize.assert_not_called()
     reconciliation.mark_complete.assert_not_called()
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
+    assert ph_hass.config_entries.async_unload_platforms.await_args.args[0] is entry
     ph_hass.config_entries.async_update_entry.assert_not_called()
     assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
 
@@ -4157,6 +4170,151 @@ async def test_reconciliation_marker_clear_exception_retains_marker(
     ph_hass.config_entries.async_update_entry.assert_called_once()
     reconciliation.mark_complete.assert_not_called()
     assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_deletes_stale_device_id_mismatch_issue(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """A matching device ID should clear any stale startup mismatch issue."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+    )
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_reload = AsyncMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is True
+    expected_issue_id = f"{entry.entry_id}_device_id_mismatched"
+    deleted_issue_ids = [call[0][2] for call in delete_issue.call_args_list if len(call[0]) > 2]
+    assert expected_issue_id in deleted_issue_ids
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_preserves_marker_and_skips_stale_issue_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An active repair marker should skip stale mismatch issue deletion until reconcile completes."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
+    ph_hass.config_entries.async_reload = AsyncMock()
+    delete_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_delete_issue", delete_issue)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is True
+    delete_issue_ids = [call[0][2] for call in delete_issue.call_args_list if len(call[0]) > 2]
+    assert f"{entry.entry_id}_device_id_mismatched" not in delete_issue_ids
+    assert (
+        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_min_firmware_"
+        f"{init_mod.OPNSENSE_MIN_FIRMWARE}" in delete_issue_ids
+    )
+    assert (
+        f"{entry.data[init_mod.CONF_DEVICE_UNIQUE_ID]}_opnsense_below_ltd_firmware_"
+        f"{init_mod.OPNSENSE_LTD_FIRMWARE}" in delete_issue_ids
+    )
+    ph_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
+    ph_hass.config_entries.async_update_entry.assert_called_once()
+    reconciliation.require_platforms_complete.assert_called_once()
+    reconciliation.finalize.assert_called_once_with()
+    reconciliation.mark_complete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unloading_platforms(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Reconciliation preflight failures emit retryable marker issue and skip platform unload."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.prepare.side_effect = init_mod.RepairReconciliationError("prepare failed")
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_reload = AsyncMock()
+    ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    expected_issue_id = f"{entry.entry_id}_device_id_mismatched"
+    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count == 1
+    assert issue_kwargs["issue_id"] == expected_issue_id
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    ph_hass.config_entries.async_unload_platforms.assert_not_awaited()
+    ph_hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any, Never, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, call
 
+from aiopnsense import OPNsenseClient
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
@@ -680,7 +681,6 @@ async def test_async_setup_entry_carp_registers_update_listener_after_forwarding
     "error",
     [
         pytest.param(OPNsenseError("boom"), id="generic"),
-        pytest.param(OPNsenseTimeoutError("timed out"), id="timeout"),
     ],
 )
 async def test_async_setup_entry_closes_client_when_validation_fails(
@@ -923,7 +923,7 @@ async def test_async_setup_entry_with_repair_marker_recreates_issue_on_early_pro
     monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
 
     if failure_step == "validate":
-        with pytest.raises(OPNsenseTimeoutError, match="validate timeout"):
+        with pytest.raises(ConfigEntryNotReady, match="validation timed out"):
             await init_mod.async_setup_entry(ph_hass, entry)
     elif failure_step == "device_probe":
         with pytest.raises(OPNsenseConnectionError, match="probe timeout"):
@@ -3486,7 +3486,7 @@ async def test_migrate_3_to_4_skips_filesystems_when_telemetry_is_not_mapping(
     hass.config_entries = MagicMock()
     hass.config_entries.async_update_entry = MagicMock(return_value=True)
 
-    result = await init_mod._migrate_3_to_4(hass, config_entry, client)
+    result = await init_mod._migrate_3_to_4(hass, config_entry, cast("OPNsenseClient", client))
 
     assert result is False
     entity_registry.async_update_entity.assert_called_once_with(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4218,12 +4218,20 @@ async def test_cleanup_reconciliation_failure_returns_platform_unload_result(
 ) -> None:
     """Marker creation should precede unload and the helper should return its unload result."""
     entry = make_config_entry()
+    events: list[str] = []
     repair_marker = MagicMock()
     repair_marker.old_device_id = "old-dev"
     repair_marker.new_device_id = "new-dev"
     issue_create = MagicMock()
+    issue_create.side_effect = lambda *args, **kwargs: events.append("create_issue")
     monkeypatch.setattr(init_mod.ir, "async_create_issue", issue_create)
-    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    async def _unload_platforms(*args: Any, **kwargs: Any) -> bool:
+        del args, kwargs
+        events.append("unload_platforms")
+        return True
+
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(side_effect=_unload_platforms)
 
     result = await init_mod._cleanup_reconciliation_failure(
         ph_hass,
@@ -4234,6 +4242,7 @@ async def test_cleanup_reconciliation_failure_returns_platform_unload_result(
 
     assert result is True
     issue_create.assert_called_once()
+    assert events == ["create_issue", "unload_platforms"]
     ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1001,8 +1001,10 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_client: Any,
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """async_setup_entry should fail when client reports mismatched device id."""
+    caplog.set_level(logging.ERROR, logger=init_mod.__name__)
     patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id="other"))
     # use shared coordinator capture fixture
     monkeypatch.setattr(
@@ -1024,12 +1026,35 @@ async def test_async_setup_entry_device_id_mismatch(
     hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
     hass.config_entries.async_reload = AsyncMock()
 
+    issue_kwargs: dict[str, Any] = {}
+
+    def _capture_issue(**kwargs: Any) -> None:
+        """Capture the startup device-ID repair issue payload."""
+        issue_kwargs.update(kwargs)
+
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
+
     # should return False because router id mismatches and coordinator.shutdown called
     res = await init_mod.async_setup_entry(hass, entry)
     assert res is False
 
     # ensure coordinator shutdown was invoked
     assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
+    assert hass.config_entries.async_forward_entry_setups.await_count == 0
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    assert issue_kwargs["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    assert "fixable repair issue" in caplog.text
+    assert "rebuild entities" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,7 +22,7 @@ from aiopnsense.exceptions import (
 )
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -4023,6 +4023,140 @@ async def test_async_setup_entry_cleans_up_when_platform_forwarding_fails(
     remove_listener.assert_not_called()
     assert entry.runtime_data is None
     assert entry.entry_id not in hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An unreported forwarded platform retains the marker and skips pruning."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+        "platform discovery incomplete: sensor"
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_update_entry = MagicMock(return_value=True)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    ph_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
+    reconciliation.prepare.assert_called_once_with()
+    reconciliation.require_platforms_complete.assert_called_once()
+    reconciliation.finalize.assert_not_called()
+    reconciliation.mark_complete.assert_not_called()
+    ph_hass.config_entries.async_update_entry.assert_not_called()
+    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_marker_clear_false_retains_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """A rejected marker-clear update leaves persisted repair intent retryable."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_update_entry = MagicMock(return_value=False)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    reconciliation.require_platforms_complete.assert_called_once()
+    reconciliation.finalize.assert_called_once_with()
+    ph_hass.config_entries.async_update_entry.assert_called_once()
+    reconciliation.mark_complete.assert_not_called()
+    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "clear_error",
+    [HomeAssistantError("storage failed"), KeyError("entry removed")],
+)
+async def test_reconciliation_marker_clear_exception_retains_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    clear_error: BaseException,
+) -> None:
+    """Handled marker-clear failures preserve repair intent for retry."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_update_entry = MagicMock(side_effect=clear_error)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    ph_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
+    reconciliation.require_platforms_complete.assert_called_once()
+    reconciliation.finalize.assert_called_once_with()
+    ph_hass.config_entries.async_update_entry.assert_called_once()
+    reconciliation.mark_complete.assert_not_called()
+    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -860,6 +860,106 @@ async def test_async_setup_entry_does_not_retry_non_transient_validation_failure
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure_step",
+    [
+        "validate",
+        "device_probe",
+        "firmware_probe",
+    ],
+)
+async def test_async_setup_entry_with_repair_marker_recreates_issue_on_early_probe_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    failure_step: str,
+) -> None:
+    """A valid repair marker should create its mismatch issue before probe failures."""
+    create_client = _make_valid_setup_client()
+    if failure_step == "validate":
+        create_client.validate = AsyncMock(side_effect=OPNsenseTimeoutError("validate timeout"))
+    elif failure_step == "device_probe":
+        create_client.get_device_unique_id = AsyncMock(
+            side_effect=OPNsenseConnectionError("probe timeout")
+        )
+    else:
+        create_client.get_host_firmware_version = AsyncMock(
+            side_effect=OPNsenseConnectionError("firmware check timeout")
+        )
+
+    def _create_client(**kwargs: Any) -> Any:
+        """Return the marker-aware client used by this setup failure test."""
+        del kwargs
+        return create_client
+
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(
+        init_mod,
+        "create_opnsense_client_from_config_entry",
+        _create_client,
+    )
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            CONF_DEVICE_UNIQUE_ID: "dev1",
+            REPAIR_MARKER_KEY: {
+                "version": 1,
+                "old_device_id": "old-dev",
+                "new_device_id": "dev1",
+            },
+        },
+        options={CONF_DEVICE_TRACKER_ENABLED: False},
+        unique_id="dev1",
+    )
+
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_reload = MagicMock()
+    ph_hass.data = {}
+    create_issue = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", create_issue)
+
+    if failure_step == "validate":
+        with pytest.raises(OPNsenseTimeoutError, match="validate timeout"):
+            await init_mod.async_setup_entry(ph_hass, entry)
+    elif failure_step == "device_probe":
+        with pytest.raises(OPNsenseConnectionError, match="probe timeout"):
+            await init_mod.async_setup_entry(ph_hass, entry)
+    else:
+        with pytest.raises(OPNsenseConnectionError, match="firmware check timeout"):
+            await init_mod.async_setup_entry(ph_hass, entry)
+
+    ph_hass.config_entries.async_forward_entry_setups.assert_not_awaited()
+    assert create_issue.call_count >= 1
+    issue_kwargs = create_issue.call_args_list[0].kwargs
+    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+    assert issue_kwargs["is_fixable"] is True
+    assert issue_kwargs["is_persistent"] is False
+    assert issue_kwargs["translation_key"] == "device_id_mismatched"
+    assert issue_kwargs["translation_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    assert issue_kwargs["data"] == {
+        "entry_id": entry.entry_id,
+        "old_device_id": "old-dev",
+        "new_device_id": "dev1",
+    }
+    assert entry.entry_id not in ph_hass.data.get(DOMAIN, {})
+    if failure_step == "validate":
+        coordinator.async_shutdown.assert_not_awaited()
+        assert entry.runtime_data is not None
+    else:
+        assert entry.runtime_data is None
+        coordinator.async_shutdown.assert_awaited_once()
+    create_client.async_close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_reraises_client_creation_error(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
@@ -4008,8 +4108,8 @@ async def test_async_setup_entry_recreates_marker_issue_when_main_refresh_fails(
         await init_mod.async_setup_entry(hass, entry)
 
     hass.config_entries.async_forward_entry_setups.assert_not_awaited()
-    create_issue.assert_called_once()
-    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count >= 2
+    issue_kwargs = create_issue.call_args_list[0].kwargs
     assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False
@@ -4138,8 +4238,8 @@ async def test_async_setup_entry_recreates_marker_issue_when_device_tracker_refr
     reconciliation.prepare.assert_not_called()
     reconciliation.require_platforms_complete.assert_not_called()
     reconciliation.finalize.assert_not_called()
-    assert create_issue.call_count == 1
-    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count >= 2
+    issue_kwargs = create_issue.call_args_list[0].kwargs
     assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False
@@ -4250,8 +4350,8 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
     reconciliation.prepare.assert_called_once_with()
     reconciliation.require_platforms_complete.assert_not_called()
     reconciliation.finalize.assert_not_called()
-    assert create_issue.call_count == 1
-    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count >= 2
+    issue_kwargs = create_issue.call_args_list[0].kwargs
     assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False
@@ -4314,8 +4414,8 @@ async def test_async_setup_entry_recreates_marker_issue_when_platform_forwarding
 
     reconciliation.prepare.assert_called_once_with()
     assert ph_hass.config_entries.async_unload_platforms.await_count == 1
-    assert create_issue.call_count == 1
-    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count >= 2
+    issue_kwargs = create_issue.call_args_list[0].kwargs
     assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False
@@ -4814,8 +4914,8 @@ async def test_reconciliation_prepare_failure_recreates_marker_issue_without_unl
 
     assert result is False
     expected_issue_id = f"{entry.entry_id}_device_id_mismatched"
-    issue_kwargs = create_issue.call_args.kwargs
-    assert create_issue.call_count == 1
+    issue_kwargs = create_issue.call_args_list[0].kwargs
+    assert create_issue.call_count >= 2
     assert issue_kwargs["issue_id"] == expected_issue_id
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False
@@ -4882,8 +4982,8 @@ async def test_async_setup_entry_recreates_marker_issue_on_probe_mismatch_before
     assert result is False
     assert ph_hass.config_entries.async_forward_entry_setups.await_count == 0
     assert ph_hass.config_entries.async_unload_platforms.await_count == 0
-    assert create_issue.call_count == 1
-    issue_kwargs = create_issue.call_args.kwargs
+    assert create_issue.call_count >= 2
+    issue_kwargs = create_issue.call_args_list[0].kwargs
     assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
     assert issue_kwargs["is_fixable"] is True
     assert issue_kwargs["is_persistent"] is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -994,6 +994,16 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("router_device_id", "should_create_issue"),
+    [
+        ("other", True),
+        (None, False),
+        ("", False),
+        ("   ", False),
+        (123, False),
+    ],
+)
 async def test_async_setup_entry_device_id_mismatch(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
@@ -1002,10 +1012,12 @@ async def test_async_setup_entry_device_id_mismatch(
     fake_coordinator: Any,
     make_config_entry: Callable[..., MockConfigEntry],
     caplog: pytest.LogCaptureFixture,
+    router_device_id: Any,
+    should_create_issue: bool,
 ) -> None:
     """async_setup_entry should fail when client reports mismatched device id."""
     caplog.set_level(logging.ERROR, logger=init_mod.__name__)
-    patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id="other"))
+    patch_opnsense_client(monkeypatch, init_mod, fake_client(device_id=router_device_id))
     # use shared coordinator capture fixture
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -1034,27 +1046,31 @@ async def test_async_setup_entry_device_id_mismatch(
 
     monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
 
-    # should return False because router id mismatches and coordinator.shutdown called
     res = await init_mod.async_setup_entry(hass, entry)
-    assert res is False
-
-    # ensure coordinator shutdown was invoked
-    assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
-    assert hass.config_entries.async_forward_entry_setups.await_count == 0
-    assert issue_kwargs["is_fixable"] is True
-    assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
-    assert issue_kwargs["data"] == {
-        "entry_id": entry.entry_id,
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-    assert issue_kwargs["translation_placeholders"] == {
-        "entry_title": entry.title,
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-    assert "fixable repair issue" in caplog.text
-    assert "rebuild entities" in caplog.text
+    if should_create_issue:
+        # should return False because router id mismatches and coordinator.shutdown called
+        assert res is False
+        assert any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
+        assert hass.config_entries.async_forward_entry_setups.await_count == 0
+        assert issue_kwargs["is_fixable"] is True
+        assert issue_kwargs["issue_id"] == f"{entry.entry_id}_device_id_mismatched"
+        assert issue_kwargs["data"] == {
+            "entry_id": entry.entry_id,
+            "old_device_id": "dev1",
+            "new_device_id": router_device_id,
+        }
+        assert issue_kwargs["translation_placeholders"] == {
+            "entry_title": entry.title,
+            "old_device_id": "dev1",
+            "new_device_id": router_device_id,
+        }
+        assert "fixable repair issue" in caplog.text
+        assert "rebuild entities" in caplog.text
+    else:
+        assert res is True
+        assert not issue_kwargs
+        assert hass.config_entries.async_forward_entry_setups.await_count == 1
+        assert not any(getattr(inst, "shut", False) for inst in coordinator_capture.instances)
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4492,6 +4492,7 @@ async def _run_reconciliation_cleanup_unload(
         (pytest.param(False, True, id="unload-false-preserves-runtime")),
         (pytest.param(HomeAssistantError("unload failed"), True, id="homeassistant-error")),
         (pytest.param(KeyError("entry key"), True, id="key-error")),
+        (pytest.param(TimeoutError("unload timed out"), True, id="timeout-error")),
         (pytest.param(True, False, id="unload-success-tears-down-runtime")),
     ],
 )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4597,6 +4597,175 @@ async def test_async_setup_entry_recreates_marker_issue_on_probe_mismatch_before
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_rejects_entry_with_malformed_repair_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Malformed repair marker payloads should abort setup and avoid client creation."""
+    client = _make_valid_setup_client()
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        init_mod,
+        "create_opnsense_client_from_config_entry",
+        create_client,
+    )
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            # malformed marker is missing new_device_id (must be string)
+            init_mod.REPAIR_MARKER_KEY: {"version": 1, "old_device_id": "old-dev"},
+        },
+        options={},
+    )
+    forward_entry_setups = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        ph_hass.config_entries,
+        "async_forward_entry_setups",
+        forward_entry_setups,
+    )
+    monkeypatch.setattr(ph_hass.config_entries, "async_reload", MagicMock())
+    ph_hass.data.clear()
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    create_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("config_device_id", "entry_unique_id", "marker_device_id"),
+    [
+        pytest.param("dev1", "dev1", "dev2", id="config-mismatch"),
+        pytest.param("dev2", "old-dev", "dev2", id="entry-mismatch"),
+    ],
+)
+async def test_async_setup_entry_rejects_entry_when_marker_and_entry_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    config_device_id: str,
+    entry_unique_id: str,
+    marker_device_id: str,
+) -> None:
+    """Repair marker new-device ID must match both stored config and unique id."""
+    client = _make_valid_setup_client()
+    client.get_device_unique_id = AsyncMock(return_value=config_device_id)
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        init_mod,
+        "create_opnsense_client_from_config_entry",
+        create_client,
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: config_device_id,
+            init_mod.REPAIR_MARKER_KEY: {
+                "version": 1,
+                "old_device_id": "old-dev",
+                "new_device_id": marker_device_id,
+            },
+        },
+        options={},
+        unique_id=entry_unique_id,
+    )
+    forward_entry_setups = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        ph_hass.config_entries,
+        "async_forward_entry_setups",
+        forward_entry_setups,
+    )
+    monkeypatch.setattr(ph_hass.config_entries, "async_reload", MagicMock())
+    ph_hass.data.clear()
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    forward_entry_setups.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cleanup_error", [HomeAssistantError("cleanup"), KeyError("cleanup")])
+async def test_async_setup_entry_keeps_runtime_when_reconciliation_cleanup_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: HomeAssistant,
+    make_config_entry: Callable[..., MockConfigEntry],
+    cleanup_error: HomeAssistantError | KeyError,
+) -> None:
+    """Reconciliation cleanup exceptions should keep runtime state and return False."""
+    client = _make_valid_setup_client()
+    create_client = MagicMock(return_value=client)
+    monkeypatch.setattr(
+        init_mod,
+        "create_opnsense_client_from_config_entry",
+        create_client,
+    )
+    coordinator = _make_setup_coordinator()
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", lambda **_kwargs: coordinator)
+
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: {
+                "version": 1,
+                "old_device_id": "old-dev",
+                "new_device_id": "dev1",
+            },
+        },
+        options={},
+        unique_id="dev1",
+    )
+
+    reconciliation = MagicMock()
+    reconciliation.marker = init_mod.RepairMarker(
+        version=1,
+        old_device_id="old-dev",
+        new_device_id="dev1",
+    )
+    reconciliation.require_platforms_complete = MagicMock(
+        side_effect=init_mod.RepairReconciliationError("platforms incomplete")
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    monkeypatch.setattr(
+        init_mod,
+        "_cleanup_reconciliation_failure",
+        AsyncMock(side_effect=cleanup_error),
+    )
+    forward_entry_setups = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        ph_hass.config_entries,
+        "async_forward_entry_setups",
+        forward_entry_setups,
+    )
+    monkeypatch.setattr(ph_hass.config_entries, "async_reload", MagicMock())
+    ph_hass.data.clear()
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.coordinator is coordinator
+    assert entry.runtime_data.opnsense_client is client
+    assert ph_hass.data[init_mod.DOMAIN][entry.entry_id] is client
+    coordinator.async_shutdown.assert_not_awaited()
+    client.async_close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_registers_update_listener_after_forwarding(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4084,13 +4084,14 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
     assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
 
 
-@pytest.mark.asyncio
-async def test_reconciliation_cleanup_unload_false_keeps_runtime_state_for_platforms(
+async def _run_reconciliation_cleanup_unload(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    unload_result: bool | BaseException,
+    preserve_runtime: bool,
 ) -> None:
-    """Failure to unload platforms during reconciliation cleanup must preserve runtime state."""
+    """Run a reconciliation cleanup attempt with a configurable unload outcome."""
     client = _make_valid_setup_client()
     monkeypatch.setattr(
         init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
@@ -4122,137 +4123,59 @@ async def test_reconciliation_cleanup_unload_false_keeps_runtime_state_for_platf
     )
     monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
     ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+    if isinstance(unload_result, BaseException):
+        ph_hass.config_entries.async_unload_platforms = AsyncMock(side_effect=unload_result)
+    else:
+        ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=unload_result)
     ph_hass.data = {}
 
     result = await init_mod.async_setup_entry(ph_hass, entry)
 
     assert result is False
     ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
-    assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator is coordinator
-    assert entry.runtime_data.opnsense_client is client
-    assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
-    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
-    coordinator.async_shutdown.assert_not_awaited()
-    tracker_coordinator.async_shutdown.assert_not_awaited()
-    client.async_close.assert_not_awaited()
-    assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
+    if preserve_runtime:
+        assert entry.runtime_data is not None
+        assert entry.runtime_data.coordinator is coordinator
+        assert entry.runtime_data.opnsense_client is client
+        assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
+        assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+        coordinator.async_shutdown.assert_not_awaited()
+        tracker_coordinator.async_shutdown.assert_not_awaited()
+        client.async_close.assert_not_awaited()
+        assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
+    else:
+        coordinator.async_shutdown.assert_awaited_once()
+        tracker_coordinator.async_shutdown.assert_awaited_once()
+        client.async_close.assert_awaited_once()
+        assert entry.runtime_data is None
+        assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "unload_error",
+    ("unload_result", "preserve_runtime"),
     [
-        pytest.param(HomeAssistantError("unload failed"), id="homeassistant-error"),
-        pytest.param(KeyError("entry key"), id="key-error"),
+        (pytest.param(False, True, id="unload-false-preserves-runtime")),
+        (pytest.param(HomeAssistantError("unload failed"), True, id="homeassistant-error")),
+        (pytest.param(KeyError("entry key"), True, id="key-error")),
+        (pytest.param(True, False, id="unload-success-tears-down-runtime")),
     ],
 )
-async def test_reconciliation_cleanup_unload_exception_keeps_runtime_state_for_platforms(
-    monkeypatch: pytest.MonkeyPatch,
-    ph_hass: Any,
-    make_config_entry: Callable[..., MockConfigEntry],
-    unload_error: BaseException,
-) -> None:
-    """A handled unload exception should preserve reconciliation runtime state."""
-    client = _make_valid_setup_client()
-    monkeypatch.setattr(
-        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
-    )
-    coordinator = _make_setup_coordinator()
-    tracker_coordinator = _make_setup_coordinator()
-    coordinators: list[Any] = [coordinator, tracker_coordinator]
-
-    def _coordinator_factory(**_kwargs: Any) -> Any:
-        """Return the base and tracker coordinators in setup order."""
-        return coordinators.pop(0)
-
-    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
-    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
-    entry = make_config_entry(
-        data={
-            CONF_URL: "http://1.2.3.4",
-            CONF_USERNAME: "u",
-            CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
-        },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
-        unique_id="dev1",
-    )
-    reconciliation = MagicMock()
-    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
-        "platforms still loading"
-    )
-    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
-    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    ph_hass.config_entries.async_unload_platforms = AsyncMock(side_effect=unload_error)
-    ph_hass.data = {}
-
-    result = await init_mod.async_setup_entry(ph_hass, entry)
-
-    assert result is False
-    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
-    assert entry.runtime_data is not None
-    assert entry.runtime_data.coordinator is coordinator
-    assert entry.runtime_data.opnsense_client is client
-    assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
-    assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
-    coordinator.async_shutdown.assert_not_awaited()
-    tracker_coordinator.async_shutdown.assert_not_awaited()
-    client.async_close.assert_not_awaited()
-
-
 @pytest.mark.asyncio
-async def test_reconciliation_cleanup_unload_success_still_performs_teardown(
+async def test_reconciliation_cleanup_unload_outcomes(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,
     make_config_entry: Callable[..., MockConfigEntry],
+    unload_result: bool | BaseException,
+    preserve_runtime: bool,
 ) -> None:
-    """Successful cleanup should return false and still run the normal teardown path."""
-    client = _make_valid_setup_client()
-    monkeypatch.setattr(
-        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    """Reconciliation cleanup handles unload outcomes with explicit runtime lifecycle expectations."""
+    await _run_reconciliation_cleanup_unload(
+        monkeypatch=monkeypatch,
+        ph_hass=ph_hass,
+        make_config_entry=make_config_entry,
+        unload_result=unload_result,
+        preserve_runtime=preserve_runtime,
     )
-    coordinator = _make_setup_coordinator()
-    tracker_coordinator = _make_setup_coordinator()
-    coordinators: list[Any] = [coordinator, tracker_coordinator]
-
-    def _coordinator_factory(**_kwargs: Any) -> Any:
-        """Return the base and tracker coordinators in setup order."""
-        return coordinators.pop(0)
-
-    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
-    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
-    entry = make_config_entry(
-        data={
-            CONF_URL: "http://1.2.3.4",
-            CONF_USERNAME: "u",
-            CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
-            init_mod.REPAIR_MARKER_KEY: marker,
-        },
-        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
-        unique_id="dev1",
-    )
-    reconciliation = MagicMock()
-    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
-        "platforms still loading"
-    )
-    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
-    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
-    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
-    ph_hass.data = {}
-
-    result = await init_mod.async_setup_entry(ph_hass, entry)
-
-    assert result is False
-    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
-    coordinator.async_shutdown.assert_awaited_once()
-    tracker_coordinator.async_shutdown.assert_awaited_once()
-    client.async_close.assert_awaited_once()
-    assert entry.runtime_data is None
-    assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
 
 
 @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -176,7 +176,7 @@ async def test_async_setup_entry_validates_client_before_probes(
     client.validate = AsyncMock(side_effect=lambda: probe_calls.append("validate"))
 
     async def _get_device_unique_id(expected_id: str | None = None) -> str:
-        """Return test router device id after recording probe ordering."""
+        """Return test router Device ID after recording probe ordering."""
         probe_calls.append("get_device_unique_id")
         return "dev1"
 
@@ -885,7 +885,7 @@ async def test_async_setup_entry_continues_after_firmware_validation_error(
     client.async_close = AsyncMock(return_value=True)
 
     async def _get_device_unique_id(expected_id: str | None = None) -> str:
-        """Return test router device id after recording probe ordering."""
+        """Return test router Device ID after recording probe ordering."""
         probe_calls.append("get_device_unique_id")
         return "dev1"
 
@@ -943,12 +943,12 @@ async def test_async_setup_entry_continues_after_missing_device_unique_id_valida
     client = MagicMock()
     client.name = "test-router"
     client.validate = AsyncMock(
-        side_effect=init_mod.OPNsenseMissingDeviceUniqueID("unable to determine device id")
+        side_effect=init_mod.OPNsenseMissingDeviceUniqueID("unable to determine Device ID")
     )
     client.async_close = AsyncMock(return_value=True)
 
     async def _get_device_unique_id(expected_id: str | None = None) -> str:
-        """Return test router device id after recording probe ordering."""
+        """Return test router Device ID after recording probe ordering."""
         probe_calls.append("get_device_unique_id")
         return "dev1"
 
@@ -1046,7 +1046,7 @@ async def test_async_setup_entry_device_id_mismatch(
     issue_kwargs: dict[str, Any] = {}
 
     def _capture_issue(**kwargs: Any) -> None:
-        """Capture the startup device-ID repair issue payload."""
+        """Capture the startup Device ID repair issue payload."""
         issue_kwargs.update(kwargs)
 
     monkeypatch.setattr(init_mod.ir, "async_create_issue", _capture_issue)
@@ -2809,7 +2809,7 @@ async def test_async_setup_entry_firmware_below_min(
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """async_setup_entry returns False for devices with firmware below minimum supported."""
-    # fake client where device id matches but firmware is below min
+    # fake client where Device ID matches but firmware is below min
     patch_opnsense_client(monkeypatch, init_mod, fake_client(firmware_version="1.0"))
     monkeypatch.setattr(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(fake_coordinator)
@@ -2882,7 +2882,7 @@ async def test_async_setup_entry_firmware_between_min_and_ltd(
 async def test_migrate_2_to_3_missing_device_id(
     monkeypatch: pytest.MonkeyPatch, fake_client: Any
 ) -> None:
-    """_migrate_2_to_3 returns False when the client provides no device id."""
+    """_migrate_2_to_3 returns False when the client provides no Device ID."""
     client = fake_client(device_id=None)()
     cfg = MagicMock()
     cfg.data = {
@@ -2903,7 +2903,7 @@ async def test_migrate_2_to_3_missing_device_id(
 
 @pytest.mark.asyncio
 async def test_migrate_2_to_3_success(monkeypatch: pytest.MonkeyPatch, fake_client: Any) -> None:
-    """_migrate_2_to_3 updates device and entity identifiers when client reports new device id."""
+    """_migrate_2_to_3 updates device and entity identifiers when client reports new Device ID."""
     client = fake_client(device_id="newdev")()
 
     # fake device entries and entity entries
@@ -3051,7 +3051,7 @@ async def test_async_setup_entry_awesomeversion_exception(
 ) -> None:
     """async_setup_entry should continue when AwesomeVersion comparison raises an exception."""
 
-    # fake client where device id matches but awesomeversion comparison raises
+    # fake client where Device ID matches but awesomeversion comparison raises
     # monkeypatch AwesomeVersion to a class that raises on comparison
     class DummyAV:
         """AwesomeVersion replacement that raises on comparisons."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4085,6 +4085,236 @@ async def test_reconciliation_incomplete_platform_does_not_finalize_or_clear_mar
 
 
 @pytest.mark.asyncio
+async def test_reconciliation_cleanup_unload_false_keeps_runtime_state_for_platforms(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Failure to unload platforms during reconciliation cleanup must preserve runtime state."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    tracker_coordinator = _make_setup_coordinator()
+    coordinators: list[Any] = [coordinator, tracker_coordinator]
+
+    def _coordinator_factory(**_kwargs: Any) -> Any:
+        """Return the base and tracker coordinators in setup order."""
+        return coordinators.pop(0)
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+        "platforms still loading"
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.coordinator is coordinator
+    assert entry.runtime_data.opnsense_client is client
+    assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
+    assert entry.data[init_mod.REPAIR_MARKER_KEY] == marker
+    coordinator.async_shutdown.assert_not_awaited()
+    tracker_coordinator.async_shutdown.assert_not_awaited()
+    client.async_close.assert_not_awaited()
+    assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unload_error",
+    [
+        pytest.param(HomeAssistantError("unload failed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry key"), id="key-error"),
+    ],
+)
+async def test_reconciliation_cleanup_unload_exception_keeps_runtime_state_for_platforms(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+    unload_error: BaseException,
+) -> None:
+    """A handled unload exception should preserve reconciliation runtime state."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    tracker_coordinator = _make_setup_coordinator()
+    coordinators: list[Any] = [coordinator, tracker_coordinator]
+
+    def _coordinator_factory(**_kwargs: Any) -> Any:
+        """Return the base and tracker coordinators in setup order."""
+        return coordinators.pop(0)
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+        "platforms still loading"
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(side_effect=unload_error)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
+    assert entry.runtime_data is not None
+    assert entry.runtime_data.coordinator is coordinator
+    assert entry.runtime_data.opnsense_client is client
+    assert entry.runtime_data.device_tracker_coordinator is tracker_coordinator
+    assert ph_hass.data.get(init_mod.DOMAIN, {}).get(entry.entry_id) is client
+    coordinator.async_shutdown.assert_not_awaited()
+    tracker_coordinator.async_shutdown.assert_not_awaited()
+    client.async_close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_cleanup_unload_success_still_performs_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Successful cleanup should return false and still run the normal teardown path."""
+    client = _make_valid_setup_client()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", lambda **_kwargs: client
+    )
+    coordinator = _make_setup_coordinator()
+    tracker_coordinator = _make_setup_coordinator()
+    coordinators: list[Any] = [coordinator, tracker_coordinator]
+
+    def _coordinator_factory(**_kwargs: Any) -> Any:
+        """Return the base and tracker coordinators in setup order."""
+        return coordinators.pop(0)
+
+    monkeypatch.setattr(init_mod, "OPNsenseDataUpdateCoordinator", _coordinator_factory)
+    marker = {"version": 1, "old_device_id": "old-dev", "new_device_id": "dev1"}
+    entry = make_config_entry(
+        data={
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+            init_mod.CONF_DEVICE_UNIQUE_ID: "dev1",
+            init_mod.REPAIR_MARKER_KEY: marker,
+        },
+        options={init_mod.CONF_DEVICE_TRACKER_ENABLED: True},
+        unique_id="dev1",
+    )
+    reconciliation = MagicMock()
+    reconciliation.require_platforms_complete.side_effect = init_mod.RepairReconciliationError(
+        "platforms still loading"
+    )
+    monkeypatch.setattr(init_mod, "RepairReconciliation", lambda *_args: reconciliation)
+    ph_hass.config_entries.async_forward_entry_setups = AsyncMock(return_value=True)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    ph_hass.data = {}
+
+    result = await init_mod.async_setup_entry(ph_hass, entry)
+
+    assert result is False
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
+    coordinator.async_shutdown.assert_awaited_once()
+    tracker_coordinator.async_shutdown.assert_awaited_once()
+    client.async_close.assert_awaited_once()
+    assert entry.runtime_data is None
+    assert entry.entry_id not in ph_hass.data.get(init_mod.DOMAIN, {})
+
+
+@pytest.mark.asyncio
+async def test_unload_setup_platforms_after_reconciliation_failure_returns_false_on_platform_unload_failure(
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """A platform unload failure should be surfaced as a failed cleanup result."""
+    entry = make_config_entry()
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+
+    result = await init_mod._unload_setup_platforms_after_reconciliation_failure(
+        ph_hass, entry, ["sensor"]
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_unload_setup_platforms_after_reconciliation_failure_returns_false_on_unload_exception(
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Unloading exceptions should be converted into a false cleanup outcome."""
+    entry = make_config_entry()
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(
+        side_effect=HomeAssistantError("unload error")
+    )
+
+    result = await init_mod._unload_setup_platforms_after_reconciliation_failure(
+        ph_hass, entry, ["sensor"]
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_reconciliation_failure_returns_platform_unload_result(
+    monkeypatch: pytest.MonkeyPatch,
+    ph_hass: Any,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Marker creation should precede unload and the helper should return its unload result."""
+    entry = make_config_entry()
+    repair_marker = MagicMock()
+    repair_marker.old_device_id = "old-dev"
+    repair_marker.new_device_id = "new-dev"
+    issue_create = MagicMock()
+    monkeypatch.setattr(init_mod.ir, "async_create_issue", issue_create)
+    ph_hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    result = await init_mod._cleanup_reconciliation_failure(
+        ph_hass,
+        entry,
+        ["sensor"],
+        repair_marker,
+    )
+
+    assert result is True
+    issue_create.assert_called_once()
+    ph_hass.config_entries.async_unload_platforms.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_reconciliation_marker_clear_false_retains_marker(
     monkeypatch: pytest.MonkeyPatch,
     ph_hass: Any,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,14 +23,22 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.const import CONF_NAME, CONF_PASSWORD, CONF_URL, CONF_USERNAME, CONF_VERIFY_SSL
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.opnsense as init_mod
-from custom_components.opnsense import config_flow as cf_mod
+from custom_components.opnsense import (
+    _async_update_listener,
+    async_migrate_entry,
+    async_setup_entry,
+    async_unload_entry,
+    config_flow as cf_mod,
+)
 from custom_components.opnsense.config_flow import (
     CONF_DEVICE_TRACKING_MODE,
     DEVICE_TRACKING_MODE_SELECTED,
+    OPNsenseConfigFlow,
 )
 from custom_components.opnsense.const import (
     CONF_DEVICE_TRACKER_ENABLED,
@@ -299,7 +307,7 @@ async def test_e2e_basic_config_flow_and_setup(
         cf_mod, "async_create_clientsession", lambda **k: MagicMock(), raising=False
     )
 
-    flow = cf_mod.OPNsenseConfigFlow()
+    flow = OPNsenseConfigFlow()
     hass = _build_mock_hass()
     flow.hass = hass
 
@@ -343,7 +351,7 @@ async def test_e2e_basic_config_flow_and_setup(
     entry.async_on_unload = lambda x: None
     hass.data = {}
 
-    ok = await init_mod.async_setup_entry(hass, entry)
+    ok = await async_setup_entry(hass, entry)
     assert ok is True
     # hass.data should contain stored client under domain/entry_id
     assert DOMAIN in hass.data
@@ -374,7 +382,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
         cf_mod, "async_create_clientsession", lambda **k: MagicMock(), raising=False
     )
 
-    flow = cf_mod.OPNsenseConfigFlow()
+    flow = OPNsenseConfigFlow()
     hass = _build_mock_hass()
     flow.hass = hass
 
@@ -433,9 +441,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
         hass.config_entries.async_get_known_entry = _get_known_entry
 
     # Options flow path
-    opt_flow = cf_mod.OPNsenseConfigFlow.async_get_options_flow(
-        entry
-    )  # returns OPNsenseOptionsFlow
+    opt_flow = OPNsenseConfigFlow.async_get_options_flow(entry)  # returns OPNsenseOptionsFlow
     opt_flow.hass = hass
     opt_flow.handler = entry.entry_id
     # initial options step: enable device tracker & granular sync
@@ -473,7 +479,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
         init_mod, "OPNsenseDataUpdateCoordinator", coordinator_capture.factory(_FakeCoordinator)
     )
 
-    ok = await init_mod.async_setup_entry(hass, entry)
+    ok = await async_setup_entry(hass, entry)
     assert ok is True
     # Expect two coordinators: main + device tracker
     assert len(coordinator_capture.instances) == 2
@@ -499,7 +505,7 @@ async def test_e2e_reload_and_unload(
         cf_mod, "async_create_clientsession", lambda **k: MagicMock(), raising=False
     )
 
-    flow = cf_mod.OPNsenseConfigFlow()
+    flow = OPNsenseConfigFlow()
     hass = _build_mock_hass()
     flow.hass = hass
 
@@ -539,27 +545,23 @@ async def test_e2e_reload_and_unload(
     entry.async_on_unload = lambda x: None
 
     # Setup
-    ok = await init_mod.async_setup_entry(hass, entry)
+    ok = await async_setup_entry(hass, entry)
     assert ok is True
     assert entry.entry_id in hass.data[DOMAIN]
 
     # Patch registries for update listener (return no entities/devices)
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.er, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: MagicMock())
-    monkeypatch.setattr(
-        init_mod.dr, "async_entries_for_config_entry", lambda registry, config_entry_id: []
-    )
+    monkeypatch.setattr(er, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(er, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
+    monkeypatch.setattr(dr, "async_get", lambda hass: MagicMock())
+    monkeypatch.setattr(dr, "async_entries_for_config_entry", lambda registry, config_entry_id: [])
 
     # Trigger update listener -> should schedule reload
     setattr(entry.runtime_data, SHOULD_RELOAD, True)
-    await init_mod._async_update_listener(hass, entry)
+    await _async_update_listener(hass, entry)
     assert hass.config_entries.async_reload.call_count == 1
 
     # Unload
-    res_unload = await init_mod.async_unload_entry(hass, entry)
+    res_unload = await async_unload_entry(hass, entry)
     assert res_unload is True
     assert entry.entry_id not in hass.data[DOMAIN]
     assert runtime_client._closed is True
@@ -706,15 +708,15 @@ async def test_e2e_full_migration_chain(
     fake_entity_reg = FakeEntityRegistry()
 
     # Monkeypatch registry access/functions used in migration helpers
-    monkeypatch.setattr(init_mod.dr, "async_get", lambda hass: fake_device_reg)
-    monkeypatch.setattr(init_mod.er, "async_get", lambda hass: fake_entity_reg)
+    monkeypatch.setattr(dr, "async_get", lambda hass: fake_device_reg)
+    monkeypatch.setattr(er, "async_get", lambda hass: fake_entity_reg)
     monkeypatch.setattr(
-        init_mod.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: list(fake_device_reg._devices),
     )
     monkeypatch.setattr(
-        init_mod.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, config_entry_id: list(fake_entity_reg._entities.values()),
     )
@@ -772,7 +774,7 @@ async def test_e2e_full_migration_chain(
     )
 
     # Run full migration
-    ok = await init_mod.async_migrate_entry(hass, entry)
+    ok = await async_migrate_entry(hass, entry)
     assert ok is True
     assert entry.version == 5
     assert len(migration_clients) == 1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -477,7 +477,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
     assert ok is True
     # Expect two coordinators: main + device tracker
     assert len(coordinator_capture.instances) == 2
-    assert any(c._device_tracker for c in coordinator_capture.instances)
+    assert entry.runtime_data.device_tracker_coordinator in coordinator_capture.instances
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,12 +28,19 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 import custom_components.opnsense as init_mod
 from custom_components.opnsense import config_flow as cf_mod
+from custom_components.opnsense.config_flow import (
+    CONF_DEVICE_TRACKING_MODE,
+    DEVICE_TRACKING_MODE_SELECTED,
+)
 from custom_components.opnsense.const import (
+    CONF_DEVICE_TRACKER_ENABLED,
     CONF_DEVICE_UNIQUE_ID,
     CONF_DEVICES,
     CONF_GRANULAR_SYNC_OPTIONS,
     CONF_MANUAL_DEVICES,
     CONF_TLS_INSECURE,
+    DOMAIN,
+    SHOULD_RELOAD,
 )
 from tests.utilities import patch_opnsense_client
 
@@ -339,8 +346,8 @@ async def test_e2e_basic_config_flow_and_setup(
     ok = await init_mod.async_setup_entry(hass, entry)
     assert ok is True
     # hass.data should contain stored client under domain/entry_id
-    assert init_mod.DOMAIN in hass.data
-    assert entry.entry_id in hass.data[init_mod.DOMAIN]
+    assert DOMAIN in hass.data
+    assert entry.entry_id in hass.data[DOMAIN]
     # Runtime data should be populated
     assert hasattr(entry, "runtime_data")
     assert getattr(entry.runtime_data, "coordinator", None) is not None
@@ -407,7 +414,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
     entry.async_on_unload = lambda x: None
 
     # Add to fake hass store so options flow update calls can mutate it
-    hass.data.setdefault(init_mod.DOMAIN, {})
+    hass.data.setdefault(DOMAIN, {})
     # Provide async_get_known_entry for options flow compatibility
     if not hasattr(hass.config_entries, "async_get_known_entry"):
         hass.config_entries._entries = {entry.entry_id: entry}
@@ -434,7 +441,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
     # initial options step: enable device tracker & granular sync
     opt_init = await opt_flow.async_step_init(
         user_input={
-            cf_mod.CONF_DEVICE_TRACKING_MODE: cf_mod.DEVICE_TRACKING_MODE_SELECTED,
+            CONF_DEVICE_TRACKING_MODE: DEVICE_TRACKING_MODE_SELECTED,
             CONF_GRANULAR_SYNC_OPTIONS: True,
         }
     )
@@ -456,7 +463,7 @@ async def test_e2e_granular_sync_and_options_device_tracker(
     # Options merged list should contain unique MACs (order not strictly enforced)
     devices_set = set(entry.options.get(CONF_DEVICES, []))
     assert {"aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66", "77:88:99:aa:bb:cc"}.issubset(devices_set)
-    assert entry.options.get(cf_mod.CONF_DEVICE_TRACKER_ENABLED) is True
+    assert entry.options.get(CONF_DEVICE_TRACKER_ENABLED) is True
 
     # Patch runtime setup components (client + coordinator) to count device tracker coordinator instantiation
     patch_opnsense_client(
@@ -534,7 +541,7 @@ async def test_e2e_reload_and_unload(
     # Setup
     ok = await init_mod.async_setup_entry(hass, entry)
     assert ok is True
-    assert entry.entry_id in hass.data[init_mod.DOMAIN]
+    assert entry.entry_id in hass.data[DOMAIN]
 
     # Patch registries for update listener (return no entities/devices)
     monkeypatch.setattr(init_mod.er, "async_get", lambda hass: MagicMock())
@@ -547,14 +554,14 @@ async def test_e2e_reload_and_unload(
     )
 
     # Trigger update listener -> should schedule reload
-    setattr(entry.runtime_data, init_mod.SHOULD_RELOAD, True)
+    setattr(entry.runtime_data, SHOULD_RELOAD, True)
     await init_mod._async_update_listener(hass, entry)
     assert hass.config_entries.async_reload.call_count == 1
 
     # Unload
     res_unload = await init_mod.async_unload_entry(hass, entry)
     assert res_unload is True
-    assert entry.entry_id not in hass.data[init_mod.DOMAIN]
+    assert entry.entry_id not in hass.data[DOMAIN]
     assert runtime_client._closed is True
     hass.config_entries.async_unload_platforms.assert_awaited_once()
 
@@ -754,7 +761,7 @@ async def test_e2e_full_migration_chain(
             CONF_URL: "https://router.example",
             CONF_USERNAME: "u",
             CONF_PASSWORD: "p",
-            init_mod.CONF_DEVICE_UNIQUE_ID: "oldmacid",
+            CONF_DEVICE_UNIQUE_ID: "oldmacid",
             CONF_TLS_INSECURE: True,
         },
         title="Router",
@@ -774,7 +781,7 @@ async def test_e2e_full_migration_chain(
     assert CONF_TLS_INSECURE not in entry.data
     assert entry.data.get(CONF_VERIFY_SSL) is False
     # v2->3: unique id updated
-    assert entry.data[init_mod.CONF_DEVICE_UNIQUE_ID] == "newmacid"
+    assert entry.data[CONF_DEVICE_UNIQUE_ID] == "newmacid"
     assert entry.unique_id == "newmacid"
     # Device identifiers updated
     main_dev = next(d for d in fake_device_reg._devices if d.id == "dev-main")

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -111,6 +111,13 @@ def _entry(unique_id: str, *, entity_id: str, device_id: str | None = None, **at
     )
 
 
+def _config_entry_with_runtime_data(runtime_data: Any) -> MockConfigEntry:
+    """Create an entry carrying explicit runtime reconciliation wiring."""
+    entry = _other_config_entry("entry-1", "new")
+    object.__setattr__(entry, "runtime_data", runtime_data)
+    return entry
+
+
 def _device(
     device_id: str,
     identifier: str,
@@ -402,3 +409,39 @@ def test_none_authenticates_as_incomplete_platform_discovery() -> None:
 
     with pytest.raises(rr.RepairReconciliationError, match="sensor"):
         reconciliation.require_platforms_complete(("sensor",))
+
+
+def test_record_desired_entities_and_is_reconciliation_active_handle_none_marker() -> None:
+    """None marker should be treated as inactive without raising."""
+    entry = _config_entry_with_runtime_data(SimpleNamespace(repair_reconciliation=None))
+    entity = Entity()
+    entity._attr_unique_id = "new_sensor"
+
+    rr.record_desired_entities(entry, "sensor", [entity])
+    assert rr.is_reconciliation_active(entry) is False
+
+
+def test_record_desired_entities_requires_runtime_marker_attribute() -> None:
+    """Missing repair_reconciliation on runtime_data should now raise."""
+    entry = _config_entry_with_runtime_data(SimpleNamespace())
+    entity = Entity()
+    entity._attr_unique_id = "new_sensor"
+
+    with pytest.raises(AttributeError):
+        rr.record_desired_entities(entry, "sensor", [entity])
+
+
+def test_record_desired_entities_uses_active_reconciliation_state() -> None:
+    """Active reconciliation keeps desired identities and returns active state."""
+    entry = _config_entry_with_runtime_data(SimpleNamespace())
+    entry.runtime_data.repair_reconciliation = rr.RepairReconciliation(
+        MagicMock(), entry, rr.RepairMarker(1, "old", "new")
+    )
+    entity = Entity()
+    entity._attr_unique_id = "new_sensor"
+
+    rr.record_desired_entities(entry, "sensor", [entity])
+    assert rr.is_reconciliation_active(entry) is True
+    assert "new_sensor" in {
+        identity[2] for identity in entry.runtime_data.repair_reconciliation.desired_identities
+    }

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import repair_reconciliation as rr
-from custom_components.opnsense.const import DOMAIN
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
 
 
 class _EntityRegistry:
@@ -71,7 +71,31 @@ class _DeviceRegistry:
             device.identifiers = changes["new_identifiers"]
         if "remove_config_entry_id" in changes:
             device.config_entries.discard(changes["remove_config_entry_id"])
+        if "via_device_id" in changes:
+            device.via_device_id = changes["via_device_id"]
         return device
+
+
+class _ConfigEntries:
+    """Minimal config-entry registry used for shared-router lookup."""
+
+    def __init__(self, entries: dict[str, object]) -> None:
+        self._entries = entries
+
+    def async_get_entry(self, entry_id: str) -> object | None:
+        """Return a stored config entry."""
+        return self._entries.get(entry_id)
+
+
+def _other_config_entry(entry_id: str, unique_id: str) -> MockConfigEntry:
+    """Create a config entry carrying OPNsense device unique identifier."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DEVICE_UNIQUE_ID: unique_id},
+        unique_id=unique_id,
+    )
+    object.__setattr__(entry, "entry_id", entry_id)
+    return entry
 
 
 def _entry(unique_id: str, *, entity_id: str, device_id: str | None = None, **attrs: Any) -> Any:
@@ -92,12 +116,14 @@ def _device(
     identifier: str,
     *,
     config_entries: set[str] | None = None,
+    via_device_id: str | None = None,
 ) -> Any:
     """Create a device-registry stand-in."""
     return SimpleNamespace(
         id=device_id,
         identifiers={(DOMAIN, identifier)},
         config_entries=set(config_entries or {"entry-1"}),
+        via_device_id=via_device_id,
     )
 
 
@@ -105,6 +131,7 @@ def _subject(
     monkeypatch: pytest.MonkeyPatch,
     entities: list[Any],
     devices: list[Any],
+    extra_config_entries: dict[str, MockConfigEntry] | None = None,
 ) -> tuple[rr.RepairReconciliation, _EntityRegistry, _DeviceRegistry]:
     """Create reconciliation with patched mutable registries."""
     entity_registry = _EntityRegistry(entities)
@@ -127,9 +154,12 @@ def _subject(
     )
     entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="new_id")
     object.__setattr__(entry, "entry_id", "entry-1")
-    reconciliation = rr.RepairReconciliation(
-        MagicMock(), entry, rr.RepairMarker(1, "old_id", "new_id")
-    )
+    config_entry_map: dict[str, MockConfigEntry] = {"entry-1": entry}
+    if extra_config_entries:
+        config_entry_map.update(extra_config_entries)
+    hass = MagicMock()
+    hass.config_entries = _ConfigEntries(config_entry_map)
+    reconciliation = rr.RepairReconciliation(hass, entry, rr.RepairMarker(1, "old_id", "new_id"))
     return reconciliation, entity_registry, device_registry
 
 
@@ -280,6 +310,57 @@ def test_prepare_and_finalize_are_idempotent_after_partial_retry(
         "new_id_second",
     }
     assert registry.removed == []
+
+
+def test_finalize_reassigns_shared_tracker_parent_to_remaining_router(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared tracker devices are reparented when another router still owns shared trackers."""
+    stale = _entry("old_id_stale", entity_id="sensor.stale", device_id="shared-device")
+    surviving_entry = _other_config_entry("entry-2", "survivor_router")
+    current_router = _device("current_router", "new_id")
+    surviving_router = _device("survivor_router_id", "survivor_router", config_entries={"entry-2"})
+    shared_tracker = _device(
+        "shared-device",
+        "shared-tracker",
+        config_entries={"entry-1", "entry-2"},
+    )
+    shared_tracker.via_device_id = current_router.id
+
+    reconciliation, _, devices = _subject(
+        monkeypatch,
+        [stale],
+        [current_router, surviving_router, shared_tracker],
+        extra_config_entries={"entry-2": surviving_entry},
+    )
+    reconciliation.prepare()
+
+    reconciliation.finalize()
+
+    assert (
+        "shared-device",
+        {"remove_config_entry_id": "entry-1", "via_device_id": "survivor_router_id"},
+    ) in devices.updates
+
+
+def test_finalize_clears_parent_from_shared_tracker_when_no_replacement_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared tracker parent reference is cleared when no surviving router can be resolved."""
+    stale = _entry("old_id_stale", entity_id="sensor.stale", device_id="shared-device")
+    current_router = _device("current_router", "new_id")
+    shared_tracker = _device("shared-device", "shared-tracker", config_entries={"entry-1"})
+    shared_tracker.via_device_id = current_router.id
+
+    reconciliation, _, devices = _subject(monkeypatch, [stale], [current_router, shared_tracker])
+    reconciliation.prepare()
+
+    reconciliation.finalize()
+
+    assert (
+        "shared-device",
+        {"remove_config_entry_id": "entry-1", "via_device_id": None},
+    ) in devices.updates
 
 
 def test_records_all_final_platform_lists_including_disabled_entities() -> None:

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -1,4 +1,4 @@
-"""Tests for restart-safe device-ID repair reconciliation."""
+"""Tests for restart-safe Device ID repair reconciliation."""
 
 from collections.abc import Callable
 from types import SimpleNamespace

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -12,6 +12,17 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import repair_reconciliation as rr
 from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from custom_components.opnsense.repair_reconciliation import (
+    REPAIR_MARKER_KEY,
+    RepairMarker,
+    RepairReconciliation,
+    RepairReconciliationError,
+    build_repair_marker,
+    has_repair_marker,
+    is_reconciliation_active,
+    parse_repair_marker,
+    record_desired_entities,
+)
 
 
 class _EntityRegistry:
@@ -157,7 +168,7 @@ def _subject(
     entities: list[Any],
     devices: list[Any],
     extra_config_entries: dict[str, MockConfigEntry] | None = None,
-) -> tuple[rr.RepairReconciliation, _EntityRegistry, _DeviceRegistry]:
+) -> tuple[RepairReconciliation, _EntityRegistry, _DeviceRegistry]:
     """Create reconciliation with patched mutable registries."""
     entity_registry = _EntityRegistry(entities)
     device_registry = _DeviceRegistry(devices)
@@ -184,7 +195,7 @@ def _subject(
         config_entry_map.update(extra_config_entries)
     hass = MagicMock()
     hass.config_entries = _ConfigEntries(config_entry_map)
-    reconciliation = rr.RepairReconciliation(hass, entry, rr.RepairMarker(1, "old_id", "new_id"))
+    reconciliation = RepairReconciliation(hass, entry, RepairMarker(1, "old_id", "new_id"))
     return reconciliation, entity_registry, device_registry
 
 
@@ -203,20 +214,20 @@ def _subject(
 )
 def test_parse_repair_marker_rejects_invalid_values(value: object) -> None:
     """Malformed markers must never start reconciliation."""
-    entry = MockConfigEntry(domain=DOMAIN, data={rr.REPAIR_MARKER_KEY: value})
+    entry = MockConfigEntry(domain=DOMAIN, data={REPAIR_MARKER_KEY: value})
 
-    assert rr.has_repair_marker(entry)
-    assert rr.parse_repair_marker(entry) is None
+    assert has_repair_marker(entry)
+    assert parse_repair_marker(entry) is None
 
 
 def test_parse_repair_marker_accepts_current_marker() -> None:
     """A current complete marker is parsed exactly."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={rr.REPAIR_MARKER_KEY: rr.build_repair_marker("old", "new")},
+        data={REPAIR_MARKER_KEY: build_repair_marker("old", "new")},
     )
 
-    assert rr.parse_repair_marker(entry) == rr.RepairMarker(1, "old", "new")
+    assert parse_repair_marker(entry) == RepairMarker(1, "old", "new")
 
 
 def test_prepare_migrates_exact_prefix_in_place_and_preserves_metadata(
@@ -251,7 +262,7 @@ def test_prepare_rejects_full_identity_collision(monkeypatch: pytest.MonkeyPatch
     collision = _entry("new_id_status", entity_id="sensor.other")
     reconciliation, _, _ = _subject(monkeypatch, [candidate, collision], [])
 
-    with pytest.raises(rr.RepairReconciliationError, match="entity target collision"):
+    with pytest.raises(RepairReconciliationError, match="entity target collision"):
         reconciliation.prepare()
 
 
@@ -272,12 +283,12 @@ def test_prepare_migrates_primary_device_or_rejects_foreign_collision(
 
     foreign = _device("foreign", "new_id", config_entries={"entry-2"})
     reconciliation, _, _ = _subject(monkeypatch, [], [foreign])
-    with pytest.raises(rr.RepairReconciliationError, match="primary device"):
+    with pytest.raises(RepairReconciliationError, match="primary device"):
         reconciliation.prepare()
 
     simultaneous = _device("target", "new_id")
     reconciliation, _, _ = _subject(monkeypatch, [], [_device("source", "old_id"), simultaneous])
-    with pytest.raises(rr.RepairReconciliationError, match="primary device"):
+    with pytest.raises(RepairReconciliationError, match="primary device"):
         reconciliation.prepare()
 
 
@@ -404,7 +415,7 @@ def test_prepare_wraps_registry_identifier_migration_failure(
     )
 
     with pytest.raises(
-        rr.RepairReconciliationError, match="registry identifier migration failed"
+        RepairReconciliationError, match="registry identifier migration failed"
     ) as err:
         reconciliation.prepare()
     assert isinstance(err.value.__cause__, expected)
@@ -430,7 +441,7 @@ def test_finalize_wraps_detach_failure_as_registry_error(
         lambda *args, **kwargs: (_ for _ in ()).throw(KeyError("detach shared tracker")),
     )
 
-    with pytest.raises(rr.RepairReconciliationError, match="registry finalization failed") as err:
+    with pytest.raises(RepairReconciliationError, match="registry finalization failed") as err:
         reconciliation.finalize()
     assert isinstance(err.value.__cause__, KeyError)
     assert device_registry.updates == []
@@ -438,10 +449,10 @@ def test_finalize_wraps_detach_failure_as_registry_error(
 
 def test_mark_complete_deactivates() -> None:
     """Finishing reconciliation disables active state."""
-    reconciliation = rr.RepairReconciliation(
+    reconciliation = RepairReconciliation(
         MagicMock(),
         _other_config_entry("entry-1", "old"),
-        rr.RepairMarker(1, "old", "new"),
+        RepairMarker(1, "old", "new"),
     )
     assert reconciliation.active is True
 
@@ -503,9 +514,7 @@ def test_finalize_clears_parent_from_shared_tracker_when_no_replacement_exists(
 
 def test_records_all_final_platform_lists_including_disabled_entities() -> None:
     """Every forwarded platform contributes its complete final identity list."""
-    reconciliation = rr.RepairReconciliation(
-        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
-    )
+    reconciliation = RepairReconciliation(MagicMock(), MagicMock(), RepairMarker(1, "old", "new"))
     for platform in ("binary_sensor", "sensor", "switch", "update", "device_tracker"):
         entity = Entity()
         entity._attr_unique_id = f"new_{platform}"
@@ -522,23 +531,19 @@ def test_records_all_final_platform_lists_including_disabled_entities() -> None:
 
 def test_incomplete_platform_lists_block_finalization() -> None:
     """Missing a forwarded platform completion is a hard reconciliation failure."""
-    reconciliation = rr.RepairReconciliation(
-        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
-    )
+    reconciliation = RepairReconciliation(MagicMock(), MagicMock(), RepairMarker(1, "old", "new"))
     reconciliation.record_desired_entities("sensor", [])
 
-    with pytest.raises(rr.RepairReconciliationError, match="binary_sensor"):
+    with pytest.raises(RepairReconciliationError, match="binary_sensor"):
         reconciliation.require_platforms_complete(("sensor", "binary_sensor"))
 
 
 def test_none_authenticates_as_incomplete_platform_discovery() -> None:
     """Missing or malformed payloads keep a platform from being marked complete."""
-    reconciliation = rr.RepairReconciliation(
-        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
-    )
+    reconciliation = RepairReconciliation(MagicMock(), MagicMock(), RepairMarker(1, "old", "new"))
     reconciliation.record_desired_entities("sensor", None)
 
-    with pytest.raises(rr.RepairReconciliationError, match="sensor"):
+    with pytest.raises(RepairReconciliationError, match="sensor"):
         reconciliation.require_platforms_complete(("sensor",))
 
 
@@ -548,8 +553,8 @@ def test_record_desired_entities_and_is_reconciliation_active_handle_none_marker
     entity = Entity()
     entity._attr_unique_id = "new_sensor"
 
-    rr.record_desired_entities(entry, "sensor", [entity])
-    assert rr.is_reconciliation_active(entry) is False
+    record_desired_entities(entry, "sensor", [entity])
+    assert is_reconciliation_active(entry) is False
 
 
 def test_record_desired_entities_requires_runtime_marker_attribute() -> None:
@@ -559,20 +564,20 @@ def test_record_desired_entities_requires_runtime_marker_attribute() -> None:
     entity._attr_unique_id = "new_sensor"
 
     with pytest.raises(AttributeError):
-        rr.record_desired_entities(entry, "sensor", [entity])
+        record_desired_entities(entry, "sensor", [entity])
 
 
 def test_record_desired_entities_uses_active_reconciliation_state() -> None:
     """Active reconciliation keeps desired identities and returns active state."""
     entry = _config_entry_with_runtime_data(SimpleNamespace())
-    entry.runtime_data.repair_reconciliation = rr.RepairReconciliation(
-        MagicMock(), entry, rr.RepairMarker(1, "old", "new")
+    entry.runtime_data.repair_reconciliation = RepairReconciliation(
+        MagicMock(), entry, RepairMarker(1, "old", "new")
     )
     entity = Entity()
     entity._attr_unique_id = "new_sensor"
 
-    rr.record_desired_entities(entry, "sensor", [entity])
-    assert rr.is_reconciliation_active(entry) is True
+    record_desired_entities(entry, "sensor", [entity])
+    assert is_reconciliation_active(entry) is True
     assert "new_sensor" in {
         identity[2] for identity in entry.runtime_data.repair_reconciliation.desired_identities
     }

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -89,6 +89,20 @@ class _ConfigEntries:
         return self._entries.get(entry_id)
 
 
+class _DesiredTrackerEntity(Entity):
+    """Minimal desired tracker entity carrying a MAC connection identity."""
+
+    def __init__(self, unique_id: str, mac_address: str) -> None:
+        """Initialize the desired tracker identity."""
+        self._attr_unique_id = unique_id
+        self._mac_address = mac_address
+
+    @property
+    def mac_address(self) -> str:
+        """Return the tracker MAC address."""
+        return self._mac_address
+
+
 def _other_config_entry(entry_id: str, unique_id: str) -> MockConfigEntry:
     """Create a config entry carrying OPNsense device unique identifier."""
     entry = MockConfigEntry(
@@ -126,6 +140,7 @@ def _device(
     *,
     config_entries: set[str] | None = None,
     via_device_id: str | None = None,
+    connections: set[tuple[str, str]] | None = None,
 ) -> Any:
     """Create a device-registry stand-in."""
     return SimpleNamespace(
@@ -133,6 +148,7 @@ def _device(
         identifiers={(DOMAIN, identifier)},
         config_entries=set(config_entries or {"entry-1"}),
         via_device_id=via_device_id,
+        connections=set(connections or set()),
     )
 
 
@@ -295,6 +311,42 @@ def test_finalize_removes_only_stale_snapshot_and_preserves_device_associations(
         device_id for device_id, changes in devices.updates if "remove_config_entry_id" in changes
     ]
     assert all(device_id not in {"main", "used"} for device_id in removals)
+
+
+def test_finalize_preserves_desired_disabled_tracker_device_by_mac(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A desired disabled tracker keeps its MAC device without an entity device ID."""
+    tracker = _entry(
+        "old_id_mac_aa_bb_cc_dd_ee_ff",
+        entity_id="device_tracker.disabled_tracker",
+        device_id=None,
+    )
+    main = _device("main", "old_id")
+    tracked_device = _device(
+        "tracked-device",
+        "tracked-client",
+        via_device_id=main.id,
+        connections={("mac", "aa:bb:cc:dd:ee:ff")},
+    )
+    reconciliation, _, devices = _subject(
+        monkeypatch,
+        [tracker],
+        [main, tracked_device],
+    )
+    reconciliation.prepare()
+    desired_tracker = _DesiredTrackerEntity(
+        "new_id_mac_aa_bb_cc_dd_ee_ff",
+        "aa:bb:cc:dd:ee:ff",
+    )
+    reconciliation.record_desired_entities("device_tracker", [desired_tracker])
+
+    reconciliation.finalize()
+
+    assert all(
+        not (device_id == tracked_device.id and changes.get("remove_config_entry_id") == "entry-1")
+        for device_id, changes in devices.updates
+    )
 
 
 def test_prepare_and_finalize_are_idempotent_after_partial_retry(

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -391,3 +391,14 @@ def test_incomplete_platform_lists_block_finalization() -> None:
 
     with pytest.raises(rr.RepairReconciliationError, match="binary_sensor"):
         reconciliation.require_platforms_complete(("sensor", "binary_sensor"))
+
+
+def test_none_authenticates_as_incomplete_platform_discovery() -> None:
+    """Missing or malformed payloads keep a platform from being marked complete."""
+    reconciliation = rr.RepairReconciliation(
+        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
+    )
+    reconciliation.record_desired_entities("sensor", None)
+
+    with pytest.raises(rr.RepairReconciliationError, match="sensor"):
+        reconciliation.require_platforms_complete(("sensor",))

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -292,6 +292,41 @@ def test_prepare_migrates_primary_device_or_rejects_foreign_collision(
         reconciliation.prepare()
 
 
+def test_prepare_keeps_all_identifiers_except_old_domain_on_main_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserve unrelated identifiers when the target already has both old and new IDs."""
+    main_device = _device(
+        "main",
+        "old_id",
+        config_entries={"entry-1"},
+    )
+    main_device.identifiers.add((DOMAIN, "new_id"))
+    main_device.identifiers.add((DOMAIN, "other-domain-id"))
+    main_device.identifiers.add(("other", "unrelated"))
+    reconciliation, _, devices = _subject(monkeypatch, [], [main_device])
+
+    reconciliation.prepare()
+
+    assert main_device.identifiers == {
+        (DOMAIN, "new_id"),
+        (DOMAIN, "other-domain-id"),
+        ("other", "unrelated"),
+    }
+    assert devices.updates == [
+        (
+            "main",
+            {
+                "new_identifiers": {
+                    (DOMAIN, "new_id"),
+                    (DOMAIN, "other-domain-id"),
+                    ("other", "unrelated"),
+                }
+            },
+        )
+    ]
+
+
 def test_finalize_removes_only_stale_snapshot_and_preserves_device_associations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -1,0 +1,312 @@
+"""Tests for restart-safe device-ID repair reconciliation."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from homeassistant.helpers.entity import Entity
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.opnsense import repair_reconciliation as rr
+from custom_components.opnsense.const import DOMAIN
+
+
+class _EntityRegistry:
+    """Minimal mutable entity registry used by reconciliation tests."""
+
+    def __init__(self, entries: list[Any]) -> None:
+        self.entries = entries
+        self.removed: list[str] = []
+
+    def async_get(self, entity_id: str) -> Any | None:
+        """Return an entry by entity ID."""
+        return next((entry for entry in self.entries if entry.entity_id == entity_id), None)
+
+    def async_get_entity_id(self, domain: str, platform: str, unique_id: str) -> str | None:
+        """Return the entity ID matching a full registry identity."""
+        entry = next(
+            (
+                item
+                for item in self.entries
+                if (item.domain, item.platform, item.unique_id) == (domain, platform, unique_id)
+            ),
+            None,
+        )
+        return entry.entity_id if entry else None
+
+    def async_update_entity(self, entity_id: str, **changes: Any) -> Any:
+        """Apply supported registry changes in place."""
+        entry = self.async_get(entity_id)
+        if entry is None:
+            raise KeyError(entity_id)
+        if "new_unique_id" in changes:
+            entry.unique_id = changes["new_unique_id"]
+        if "device_id" in changes:
+            entry.device_id = changes["device_id"]
+        return entry
+
+    def async_remove(self, entity_id: str) -> None:
+        """Remove an entity by ID."""
+        self.removed.append(entity_id)
+        self.entries[:] = [entry for entry in self.entries if entry.entity_id != entity_id]
+
+
+class _DeviceRegistry:
+    """Minimal mutable device registry used by reconciliation tests."""
+
+    def __init__(self, devices: list[Any]) -> None:
+        self.devices = devices
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+
+    def async_get_device(self, *, identifiers: set[tuple[str, str]]) -> Any | None:
+        """Return a device matching an identifier."""
+        return next((device for device in self.devices if device.identifiers & identifiers), None)
+
+    def async_update_device(self, device_id: str, **changes: Any) -> Any:
+        """Apply identifiers or config-entry removal."""
+        self.updates.append((device_id, changes))
+        device = next(item for item in self.devices if item.id == device_id)
+        if "new_identifiers" in changes:
+            device.identifiers = changes["new_identifiers"]
+        if "remove_config_entry_id" in changes:
+            device.config_entries.discard(changes["remove_config_entry_id"])
+        return device
+
+
+def _entry(unique_id: str, *, entity_id: str, device_id: str | None = None, **attrs: Any) -> Any:
+    """Create a registry-entry stand-in."""
+    return SimpleNamespace(
+        entity_id=entity_id,
+        domain=entity_id.split(".", 1)[0],
+        platform=DOMAIN,
+        unique_id=unique_id,
+        config_entry_id="entry-1",
+        device_id=device_id,
+        **attrs,
+    )
+
+
+def _device(
+    device_id: str,
+    identifier: str,
+    *,
+    config_entries: set[str] | None = None,
+) -> Any:
+    """Create a device-registry stand-in."""
+    return SimpleNamespace(
+        id=device_id,
+        identifiers={(DOMAIN, identifier)},
+        config_entries=set(config_entries or {"entry-1"}),
+    )
+
+
+def _subject(
+    monkeypatch: pytest.MonkeyPatch,
+    entities: list[Any],
+    devices: list[Any],
+) -> tuple[rr.RepairReconciliation, _EntityRegistry, _DeviceRegistry]:
+    """Create reconciliation with patched mutable registries."""
+    entity_registry = _EntityRegistry(entities)
+    device_registry = _DeviceRegistry(devices)
+    monkeypatch.setattr(rr.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(
+        rr.er,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [
+            item for item in registry.entries if item.config_entry_id == entry_id
+        ],
+    )
+    monkeypatch.setattr(rr.dr, "async_get", lambda _hass: device_registry)
+    monkeypatch.setattr(
+        rr.dr,
+        "async_entries_for_config_entry",
+        lambda registry, entry_id: [
+            item for item in registry.devices if entry_id in item.config_entries
+        ],
+    )
+    entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id="new_id")
+    object.__setattr__(entry, "entry_id", "entry-1")
+    reconciliation = rr.RepairReconciliation(
+        MagicMock(), entry, rr.RepairMarker(1, "old_id", "new_id")
+    )
+    return reconciliation, entity_registry, device_registry
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        {},
+        {"version": 2, "old_device_id": "old", "new_device_id": "new"},
+        {"version": 1, "old_device_id": "", "new_device_id": "new"},
+        {"version": 1, "old_device_id": "same", "new_device_id": "same"},
+        {"version": 1, "old_device_id": 1, "new_device_id": "new"},
+    ],
+)
+def test_parse_repair_marker_rejects_invalid_values(value: object) -> None:
+    """Malformed markers must never start reconciliation."""
+    entry = MockConfigEntry(domain=DOMAIN, data={rr.REPAIR_MARKER_KEY: value})
+
+    assert rr.has_repair_marker(entry)
+    assert rr.parse_repair_marker(entry) is None
+
+
+def test_parse_repair_marker_accepts_current_marker() -> None:
+    """A current complete marker is parsed exactly."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={rr.REPAIR_MARKER_KEY: rr.build_repair_marker("old", "new")},
+    )
+
+    assert rr.parse_repair_marker(entry) == rr.RepairMarker(1, "old", "new")
+
+
+def test_prepare_migrates_exact_prefix_in_place_and_preserves_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the exact slugged old prefix changes, preserving registry identity and metadata."""
+    migrated = _entry(
+        "old_id_interface_lan_with_under_scores",
+        entity_id="sensor.kept",
+        device_id="main",
+        disabled_by="user",
+        original_name="Original",
+    )
+    immune = _entry("old_identifier_other", entity_id="sensor.immune", device_id="main")
+    reconciliation, registry, _ = _subject(
+        monkeypatch, [migrated, immune], [_device("main", "old_id")]
+    )
+
+    reconciliation.prepare()
+
+    assert migrated.entity_id == "sensor.kept"
+    assert migrated.unique_id == "new_id_interface_lan_with_under_scores"
+    assert migrated.disabled_by == "user"
+    assert migrated.original_name == "Original"
+    assert immune.unique_id == "old_identifier_other"
+    assert registry.removed == []
+
+
+def test_prepare_rejects_full_identity_collision(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A collision is determined by domain, platform, and unique ID."""
+    candidate = _entry("old_id_status", entity_id="sensor.old")
+    collision = _entry("new_id_status", entity_id="sensor.other")
+    reconciliation, _, _ = _subject(monkeypatch, [candidate, collision], [])
+
+    with pytest.raises(rr.RepairReconciliationError, match="entity target collision"):
+        reconciliation.prepare()
+
+
+def test_prepare_migrates_primary_device_or_rejects_foreign_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The primary device migrates in place, while a foreign target blocks repair."""
+    old = _device("main", "old_id")
+    reconciliation, _, _ = _subject(monkeypatch, [], [old])
+
+    reconciliation.prepare()
+    assert old.id == "main"
+    assert old.identifiers == {(DOMAIN, "new_id")}
+
+    retry, _, retry_registry = _subject(monkeypatch, [], [old])
+    retry.prepare()
+    assert retry_registry.updates == []
+
+    foreign = _device("foreign", "new_id", config_entries={"entry-2"})
+    reconciliation, _, _ = _subject(monkeypatch, [], [foreign])
+    with pytest.raises(rr.RepairReconciliationError, match="primary device"):
+        reconciliation.prepare()
+
+    simultaneous = _device("target", "new_id")
+    reconciliation, _, _ = _subject(monkeypatch, [], [_device("source", "old_id"), simultaneous])
+    with pytest.raises(rr.RepairReconciliationError, match="primary device"):
+        reconciliation.prepare()
+
+
+def test_finalize_removes_only_stale_snapshot_and_preserves_device_associations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Finalization removes stale pre-repair rows but never new rows or used devices."""
+    surviving = _entry("old_id_keep", entity_id="sensor.keep", device_id="used")
+    stale = _entry("old_id_stale", entity_id="sensor.stale", device_id="obsolete")
+    reconciliation, registry, devices = _subject(
+        monkeypatch,
+        [surviving, stale],
+        [
+            _device("main", "old_id"),
+            _device("used", "child-used"),
+            _device("obsolete", "child-old", config_entries={"entry-1", "entry-2"}),
+        ],
+    )
+    reconciliation.prepare()
+    new_entity = _entry("new_id_new", entity_id="sensor.new", device_id="used")
+    registry.entries.append(new_entity)
+    reconciliation.desired_identities.add(("sensor", DOMAIN, surviving.unique_id))
+
+    reconciliation.finalize()
+
+    assert registry.removed == ["sensor.stale"]
+    assert registry.async_get("sensor.new") is new_entity
+    assert ("obsolete", {"remove_config_entry_id": "entry-1"}) in devices.updates
+    assert (
+        "entry-2" in next(item for item in devices.devices if item.id == "obsolete").config_entries
+    )
+    removals = [
+        device_id for device_id, changes in devices.updates if "remove_config_entry_id" in changes
+    ]
+    assert all(device_id not in {"main", "used"} for device_id in removals)
+
+
+def test_prepare_and_finalize_are_idempotent_after_partial_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry safely handles already-migrated and still-old candidates."""
+    first = _entry("old_id_first", entity_id="sensor.first")
+    second = _entry("old_id_second", entity_id="sensor.second")
+    reconciliation, registry, _ = _subject(monkeypatch, [first, second], [])
+    reconciliation.prepare()
+    second.unique_id = "old_id_second"
+
+    retry, _, _ = _subject(monkeypatch, registry.entries, [])
+    retry.prepare()
+    retry.desired_identities.update(
+        {("sensor", DOMAIN, "new_id_first"), ("sensor", DOMAIN, "new_id_second")}
+    )
+    retry.finalize()
+
+    assert {item.unique_id for item in registry.entries} == {
+        "new_id_first",
+        "new_id_second",
+    }
+    assert registry.removed == []
+
+
+def test_records_all_final_platform_lists_including_disabled_entities() -> None:
+    """Every forwarded platform contributes its complete final identity list."""
+    reconciliation = rr.RepairReconciliation(
+        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
+    )
+    for platform in ("binary_sensor", "sensor", "switch", "update", "device_tracker"):
+        entity = Entity()
+        entity._attr_unique_id = f"new_{platform}"
+        reconciliation.record_desired_entities(platform, [entity])
+
+    assert reconciliation.desired_identities == {
+        (platform, DOMAIN, f"new_{platform}")
+        for platform in ("binary_sensor", "sensor", "switch", "update", "device_tracker")
+    }
+    reconciliation.require_platforms_complete(
+        ("binary_sensor", "sensor", "switch", "update", "device_tracker")
+    )
+
+
+def test_incomplete_platform_lists_block_finalization() -> None:
+    """Missing a forwarded platform completion is a hard reconciliation failure."""
+    reconciliation = rr.RepairReconciliation(
+        MagicMock(), MagicMock(), rr.RepairMarker(1, "old", "new")
+    )
+    reconciliation.record_desired_entities("sensor", [])
+
+    with pytest.raises(rr.RepairReconciliationError, match="binary_sensor"):
+        reconciliation.require_platforms_complete(("sensor", "binary_sensor"))

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import Entity
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -172,17 +173,17 @@ def _subject(
     """Create reconciliation with patched mutable registries."""
     entity_registry = _EntityRegistry(entities)
     device_registry = _DeviceRegistry(devices)
-    monkeypatch.setattr(rr.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda _hass: entity_registry)
     monkeypatch.setattr(
-        rr.er,
+        er,
         "async_entries_for_config_entry",
         lambda registry, entry_id: [
             item for item in registry.entries if item.config_entry_id == entry_id
         ],
     )
-    monkeypatch.setattr(rr.dr, "async_get", lambda _hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda _hass: device_registry)
     monkeypatch.setattr(
-        rr.dr,
+        dr,
         "async_entries_for_config_entry",
         lambda registry, entry_id: [
             item for item in registry.devices if entry_id in item.config_entries
@@ -428,10 +429,10 @@ def test_prepare_and_finalize_are_idempotent_after_partial_retry(
         (lambda: KeyError("migrating entity"), KeyError),
         (lambda: ValueError("migrating entity"), ValueError),
         (
-            lambda: rr.dr.DeviceIdentifierCollisionError(
-                {("domain", "identifier")}, MagicMock(spec=rr.dr.DeviceEntry)
+            lambda: dr.DeviceIdentifierCollisionError(
+                {("domain", "identifier")}, MagicMock(spec=dr.DeviceEntry)
             ),
-            rr.dr.DeviceIdentifierCollisionError,
+            dr.DeviceIdentifierCollisionError,
         ),
     ],
 )

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -1,9 +1,11 @@
 """Tests for restart-safe device-ID repair reconciliation."""
 
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import Entity
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -317,6 +319,81 @@ def test_prepare_and_finalize_are_idempotent_after_partial_retry(
         "new_id_second",
     }
     assert registry.removed == []
+
+
+@pytest.mark.parametrize(
+    "failure_factory",
+    [
+        (lambda: HomeAssistantError("migrating entity"), HomeAssistantError),
+        (lambda: KeyError("migrating entity"), KeyError),
+        (lambda: ValueError("migrating entity"), ValueError),
+        (
+            lambda: rr.dr.DeviceIdentifierCollisionError(
+                {("domain", "identifier")}, MagicMock(spec=rr.dr.DeviceEntry)
+            ),
+            rr.dr.DeviceIdentifierCollisionError,
+        ),
+    ],
+)
+def test_prepare_wraps_registry_identifier_migration_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_factory: tuple[Callable[[], Exception], type[Exception]],
+) -> None:
+    """Update errors during identifier migration are wrapped as repair errors."""
+    candidate = _entry("old_id_sensor", entity_id="sensor.old")
+    reconciliation, entity_registry, _ = _subject(monkeypatch, [candidate], [])
+    failure, expected = failure_factory
+    monkeypatch.setattr(
+        entity_registry,
+        "async_update_entity",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(failure()),
+    )
+
+    with pytest.raises(
+        rr.RepairReconciliationError, match="registry identifier migration failed"
+    ) as err:
+        reconciliation.prepare()
+    assert isinstance(err.value.__cause__, expected)
+
+
+def test_finalize_wraps_detach_failure_as_registry_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Finalization surfaces detach failures as a repair reconciliation error."""
+    stale = _entry("old_id_stale", entity_id="sensor.stale")
+    reconciliation, _, device_registry = _subject(
+        monkeypatch,
+        [stale],
+        [
+            _device("main", "new_id"),
+            _device("obsolete", "old", config_entries={"entry-1"}),
+        ],
+    )
+    reconciliation.prepare()
+    monkeypatch.setattr(
+        rr,
+        "detach_shared_router_parent",
+        lambda *args, **kwargs: (_ for _ in ()).throw(KeyError("detach shared tracker")),
+    )
+
+    with pytest.raises(rr.RepairReconciliationError, match="registry finalization failed") as err:
+        reconciliation.finalize()
+    assert isinstance(err.value.__cause__, KeyError)
+    assert device_registry.updates == []
+
+
+def test_mark_complete_deactivates() -> None:
+    """Finishing reconciliation disables active state."""
+    reconciliation = rr.RepairReconciliation(
+        MagicMock(),
+        _other_config_entry("entry-1", "old"),
+        rr.RepairMarker(1, "old", "new"),
+    )
+    assert reconciliation.active is True
+
+    reconciliation.mark_complete()
+
+    assert reconciliation.active is False
 
 
 def test_finalize_reassigns_shared_tracker_parent_to_remaining_router(

--- a/tests/test_repair_reconciliation.py
+++ b/tests/test_repair_reconciliation.py
@@ -194,6 +194,8 @@ def _subject(
         None,
         {},
         {"version": 2, "old_device_id": "old", "new_device_id": "new"},
+        {"version": True, "old_device_id": "old", "new_device_id": "new"},
+        {"version": 1.0, "old_device_id": "old", "new_device_id": "new"},
         {"version": 1, "old_device_id": "", "new_device_id": "new"},
         {"version": 1, "old_device_id": "same", "new_device_id": "same"},
         {"version": 1, "old_device_id": 1, "new_device_id": "new"},

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -638,10 +638,11 @@ async def test_entry_changed_during_probe_or_unload_aborts_without_mutation(
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_schedule_reload.assert_not_called()
     if mutation_stage == "probe":
+        hass.config_entries.async_schedule_reload.assert_not_called()
         hass.config_entries.async_unload.assert_not_awaited()
     else:
+        hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
         hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
 
 
@@ -905,8 +906,9 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
     assert result["reason"] == "entry_changed"
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
 
 
 @pytest.mark.asyncio
@@ -1541,7 +1543,7 @@ async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
 ) -> None:
     """A changed retry entry must abort before destructive registry cleanup."""
     hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
+    entry = _make_entry(state=ConfigEntryState.NOT_LOADED)
     updated_entry = _make_entry(
         entry_id=entry.entry_id,
         device_id="mutated",
@@ -1562,5 +1564,7 @@ async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
     assert result["reason"] == "entry_changed"
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
     hass.config_entries.async_reload.assert_not_awaited()
     hass.config_entries.async_schedule_reload.assert_not_called()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -18,7 +18,7 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import repairs
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
 from custom_components.opnsense.repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker
 
 
@@ -314,10 +314,49 @@ async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
     issue_delete.assert_not_called()
     assert entry.data[CONF_DEVICE_UNIQUE_ID] == "dev1"
     assert entry.unique_id == "dev1"
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_duplicate_after_unload_schedules_changed_entry_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A duplicate that appears after unload should schedule a guarded reload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entries_calls: list[str] = []
+
+    def _entries(domain: str) -> list[Any]:
+        """Return a duplicate config entry only after unload and snapshot checks."""
+        del domain
+        entries_calls.append("entries")
+        if len(entries_calls) == 1:
+            return [entry]
+        return [entry, duplicate]
+
+    hass.config_entries.async_entries.side_effect = _entries
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch, observed_device_id="other")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1206,3 +1245,77 @@ async def test_retry_rejects_invalid_or_mismatched_marker(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "entry_changed"
     client.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_matches_snapshot_rejects_tracked_macs_mutation_by_default() -> None:
+    """Tracked-mac mutation must fail strict snapshot matching by default."""
+    entry = _make_entry()
+    baseline = dict(entry.data)
+    baseline_with_tracked_macs = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
+    object.__setattr__(entry, "data", baseline_with_tracked_macs)
+
+    current = {**baseline, TRACKED_MACS: ["11:22:33:44"]}
+    object.__setattr__(entry, "data", current)
+    entry_options_snapshot = dict(entry.options)
+
+    assert not repairs._entry_matches_snapshot(
+        entry=entry,
+        entry_id=entry.entry_id,
+        data_snapshot=baseline_with_tracked_macs,
+        options_snapshot=entry_options_snapshot,
+        unique_id_snapshot=entry.unique_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_entry_matches_snapshot_allows_only_tracked_macs_mutation_for_recovery() -> None:
+    """Recovery-mode snapshot checks should ignore tracked-MAC drift only."""
+    entry = _make_entry()
+    baseline = dict(entry.data)
+    baseline_with_tracked_macs = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
+    object.__setattr__(entry, "data", baseline_with_tracked_macs)
+
+    current = {**baseline, TRACKED_MACS: ["11:22:33:44"]}
+    object.__setattr__(entry, "data", current)
+    entry_options_snapshot = dict(entry.options)
+
+    assert repairs._entry_matches_snapshot(
+        entry=entry,
+        entry_id=entry.entry_id,
+        data_snapshot=baseline_with_tracked_macs,
+        options_snapshot=entry_options_snapshot,
+        unique_id_snapshot=entry.unique_id,
+        allow_tracked_macs_mutation=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_entry_matches_snapshot_rejects_non_tracked_mutations() -> None:
+    """Non-tracked payload mutation must invalidate the repair snapshot."""
+    entry = _make_entry()
+    baseline = dict(entry.data)
+    baseline["some_other_key"] = "original"
+    entry_options_snapshot = dict(entry.options)
+
+    object.__setattr__(entry, "data", baseline)
+    assert repairs._entry_matches_snapshot(
+        entry=entry,
+        entry_id=entry.entry_id,
+        data_snapshot=baseline,
+        options_snapshot=entry_options_snapshot,
+        unique_id_snapshot=entry.unique_id,
+    )
+
+    mutated = dict(baseline)
+    mutated["some_other_key"] = "mutated"
+    object.__setattr__(entry, "data", mutated)
+
+    assert not repairs._entry_matches_snapshot(
+        entry=entry,
+        entry_id=entry.entry_id,
+        data_snapshot=baseline,
+        options_snapshot=entry_options_snapshot,
+        unique_id_snapshot=entry.unique_id,
+        allow_tracked_macs_mutation=True,
+    )

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1259,75 +1259,65 @@ async def test_retry_rejects_invalid_or_mismatched_marker(
     client.factory.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_entry_matches_snapshot_rejects_tracked_macs_mutation_by_default() -> None:
-    """Tracked-mac mutation must fail strict snapshot matching by default."""
+@pytest.mark.parametrize(
+    ("scenario", "allow_tracked_macs_mutation"),
+    [
+        pytest.param("tracked-macs-reject", False, id="tracked-macs-reject"),
+        pytest.param("tracked-macs-allow", True, id="tracked-macs-allow"),
+        pytest.param("non-tracked-reject", True, id="non-tracked-reject"),
+    ],
+)
+def test_entry_matches_snapshot_invariants(
+    scenario: str,
+    allow_tracked_macs_mutation: bool,
+) -> None:
+    """Snapshot matching is strict by default, lenient only for tracked-MAC recovery checks."""
     entry = _make_entry()
-    baseline = dict(entry.data)
-    baseline_with_tracked_macs = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
-    object.__setattr__(entry, "data", baseline_with_tracked_macs)
+    entry_options_snapshot = dict(entry.options)
 
+    if scenario == "non-tracked-reject":
+        baseline = dict(entry.data)
+        baseline["some_other_key"] = "original"
+        object.__setattr__(entry, "data", baseline)
+
+        assert repairs._entry_matches_snapshot(
+            entry=entry,
+            entry_id=entry.entry_id,
+            data_snapshot=baseline,
+            options_snapshot=entry_options_snapshot,
+            unique_id_snapshot=entry.unique_id,
+            allow_tracked_macs_mutation=allow_tracked_macs_mutation,
+        )
+
+        mutated = dict(baseline)
+        mutated["some_other_key"] = "mutated"
+        object.__setattr__(entry, "data", mutated)
+
+        assert not repairs._entry_matches_snapshot(
+            entry=entry,
+            entry_id=entry.entry_id,
+            data_snapshot=baseline,
+            options_snapshot=entry_options_snapshot,
+            unique_id_snapshot=entry.unique_id,
+            allow_tracked_macs_mutation=allow_tracked_macs_mutation,
+        )
+        return
+
+    baseline = dict(entry.data)
+    snapshot = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
     current = {**baseline, TRACKED_MACS: ["11:22:33:44"]}
+    object.__setattr__(entry, "data", snapshot)
     object.__setattr__(entry, "data", current)
-    entry_options_snapshot = dict(entry.options)
 
-    assert not repairs._entry_matches_snapshot(
-        entry=entry,
-        entry_id=entry.entry_id,
-        data_snapshot=baseline_with_tracked_macs,
-        options_snapshot=entry_options_snapshot,
-        unique_id_snapshot=entry.unique_id,
-    )
-
-
-@pytest.mark.asyncio
-async def test_entry_matches_snapshot_allows_only_tracked_macs_mutation_for_recovery() -> None:
-    """Recovery-mode snapshot checks should ignore tracked-MAC drift only."""
-    entry = _make_entry()
-    baseline = dict(entry.data)
-    baseline_with_tracked_macs = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
-    object.__setattr__(entry, "data", baseline_with_tracked_macs)
-
-    current = {**baseline, TRACKED_MACS: ["11:22:33:44"]}
-    object.__setattr__(entry, "data", current)
-    entry_options_snapshot = dict(entry.options)
-
-    assert repairs._entry_matches_snapshot(
-        entry=entry,
-        entry_id=entry.entry_id,
-        data_snapshot=baseline_with_tracked_macs,
-        options_snapshot=entry_options_snapshot,
-        unique_id_snapshot=entry.unique_id,
-        allow_tracked_macs_mutation=True,
-    )
-
-
-@pytest.mark.asyncio
-async def test_entry_matches_snapshot_rejects_non_tracked_mutations() -> None:
-    """Non-tracked payload mutation must invalidate the repair snapshot."""
-    entry = _make_entry()
-    baseline = dict(entry.data)
-    baseline["some_other_key"] = "original"
-    entry_options_snapshot = dict(entry.options)
-
-    object.__setattr__(entry, "data", baseline)
-    assert repairs._entry_matches_snapshot(
-        entry=entry,
-        entry_id=entry.entry_id,
-        data_snapshot=baseline,
-        options_snapshot=entry_options_snapshot,
-        unique_id_snapshot=entry.unique_id,
-    )
-
-    mutated = dict(baseline)
-    mutated["some_other_key"] = "mutated"
-    object.__setattr__(entry, "data", mutated)
-
-    assert not repairs._entry_matches_snapshot(
-        entry=entry,
-        entry_id=entry.entry_id,
-        data_snapshot=baseline,
-        options_snapshot=entry_options_snapshot,
-        unique_id_snapshot=entry.unique_id,
-        allow_tracked_macs_mutation=True,
+    expected_match = scenario == "tracked-macs-allow"
+    assert (
+        repairs._entry_matches_snapshot(
+            entry=entry,
+            entry_id=entry.entry_id,
+            data_snapshot=snapshot,
+            options_snapshot=entry_options_snapshot,
+            unique_id_snapshot=entry.unique_id,
+            allow_tracked_macs_mutation=allow_tracked_macs_mutation,
+        )
+        == expected_match
     )

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -8,6 +8,7 @@ from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
     OPNsenseError,
+    OPNsenseMissingDeviceUniqueID,
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
@@ -184,6 +185,7 @@ def _patch_probe_client(
     monkeypatch: pytest.MonkeyPatch,
     *,
     observed_device_id: Any = "other",
+    validate_error: BaseException | None = None,
     probe_error: BaseException | None = None,
     events: list[str] | None = None,
 ) -> MagicMock:
@@ -209,7 +211,9 @@ def _patch_probe_client(
     client.get_device_unique_id = AsyncMock(
         side_effect=probe_error if probe_error is not None else _probe
     )
-    client.validate = AsyncMock(side_effect=_validate)
+    client.validate = AsyncMock(
+        side_effect=validate_error if validate_error is not None else _validate
+    )
     client.async_close = AsyncMock(side_effect=_close)
     factory = MagicMock(return_value=client)
     client.factory = factory
@@ -268,6 +272,27 @@ async def test_confirmation_reprobes_with_strict_client_and_closes_it(
     assert client.validate.await_count == 2
     assert client.get_device_unique_id.await_count == 2
     assert client.async_close.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_async_validate_and_probe_ignores_missing_device_unique_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing Device ID from validate should still allow a direct probe call."""
+    hass = MagicMock()
+    entry = _make_entry()
+    client = _patch_probe_client(
+        monkeypatch,
+        observed_device_id="other",
+        validate_error=OPNsenseMissingDeviceUniqueID("device-id unavailable"),
+    )
+
+    observed_device_id = await repairs._async_validate_and_probe_device_id(hass, entry)
+
+    assert observed_device_id == "other"
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    client.async_close.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -652,6 +677,46 @@ async def test_loaded_entry_reprobe_after_unload_rejects_probe_failure_without_m
         raise OPNsenseConnectionError("offline")
 
     client.get_device_unique_id.side_effect = _probe_then_fail
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    assert client.get_device_unique_id.await_count == 2
+    assert client.async_close.await_count == 2
+    assert len(probe_calls) == 2
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_reprobe_after_unload_rejects_raw_timeout_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raw timeout on reprobe after unload should recover and return cannot_connect."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    probe_calls: list[int] = []
+
+    async def _probe_then_timeout() -> str:
+        probe_calls.append(1)
+        if len(probe_calls) == 1:
+            return "other"
+        raise TimeoutError("probe timed out")
+
+    client.get_device_unique_id.side_effect = _probe_then_timeout
     flow = _make_flow(hass, entry)
 
     result = await flow.async_step_confirm({})
@@ -1464,6 +1529,32 @@ async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
     hass.config_entries.async_unload.assert_not_awaited()
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
     hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_markerless_retry_requires_entry_unique_id_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Markerless retry must validate both stored and unique IDs before reloading."""
+    hass = MagicMock()
+    entry = _make_entry(
+        state=ConfigEntryState.NOT_LOADED,
+        device_id="other",
+        unique_id="not-matching-unique",
+    )
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    client = _patch_probe_client(monkeypatch, observed_device_id="other")
+    flow = _make_flow(hass, entry, new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.factory.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -566,6 +566,43 @@ async def test_unload_failure_aborts_before_registry_mutation(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "unload_error",
+    [
+        pytest.param(HomeAssistantError("transport"), id="homeassistant-error"),
+        pytest.param(KeyError("entry key"), id="key-error"),
+    ],
+)
+async def test_unload_exception_aborts_before_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    unload_error: BaseException,
+) -> None:
+    """Exceptions when unloading a loaded entry should abort the repair with cannot_unload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_unload.side_effect = unload_error
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "state",
     [
         ConfigEntryState.FAILED_UNLOAD,

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -320,6 +320,48 @@ async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
 
 
 @pytest.mark.asyncio
+async def test_duplicate_entry_created_during_unload_aborts_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A duplicate created during unload must abort before config or registry mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entries = [entry]
+    hass.config_entries.async_entries.side_effect = lambda domain: entries
+
+    def _unload(entry_id: str) -> bool:
+        """Create a competing entry after the initial duplicate check."""
+        del entry_id
+        entries.append(duplicate)
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_update_entry.assert_not_called()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    issue_delete.assert_not_called()
+    assert entry.data[CONF_DEVICE_UNIQUE_ID] == "dev1"
+    assert entry.unique_id == "dev1"
+
+
+@pytest.mark.asyncio
 async def test_loaded_entry_unloads_before_registry_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -401,6 +443,8 @@ async def test_loaded_entry_unloads_before_registry_cleanup(
         "duplicate_scan",
         "duplicate_check",
         "unload",
+        "duplicate_scan",
+        "duplicate_check",
         "config_update",
         "entity",
         "device",

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -911,7 +911,7 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
 async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Loaded retry cleanup failures should stay available without scheduling reload."""
+    """Loaded retry cleanup failures should schedule a guarded recovery reload."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
     _configure_hass(hass, entry)
@@ -944,6 +944,13 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "repair_failed"
     assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entry.data == {
+        "url": "https://router.example",
+        "username": "api-user",
+        "password": "api-password",
+        CONF_DEVICE_UNIQUE_ID: "other",
+    }
+    assert entry.unique_id == "other"
     hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
     entity_registry.async_remove.assert_called_once_with("sensor.old")
     device_registry.async_update_device.assert_called_once_with(
@@ -951,8 +958,21 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     )
     hass.config_entries.async_update_entry.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
     issue_delete.assert_not_called()
+
+    entity_registry.async_remove.side_effect = None
+    device_registry.async_update_device.side_effect = None
+    hass.config_entries.async_schedule_reload.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert entity_registry.async_remove.call_count == 2
+    assert device_registry.async_update_device.call_count == 2
+    assert hass.config_entries.async_reload.await_count == 1
+    hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1028,12 +1048,13 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     assert len(hass.config_entries.async_update_entry.call_args_list) == 1
     issue_delete.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
 
     hass.config_entries.async_reload.reset_mock()
     entity_registry.async_remove.side_effect = None
     device_registry.async_update_device.side_effect = None
     client.get_device_unique_id.reset_mock()
+    hass.config_entries.async_schedule_reload.reset_mock()
 
     retry_result = await flow.async_step_confirm({})
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -19,6 +19,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import repairs
 from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+from custom_components.opnsense.repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker
 
 
 def _make_entry(
@@ -82,21 +83,10 @@ def _patch_registries(
     entities: list[Any] | None = None,
     devices: list[Any] | None = None,
 ) -> tuple[MagicMock, MagicMock]:
-    """Patch entity/device registry lookups and return the fake registries."""
+    """Return registry spies proving the confirmation flow does not mutate registries."""
+    del monkeypatch, entities, devices
     entity_registry = MagicMock()
     device_registry = MagicMock()
-    monkeypatch.setattr(repairs.er, "async_get", lambda hass: entity_registry)
-    monkeypatch.setattr(
-        repairs.er,
-        "async_entries_for_config_entry",
-        lambda registry, config_entry_id: entities or [],
-    )
-    monkeypatch.setattr(repairs.dr, "async_get", lambda hass: device_registry)
-    monkeypatch.setattr(
-        repairs.dr,
-        "async_entries_for_config_entry",
-        lambda registry, config_entry_id: devices or [],
-    )
     return entity_registry, device_registry
 
 
@@ -331,10 +321,10 @@ async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
 
 
 @pytest.mark.asyncio
-async def test_loaded_entry_unloads_before_registry_cleanup(
+async def test_loaded_entry_unloads_before_marker_update_and_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A loaded entry must unload before entities or devices are removed."""
+    """A loaded entry unloads before marker persistence and reload."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED)
     events: list[str] = []
@@ -415,11 +405,11 @@ async def test_loaded_entry_unloads_before_registry_cleanup(
         "duplicate_scan",
         "duplicate_check",
         "config_update",
-        "entity",
-        "device",
         "reload",
         "create",
     ]
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -596,6 +586,8 @@ async def test_entry_removed_during_unload_aborts_before_registry_mutation(
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_not_awaited()
     hass.config_entries.async_schedule_reload.assert_not_called()
 
 
@@ -703,58 +695,6 @@ async def test_nested_mutable_options_mutation_during_probe_aborts_without_mutat
 
 
 @pytest.mark.asyncio
-async def test_cleanup_removes_disabled_entities_directly(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Entity cleanup should remove all entries, including integration/user-disabled ones."""
-    hass = MagicMock()
-    entry = _make_entry()
-    _configure_hass(hass, entry)
-    entities = [
-        SimpleNamespace(entity_id="sensor.enabled", disabled_by=None),
-        SimpleNamespace(entity_id="sensor.integration_disabled", disabled_by="integration"),
-        SimpleNamespace(entity_id="sensor.user_disabled", disabled_by="user"),
-    ]
-    entity_registry, _ = _patch_registries(monkeypatch, entities=entities)
-    _patch_probe_client(monkeypatch)
-    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
-    flow = _make_flow(hass, entry)
-
-    await flow.async_step_confirm({})
-
-    assert [call.args[0] for call in entity_registry.async_remove.call_args_list] == [
-        "sensor.enabled",
-        "sensor.integration_disabled",
-        "sensor.user_disabled",
-    ]
-
-
-@pytest.mark.asyncio
-async def test_cleanup_removes_only_this_config_entry_from_shared_devices(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Shared devices should retain associations with other config entries."""
-    hass = MagicMock()
-    entry = _make_entry()
-    _configure_hass(hass, entry)
-    devices = [
-        SimpleNamespace(id="device-only", config_entries={entry.entry_id}),
-        SimpleNamespace(id="device-shared", config_entries={entry.entry_id, "entry-2"}),
-    ]
-    _, device_registry = _patch_registries(monkeypatch, devices=devices)
-    _patch_probe_client(monkeypatch)
-    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
-    flow = _make_flow(hass, entry)
-
-    await flow.async_step_confirm({})
-
-    assert device_registry.async_update_device.call_args_list == [
-        (("device-only",), {"remove_config_entry_id": entry.entry_id}),
-        (("device-shared",), {"remove_config_entry_id": entry.entry_id}),
-    ]
-
-
-@pytest.mark.asyncio
 async def test_update_preserves_connection_and_options_while_replacing_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -771,7 +711,11 @@ async def test_update_preserves_connection_and_options_while_replacing_id(
 
     hass.config_entries.async_update_entry.assert_called_once_with(
         entry,
-        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        data={
+            **entry.data,
+            CONF_DEVICE_UNIQUE_ID: "other",
+            REPAIR_MARKER_KEY: build_repair_marker("dev1", "other"),
+        },
         unique_id="other",
     )
     assert entry.data["url"] == "https://router.example"
@@ -829,7 +773,11 @@ async def test_entry_update_failure_aborts_without_registry_mutation(
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_called_once_with(
         entry,
-        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        data={
+            **entry.data,
+            CONF_DEVICE_UNIQUE_ID: "other",
+            REPAIR_MARKER_KEY: build_repair_marker("dev1", "other"),
+        },
         unique_id="other",
     )
     issue_delete.assert_not_called()
@@ -862,7 +810,11 @@ async def test_entry_update_false_aborts_before_registry_mutation_and_recovers_l
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_called_once_with(
         entry,
-        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        data={
+            **entry.data,
+            CONF_DEVICE_UNIQUE_ID: "other",
+            REPAIR_MARKER_KEY: build_repair_marker("dev1", "other"),
+        },
         unique_id="other",
     )
     hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
@@ -895,43 +847,17 @@ async def test_loaded_entry_update_exception_recovers_without_registry_mutation(
 
 
 @pytest.mark.asyncio
-async def test_expected_id_retry_reprobes_before_cleanup(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A retry must not clean registries when the firewall ID no longer matches."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
-    _configure_hass(hass, entry)
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-    client = _patch_probe_client(monkeypatch, observed_device_id="reverted")
-    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
-
-    result = await flow.async_step_confirm({})
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "entry_changed"
-    client.validate.assert_awaited_once_with()
-    client.get_device_unique_id.assert_awaited_once_with()
-    client.async_close.assert_awaited_once_with()
-    hass.config_entries.async_unload.assert_not_awaited()
-    entity_registry.async_remove.assert_not_called()
-    device_registry.async_update_device.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_expected_id_retry_rechecks_snapshot_after_unload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A retry must not clean registries after its entry changes during unload."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    object.__setattr__(
+        entry,
+        "data",
+        {**entry.data, REPAIR_MARKER_KEY: build_repair_marker("dev1", "other")},
+    )
     _configure_hass(hass, entry)
     entity_registry, device_registry = _patch_registries(
         monkeypatch,
@@ -958,179 +884,6 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
     hass.config_entries.async_update_entry.assert_not_called()
     hass.config_entries.async_reload.assert_not_awaited()
     hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
-
-
-@pytest.mark.asyncio
-async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Loaded retry cleanup failures should schedule a guarded recovery reload."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
-    _configure_hass(hass, entry)
-
-    def _unload(entry_id: str) -> bool:
-        """Record unload and transition to an unloaded state."""
-        del entry_id
-        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
-        return True
-
-    hass.config_entries.async_unload.side_effect = _unload
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-
-    def _remove_entity(entity_id: str) -> None:
-        """Fail entity cleanup to exercise retry recovery behavior."""
-        del entity_id
-        raise HomeAssistantError("entity remove")
-
-    entity_registry.async_remove.side_effect = _remove_entity
-    issue_delete = MagicMock()
-    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
-    _patch_probe_client(monkeypatch)
-    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
-
-    result = await flow.async_step_confirm({})
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "repair_failed"
-    assert entry.state is ConfigEntryState.NOT_LOADED
-    assert entry.data == {
-        "url": "https://router.example",
-        "username": "api-user",
-        "password": "api-password",
-        CONF_DEVICE_UNIQUE_ID: "other",
-    }
-    assert entry.unique_id == "other"
-    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
-    entity_registry.async_remove.assert_called_once_with("sensor.old")
-    device_registry.async_update_device.assert_called_once_with(
-        "device", remove_config_entry_id=entry.entry_id
-    )
-    hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
-    issue_delete.assert_not_called()
-
-    entity_registry.async_remove.side_effect = None
-    device_registry.async_update_device.side_effect = None
-    hass.config_entries.async_schedule_reload.reset_mock()
-
-    retry_result = await flow.async_step_confirm({})
-
-    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
-    assert entry.state is ConfigEntryState.NOT_LOADED
-    assert entity_registry.async_remove.call_count == 2
-    assert device_registry.async_update_device.call_count == 2
-    assert hass.config_entries.async_reload.await_count == 1
-    hass.config_entries.async_schedule_reload.assert_not_called()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("failure_point", "cleanup_exception"),
-    [
-        pytest.param("entity", HomeAssistantError, id="entity-homeassistant-error"),
-        pytest.param("entity", ValueError, id="entity-valueerror"),
-        pytest.param("device", HomeAssistantError, id="device-homeassistant-error"),
-        pytest.param("device", ValueError, id="device-valueerror"),
-    ],
-)
-async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
-    monkeypatch: pytest.MonkeyPatch,
-    failure_point: str,
-    cleanup_exception: type[BaseException],
-) -> None:
-    """Cleanup failure keeps replacement ID for a retry that reruns cleanup."""
-    hass = MagicMock()
-    entry = _make_entry()
-    _configure_hass(hass, entry)
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-    observed_device_id = "other"
-    client = _patch_probe_client(monkeypatch, observed_device_id=observed_device_id)
-    issue_delete = MagicMock()
-    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
-
-    old_data = dict(entry.data)
-
-    def _update_entry(
-        config_entry: MockConfigEntry,
-        *,
-        data: dict[str, Any],
-        unique_id: str,
-    ) -> bool:
-        """Apply the requested entry mutation to the in-memory test object."""
-        del config_entry
-        object.__setattr__(entry, "data", dict(data))
-        object.__setattr__(entry, "unique_id", unique_id)
-        return True
-
-    hass.config_entries.async_update_entry.side_effect = _update_entry
-
-    if failure_point == "entity":
-
-        def _remove(entity_id: str) -> None:
-            """Fail entity cleanup to exercise recovery reload behavior."""
-            del entity_id
-            raise cleanup_exception("entity remove")
-
-        entity_registry.async_remove.side_effect = _remove
-    else:
-
-        def _update_device(device_id: str, **_: Any) -> None:
-            """Fail device cleanup to exercise recovery reload behavior."""
-            del device_id
-            raise cleanup_exception("device update")
-
-        device_registry.async_update_device.side_effect = _update_device
-
-    flow = _make_flow(hass, entry)
-
-    result = await flow.async_step_confirm({})
-
-    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "repair_failed"
-    entity_registry.async_remove.assert_called_once_with("sensor.old")
-    device_registry.async_update_device.assert_called_once_with(
-        "device", remove_config_entry_id=entry.entry_id
-    )
-    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
-        "data": expected_updated_data,
-        "unique_id": observed_device_id,
-    }
-    assert entry.data == expected_updated_data
-    assert entry.unique_id == observed_device_id
-    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
-    issue_delete.assert_not_called()
-    hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
-
-    hass.config_entries.async_reload.reset_mock()
-    entity_registry.async_remove.side_effect = None
-    device_registry.async_update_device.side_effect = None
-    client.get_device_unique_id.reset_mock()
-    hass.config_entries.async_schedule_reload.reset_mock()
-
-    retry_result = await flow.async_step_confirm({})
-
-    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
-    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
-        "data": expected_updated_data,
-        "unique_id": observed_device_id,
-    }
-    client.get_device_unique_id.assert_awaited_once_with()
-    assert hass.config_entries.async_reload.await_count == 1
-    assert hass.config_entries.async_update_entry.call_count == 1
-    assert entity_registry.async_remove.call_count == 2
-    assert device_registry.async_update_device.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -1183,11 +936,15 @@ async def test_reload_failure_keeps_entry_update_and_keeps_issue(
 
     result = await flow.async_step_confirm({})
 
-    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+    expected_updated_data = {
+        **old_data,
+        CONF_DEVICE_UNIQUE_ID: observed_device_id,
+        REPAIR_MARKER_KEY: build_repair_marker("dev1", observed_device_id),
+    }
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "repair_failed"
-    entity_registry.async_remove.assert_called_once_with("sensor.old")
-    device_registry.async_update_device.assert_called_once()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
     assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
         "data": expected_updated_data,
         "unique_id": observed_device_id,
@@ -1198,189 +955,6 @@ async def test_reload_failure_keeps_entry_update_and_keeps_issue(
     issue_delete.assert_not_called()
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
     hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
-
-
-@pytest.mark.asyncio
-async def test_retry_recovers_when_reload_scheduling_failed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Retry an updated repair by loading the entry and rerunning cleanup."""
-    hass = MagicMock()
-    entry = _make_entry()
-    _configure_hass(hass, entry)
-    entities = [SimpleNamespace(entity_id="sensor.old")]
-    device = SimpleNamespace(id="device")
-    devices = [device]
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=entities,
-        devices=devices,
-    )
-    entity_scan_calls: list[str] = []
-    device_scan_calls: list[str] = []
-
-    def _entity_scan(registry: Any, config_entry_id: str) -> list[Any]:
-        """Track entity scan attempts across retries."""
-        del registry
-        entity_scan_calls.append(config_entry_id)
-        return entities
-
-    def _device_scan(registry: Any, config_entry_id: str) -> list[Any]:
-        """Track device scan attempts across retries."""
-        del registry
-        device_scan_calls.append(config_entry_id)
-        return devices
-
-    monkeypatch.setattr(repairs.er, "async_entries_for_config_entry", _entity_scan)
-    monkeypatch.setattr(repairs.dr, "async_entries_for_config_entry", _device_scan)
-    client = _patch_probe_client(monkeypatch)
-
-    def _remove_entity(entity_id: str) -> None:
-        """Remove an entity from the fake registry after successful cleanup."""
-        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
-
-    def _remove_device(device_id: str, **_: Any) -> None:
-        """Remove a device from the fake registry after successful cleanup."""
-        devices[:] = [device for device in devices if device.id != device_id]
-
-    entity_registry.async_remove.side_effect = _remove_entity
-    device_registry.async_update_device.side_effect = _remove_device
-
-    def _update_entry(
-        config_entry: MockConfigEntry,
-        *,
-        data: dict[str, Any],
-        unique_id: str,
-    ) -> bool:
-        """Apply the replacement identity to the in-memory entry."""
-        object.__setattr__(config_entry, "data", dict(data))
-        object.__setattr__(config_entry, "unique_id", unique_id)
-        return True
-
-    hass.config_entries.async_update_entry.side_effect = _update_entry
-    hass.config_entries.async_reload.side_effect = [
-        HomeAssistantError("reload failed"),
-        True,
-    ]
-    hass.config_entries.async_schedule_reload.side_effect = HomeAssistantError("schedule failed")
-    flow = _make_flow(hass, entry)
-
-    first_result = await flow.async_step_confirm({})
-
-    assert first_result["type"] is FlowResultType.ABORT
-    assert first_result["reason"] == "repair_failed"
-    assert entry.data[CONF_DEVICE_UNIQUE_ID] == "other"
-
-    hass.config_entries.async_update_entry.reset_mock()
-    entity_registry.async_remove.reset_mock()
-    device_registry.async_update_device.reset_mock()
-    client.get_device_unique_id.reset_mock()
-
-    retry_result = await flow.async_step_confirm({})
-
-    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
-    hass.config_entries.async_update_entry.assert_not_called()
-    assert entity_scan_calls == [entry.entry_id, entry.entry_id]
-    assert device_scan_calls == [entry.entry_id, entry.entry_id]
-    client.get_device_unique_id.assert_awaited_once_with()
-    assert hass.config_entries.async_reload.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_retry_repeats_registry_cleanup_after_partial_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A retry should clean up registry entries left after a failed cleanup pass."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
-    _configure_hass(hass, entry)
-    entities = [SimpleNamespace(entity_id="sensor.old")]
-    device = SimpleNamespace(id="device")
-    devices = [device]
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=entities,
-        devices=devices,
-    )
-    client = _patch_probe_client(monkeypatch)
-
-    async def _unload(entry_id: str) -> bool:
-        """Unload the entry so each cleanup pass starts at the hardware boundary."""
-        del entry_id
-        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
-        return True
-
-    hass.config_entries.async_unload.side_effect = _unload
-
-    async def _reload(entry_id: str) -> bool:
-        """Reload the entry after each cleanup attempt."""
-        del entry_id
-        object.__setattr__(entry, "state", ConfigEntryState.LOADED)
-        return True
-
-    hass.config_entries.async_reload.side_effect = _reload
-
-    def _update_entry(
-        config_entry: MockConfigEntry,
-        *,
-        data: dict[str, Any],
-        unique_id: str,
-    ) -> bool:
-        """Apply the replacement identity to the in-memory entry."""
-        object.__setattr__(config_entry, "data", dict(data))
-        object.__setattr__(config_entry, "unique_id", unique_id)
-        return True
-
-    hass.config_entries.async_update_entry.side_effect = _update_entry
-
-    def _remove_entity(entity_id: str) -> None:
-        """Remove an entity from the fake registry."""
-        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
-
-    entity_registry.async_remove.side_effect = _remove_entity
-
-    def _remove_device(device_id: str, **_: Any) -> None:
-        """Remove a device from the fake registry."""
-        devices[:] = [device for device in devices if device.id != device_id]
-
-    cleanup_attempts = 0
-
-    def _update_device(device_id: str, **kwargs: Any) -> None:
-        """Fail the first device cleanup and allow the retry to finish it."""
-        nonlocal cleanup_attempts
-        cleanup_attempts += 1
-        if cleanup_attempts == 1:
-            raise HomeAssistantError("device update")
-        _remove_device(device_id, **kwargs)
-
-    device_registry.async_update_device.side_effect = _update_device
-    flow = _make_flow(hass, entry)
-
-    first_result = await flow.async_step_confirm({})
-
-    assert first_result["type"] is FlowResultType.ABORT
-    assert first_result["reason"] == "repair_failed"
-    assert entities == []
-    assert devices == [device]
-    assert device_registry.async_update_device.call_count == 1
-    assert hass.config_entries.async_reload.await_count == 0
-
-    hass.config_entries.async_update_entry.reset_mock()
-    entity_registry.async_remove.reset_mock()
-
-    retry_result = await flow.async_step_confirm({})
-
-    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
-    hass.config_entries.async_update_entry.assert_not_called()
-    entity_registry.async_remove.assert_not_called()
-    assert device_registry.async_update_device.call_count == 2
-    device_registry.async_update_device.assert_called_with(
-        "device", remove_config_entry_id=entry.entry_id
-    )
-    assert client.get_device_unique_id.await_count == 2
-    assert hass.config_entries.async_unload.await_count == 1
-    assert hass.config_entries.async_reload.await_count == 1
-    assert devices == []
 
 
 @pytest.mark.asyncio
@@ -1411,10 +985,7 @@ async def test_retry_keeps_issue_when_recovery_reload_fails(
     hass.config_entries.async_update_entry.assert_not_called()
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
-    client.factory.assert_called_once_with(hass=hass, config_entry=entry, throw_errors=True)
-    client.validate.assert_awaited_once_with()
-    client.get_device_unique_id.assert_awaited_once_with()
-    client.async_close.assert_awaited_once_with()
+    client.factory.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1523,28 +1094,6 @@ async def test_async_create_device_id_mismatch_issue_ignores_invalid_ids(
 
 
 @pytest.mark.asyncio
-async def test_stored_expected_id_reload_false_retries_recovery_reload(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A loaded entry with matching expected ID should recover when resume reload fails."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
-    _configure_hass(hass, entry)
-    hass.config_entries.async_reload.return_value = False
-    _patch_registries(monkeypatch)
-    _patch_probe_client(monkeypatch, observed_device_id="dev1")
-    flow = _make_flow(hass, entry, new_device_id="dev1")
-
-    result = await flow.async_step_confirm({})
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "repair_failed"
-    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
-    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
-    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
-
-
-@pytest.mark.asyncio
 async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1571,61 +1120,89 @@ async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "reload_error",
-    [HomeAssistantError("reload failed"), KeyError("entry-key")],
-)
-async def test_stored_expected_id_resume_exception_recovers_reloaded_entry(
+async def test_repair_persists_marker_without_registry_mutation(
     monkeypatch: pytest.MonkeyPatch,
-    reload_error: BaseException,
 ) -> None:
-    """Handled exceptions during resume should leave a recovery-reload trace."""
+    """The repair flow persists intent and leaves registry work to setup reconciliation."""
     hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
+    entry = _make_entry()
     _configure_hass(hass, entry)
-    hass.config_entries.async_reload.side_effect = reload_error
-    _patch_registries(monkeypatch)
-    _patch_probe_client(monkeypatch, observed_device_id="dev1")
-    flow = _make_flow(hass, entry, new_device_id="dev1")
+    entity_registry, device_registry = _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
 
     result = await flow.async_step_confirm({})
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "repair_failed"
-    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
-    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
-    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={
+            **entry.data,
+            CONF_DEVICE_UNIQUE_ID: "other",
+            REPAIR_MARKER_KEY: build_repair_marker("dev1", "other"),
+        },
+        unique_id="other",
+    )
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
+async def test_valid_marker_retry_reprobes_and_reloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A changed retry entry must abort before destructive registry cleanup."""
+    """A matching persisted marker resumes only after a fresh strict probe."""
     hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.NOT_LOADED)
-    updated_entry = _make_entry(
-        entry_id=entry.entry_id,
-        device_id="mutated",
-        unique_id="mutated",
+    entry = _make_entry(device_id="other", unique_id="other")
+    object.__setattr__(
+        entry,
+        "data",
+        {**entry.data, REPAIR_MARKER_KEY: build_repair_marker("dev1", "other")},
     )
     _configure_hass(hass, entry)
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-    hass.config_entries.async_get_entry.side_effect = [entry, updated_entry]
-    _patch_probe_client(monkeypatch, observed_device_id="dev1")
-    flow = _make_flow(hass, entry, new_device_id="dev1")
+    client = _patch_probe_client(monkeypatch, observed_device_id="other")
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_completed_retry_without_marker_reloads_without_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-completed repair retries reload without reopening the hardware boundary."""
+    hass = MagicMock()
+    entry = _make_entry(device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    client.factory.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_rejects_invalid_or_mismatched_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed or stale marker cannot resume a repair flow."""
+    hass = MagicMock()
+    entry = _make_entry(device_id="other", unique_id="other")
+    object.__setattr__(entry, "data", {**entry.data, REPAIR_MARKER_KEY: {"version": 1}})
+    _configure_hass(hass, entry)
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
 
     result = await flow.async_step_confirm({})
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "entry_changed"
-    entity_registry.async_remove.assert_not_called()
-    device_registry.async_update_device.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_unload.assert_not_awaited()
-    hass.config_entries.async_reload.assert_not_awaited()
-    hass.config_entries.async_schedule_reload.assert_not_called()
+    client.factory.assert_not_called()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1680,7 +1680,6 @@ def test_entry_matches_snapshot_invariants(
     baseline = dict(entry.data)
     snapshot = {**baseline, TRACKED_MACS: ["AA:BB:CC:DD"]}
     current = {**baseline, TRACKED_MACS: ["11:22:33:44"]}
-    object.__setattr__(entry, "data", snapshot)
     object.__setattr__(entry, "data", current)
 
     expected_match = scenario == "tracked-macs-allow"

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -895,6 +895,37 @@ async def test_loaded_entry_update_exception_recovers_without_registry_mutation(
 
 
 @pytest.mark.asyncio
+async def test_expected_id_retry_reprobes_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry must not clean registries when the firewall ID no longer matches."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch, observed_device_id="reverted")
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_expected_id_retry_rechecks_snapshot_after_unload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -915,6 +946,7 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
         return True
 
     hass.config_entries.async_unload.side_effect = _unload_and_mutate
+    _patch_probe_client(monkeypatch)
     flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
 
     result = await flow.async_step_confirm({})
@@ -958,6 +990,7 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
     entity_registry.async_remove.side_effect = _remove_entity
     issue_delete = MagicMock()
     monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    _patch_probe_client(monkeypatch)
     flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
 
     result = await flow.async_step_confirm({})
@@ -1093,7 +1126,7 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
         "data": expected_updated_data,
         "unique_id": observed_device_id,
     }
-    client.get_device_unique_id.assert_not_awaited()
+    client.get_device_unique_id.assert_awaited_once_with()
     assert hass.config_entries.async_reload.await_count == 1
     assert hass.config_entries.async_update_entry.call_count == 1
     assert entity_registry.async_remove.call_count == 2
@@ -1249,7 +1282,7 @@ async def test_retry_recovers_when_reload_scheduling_failed(
     hass.config_entries.async_update_entry.assert_not_called()
     assert entity_scan_calls == [entry.entry_id, entry.entry_id]
     assert device_scan_calls == [entry.entry_id, entry.entry_id]
-    client.get_device_unique_id.assert_not_awaited()
+    client.get_device_unique_id.assert_awaited_once_with()
     assert hass.config_entries.async_reload.await_count == 2
 
 
@@ -1344,7 +1377,7 @@ async def test_retry_repeats_registry_cleanup_after_partial_failure(
     device_registry.async_update_device.assert_called_with(
         "device", remove_config_entry_id=entry.entry_id
     )
-    client.get_device_unique_id.assert_awaited_once_with()
+    assert client.get_device_unique_id.await_count == 2
     assert hass.config_entries.async_unload.await_count == 1
     assert hass.config_entries.async_reload.await_count == 1
     assert devices == []
@@ -1378,7 +1411,10 @@ async def test_retry_keeps_issue_when_recovery_reload_fails(
     hass.config_entries.async_update_entry.assert_not_called()
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
-    client.factory.assert_not_called()
+    client.factory.assert_called_once_with(hass=hass, config_entry=entry, throw_errors=True)
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    client.async_close.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio
@@ -1496,6 +1532,7 @@ async def test_stored_expected_id_reload_false_retries_recovery_reload(
     _configure_hass(hass, entry)
     hass.config_entries.async_reload.return_value = False
     _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch, observed_device_id="dev1")
     flow = _make_flow(hass, entry, new_device_id="dev1")
 
     result = await flow.async_step_confirm({})
@@ -1521,6 +1558,7 @@ async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
     _configure_hass(hass, entry)
     hass.config_entries.async_reload.return_value = False
     _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch, observed_device_id="dev1")
     flow = _make_flow(hass, entry, new_device_id="dev1")
 
     result = await flow.async_step_confirm({})
@@ -1547,6 +1585,7 @@ async def test_stored_expected_id_resume_exception_recovers_reloaded_entry(
     _configure_hass(hass, entry)
     hass.config_entries.async_reload.side_effect = reload_error
     _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch, observed_device_id="dev1")
     flow = _make_flow(hass, entry, new_device_id="dev1")
 
     result = await flow.async_step_confirm({})
@@ -1577,6 +1616,7 @@ async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
         devices=[SimpleNamespace(id="device")],
     )
     hass.config_entries.async_get_entry.side_effect = [entry, updated_entry]
+    _patch_probe_client(monkeypatch, observed_device_id="dev1")
     flow = _make_flow(hass, entry, new_device_id="dev1")
 
     result = await flow.async_step_confirm({})

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -413,12 +413,14 @@ async def test_loaded_entry_unloads_before_registry_cleanup(
         pytest.param(TimeoutError("timeout"), None, id="timeout-error"),
         pytest.param(None, None, id="missing-device-id"),
         pytest.param(None, "", id="blank-device-id"),
+        pytest.param(None, "   ", id="whitespace-device-id"),
+        pytest.param(None, 123, id="non-string-device-id"),
     ],
 )
 async def test_invalid_probe_result_aborts_without_mutations(
     monkeypatch: pytest.MonkeyPatch,
     probe_error: BaseException | None,
-    observed_device_id: str | None,
+    observed_device_id: Any,
 ) -> None:
     """Invalid strict-probe results should abort and close the client."""
     hass = MagicMock()
@@ -1392,20 +1394,81 @@ async def test_removed_entry_aborts_without_mutations(
 
 
 @pytest.mark.asyncio
-async def test_fix_flow_factory_validates_issue_suffix_and_payload() -> None:
+@pytest.mark.parametrize(
+    ("data", "expects_replacement_flow"),
+    [
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "dev1",
+                "new_device_id": "other",
+            },
+            True,
+        ),
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "dev1",
+                "new_device_id": "   ",
+            },
+            False,
+        ),
+        (
+            {
+                "entry_id": "entry-1",
+                "old_device_id": "   ",
+                "new_device_id": "other",
+            },
+            False,
+        ),
+    ],
+)
+async def test_fix_flow_factory_validates_issue_suffix_and_payload(
+    data: dict[str, str | int | float | None],
+    expects_replacement_flow: bool,
+) -> None:
     """Only well-formed device-ID issues should construct the destructive flow."""
     hass = MagicMock()
-    data: dict[str, str | int | float | None] = {
-        "entry_id": "entry-1",
-        "old_device_id": "dev1",
-        "new_device_id": "other",
-    }
-
     flow = await repairs.async_create_fix_flow(hass, "entry-1_device_id_mismatched", data)
-
-    assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    if expects_replacement_flow:
+        assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    else:
+        assert isinstance(flow, ConfirmRepairFlow)
     unknown_flow = await repairs.async_create_fix_flow(hass, "unrelated", None)
     assert isinstance(unknown_flow, ConfirmRepairFlow)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry_device_id", "observed_device_id", "expect_issue"),
+    [
+        ("dev1", "other", True),
+        ("   ", "other", False),
+        ("dev1", "   ", False),
+    ],
+)
+async def test_async_create_device_id_mismatch_issue_ignores_invalid_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    entry_device_id: str,
+    observed_device_id: str,
+    expect_issue: bool,
+) -> None:
+    """Do not create mismatches when configured or observed IDs are malformed."""
+    entry = _make_entry(device_id=entry_device_id)
+    called: dict[str, int] = {"count": 0}
+
+    def _capture_issue(**kwargs: Any) -> None:
+        del kwargs
+        called["count"] += 1
+
+    monkeypatch.setattr(repairs.ir, "async_create_issue", _capture_issue)
+
+    repairs.async_create_device_id_mismatch_issue(MagicMock(), entry, observed_device_id)
+
+    if expect_issue:
+        assert called["count"] == 1
+    else:
+        assert called["count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1461,12 +1461,16 @@ async def test_async_create_device_id_mismatch_issue_ignores_invalid_ids(
 
     monkeypatch.setattr(repairs.ir, "async_create_issue", _capture_issue)
 
-    repairs.async_create_device_id_mismatch_issue(MagicMock(), entry, observed_device_id)
+    issue_created = repairs.async_create_device_id_mismatch_issue(
+        MagicMock(), entry, observed_device_id
+    )
 
     if expect_issue:
         assert called["count"] == 1
+        assert issue_created is True
     else:
         assert called["count"] == 0
+        assert issue_created is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -976,10 +976,19 @@ async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("failure_point", ["entity", "device"])
+@pytest.mark.parametrize(
+    ("failure_point", "cleanup_exception"),
+    [
+        pytest.param("entity", HomeAssistantError, id="entity-homeassistant-error"),
+        pytest.param("entity", ValueError, id="entity-valueerror"),
+        pytest.param("device", HomeAssistantError, id="device-homeassistant-error"),
+        pytest.param("device", ValueError, id="device-valueerror"),
+    ],
+)
 async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     monkeypatch: pytest.MonkeyPatch,
     failure_point: str,
+    cleanup_exception: type[BaseException],
 ) -> None:
     """Cleanup failure keeps replacement ID for a retry that reruns cleanup."""
     hass = MagicMock()
@@ -1016,7 +1025,7 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
         def _remove(entity_id: str) -> None:
             """Fail entity cleanup to exercise recovery reload behavior."""
             del entity_id
-            raise HomeAssistantError("entity remove")
+            raise cleanup_exception("entity remove")
 
         entity_registry.async_remove.side_effect = _remove
     else:
@@ -1024,7 +1033,7 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
         def _update_device(device_id: str, **_: Any) -> None:
             """Fail device cleanup to exercise recovery reload behavior."""
             del device_id
-            raise HomeAssistantError("device update")
+            raise cleanup_exception("device update")
 
         device_registry.async_update_device.side_effect = _update_device
 

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
@@ -236,10 +236,17 @@ async def test_confirmation_reprobes_with_strict_client_and_closes_it(
     result = await flow.async_step_confirm({})
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    client.factory.assert_called_once_with(hass=hass, config_entry=entry, throw_errors=True)
-    client.validate.assert_awaited_once_with()
-    client.get_device_unique_id.assert_awaited_once_with()
-    client.async_close.assert_awaited_once_with()
+    assert client.factory.call_count == 2
+    client.factory.assert_has_calls(
+        [
+            call(hass=hass, config_entry=entry, throw_errors=True),
+            call(hass=hass, config_entry=entry, throw_errors=True),
+        ],
+        any_order=False,
+    )
+    assert client.validate.await_count == 2
+    assert client.get_device_unique_id.await_count == 2
+    assert client.async_close.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -525,6 +532,9 @@ async def test_loaded_entry_unloads_before_marker_update_and_reload(
         "duplicate_scan",
         "duplicate_check",
         "unload",
+        "validate",
+        "probe",
+        "close",
         "duplicate_scan",
         "duplicate_check",
         "config_update",
@@ -533,6 +543,130 @@ async def test_loaded_entry_unloads_before_marker_update_and_reload(
     ]
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_reprobe_after_unload_rejects_router_swap_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A router change after unload must be re-probed and must not persist stale IDs."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    probe_calls: list[int] = []
+
+    async def _probe_then_swap() -> str:
+        """Return a stale ID before unload and a swapped ID after unload."""
+        probe_calls.append(1)
+        if len(probe_calls) == 1:
+            return "other"
+        return "swapped"
+
+    client.get_device_unique_id.side_effect = _probe_then_swap
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    assert client.get_device_unique_id.await_count == 2
+    assert client.async_close.await_count == 2
+    assert len(probe_calls) == 2
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_reprobe_after_unload_rejects_probe_failure_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A strict re-probe failure after unload must abort and recover without mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    probe_calls: list[int] = []
+
+    async def _probe_then_fail() -> str:
+        """Return a stale ID before unload and fail on the re-probe."""
+        probe_calls.append(1)
+        if len(probe_calls) == 1:
+            return "other"
+        raise OPNsenseConnectionError("offline")
+
+    client.get_device_unique_id.side_effect = _probe_then_fail
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    assert client.get_device_unique_id.await_count == 2
+    assert client.async_close.await_count == 2
+    assert len(probe_calls) == 2
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_entry_swap_reprobe_snapshot_stability_checks_after_unload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An entry that mutates while reprobing must abort before persistence."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    probe_calls: list[int] = []
+
+    async def _probe_then_mutate_entry() -> str:
+        """Mutate entry persistence during the second probe cycle."""
+        probe_calls.append(1)
+        if len(probe_calls) == 2:
+            object.__setattr__(
+                entry,
+                "data",
+                {**entry.data, "url": "https://changed.example"},
+            )
+        return "other"
+
+    client.get_device_unique_id.side_effect = _probe_then_mutate_entry
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    assert client.get_device_unique_id.await_count == 2
+    assert client.async_close.await_count == 2
+    assert len(probe_calls) == 2
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
 
 
 @pytest.mark.asyncio
@@ -917,7 +1051,7 @@ async def test_entry_update_failure_aborts_without_registry_mutation(
     )
     issue_delete.assert_not_called()
     hass.config_entries.async_schedule_reload.assert_not_called()
-    client.async_close.assert_awaited_once_with()
+    assert client.async_close.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, call
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
-    OPNsenseError,
     OPNsenseMissingDeviceUniqueID,
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
@@ -782,6 +781,7 @@ async def test_entry_swap_reprobe_snapshot_stability_checks_after_unload(
     [
         pytest.param(OPNsenseConnectionError("transport"), None, id="connection-error"),
         pytest.param(OPNsenseTimeoutError("timeout"), None, id="timeout-error"),
+        pytest.param(TimeoutError("raw timeout"), None, id="raw-timeout-error"),
         pytest.param(None, None, id="missing-device-id"),
         pytest.param(None, "", id="blank-device-id"),
         pytest.param(None, "   ", id="whitespace-device-id"),
@@ -817,6 +817,7 @@ async def test_invalid_probe_result_aborts_without_mutations(
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_reload.assert_not_awaited()
     hass.config_entries.async_update_entry.assert_not_called()
     hass.config_entries.async_schedule_reload.assert_not_called()
 
@@ -1698,13 +1699,14 @@ async def test_valid_marker_retry_reprobes_and_reloads(
     [
         (OPNsenseConnectionError("transport"), None, "cannot_connect"),
         (OPNsenseTimeoutError("timeout"), None, "cannot_connect"),
+        (TimeoutError("raw timeout"), None, "cannot_connect"),
         (None, "", "cannot_connect"),
         (None, "dev1", "entry_changed"),
     ],
 )
 async def test_marker_retry_reprobe_error_and_id_checks_abort_without_mutation(
     monkeypatch: pytest.MonkeyPatch,
-    probe_error: OPNsenseError | None,
+    probe_error: BaseException | None,
     observed_device_id: Any | None,
     expected_reason: str,
 ) -> None:
@@ -1730,7 +1732,9 @@ async def test_marker_retry_reprobe_error_and_id_checks_abort_without_mutation(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
     hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_reload.assert_not_awaited()
     hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import HomeAssistantError
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import repairs
+from custom_components.opnsense import repair_reconciliation, repairs
 from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
 from custom_components.opnsense.repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker
 
@@ -85,9 +85,63 @@ def _patch_registries(
     devices: list[Any] | None = None,
 ) -> tuple[MagicMock, MagicMock]:
     """Return registry spies proving the confirmation flow does not mutate registries."""
-    del monkeypatch, entities, devices
+    entries = list(entities or [])
+    devices = list(devices or [])
     entity_registry = MagicMock()
     device_registry = MagicMock()
+
+    def _get_entry(entity_id: str) -> Any:
+        """Return a matching entity from the provided entity fixture list."""
+        for entry in entries:
+            if getattr(entry, "entity_id", None) == entity_id:
+                return entry
+        return None
+
+    def _get_entity_id(domain: str, platform: str, unique_id: str) -> str | None:
+        """Return the stored entity_id matching domain, platform, and unique_id."""
+        for entity in entries:
+            if (
+                getattr(entity, "domain", None) == domain
+                and getattr(entity, "platform", None) == platform
+                and getattr(entity, "unique_id", None) == unique_id
+            ):
+                return getattr(entity, "entity_id", None)
+        return None
+
+    def _get_device(identifiers: set[tuple[str, str]] | frozenset[tuple[str, str]]) -> Any:
+        """Return a matching device fixture whose identifiers cover the query."""
+        for device in devices:
+            if getattr(device, "identifiers", frozenset()).issuperset(identifiers):
+                return device
+        return None
+
+    def _entities_for_config_entry(_registry: Any, _config_entry_id: Any) -> list[Any]:
+        """Return configured entities for a config-entry-based lookup."""
+        return entries
+
+    def _devices_for_config_entry(_registry: Any, _config_entry_id: Any) -> list[Any]:
+        """Return configured devices for a config-entry-based lookup."""
+        return devices
+
+    entity_registry.async_get = MagicMock(side_effect=_get_entry)
+    entity_registry.async_get_entity_id = MagicMock(side_effect=_get_entity_id)
+    entity_registry.async_update_entity = MagicMock()
+    entity_registry.async_remove = MagicMock()
+    device_registry.async_get_device = MagicMock(side_effect=_get_device)
+    device_registry.async_update_device = MagicMock()
+
+    # Install the registries behind module-level helper accessors used during
+    # repair reconciliation to ensure production call sites consume these
+    # in-memory registries directly.
+    monkeypatch.setattr(repair_reconciliation.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(
+        repair_reconciliation.er, "async_entries_for_config_entry", _entities_for_config_entry
+    )
+    monkeypatch.setattr(repair_reconciliation.dr, "async_get", lambda _hass: device_registry)
+    monkeypatch.setattr(
+        repair_reconciliation.dr, "async_entries_for_config_entry", _devices_for_config_entry
+    )
+
     return entity_registry, device_registry
 
 
@@ -1067,6 +1121,8 @@ async def test_retry_keeps_issue_when_recovery_reload_fails(
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     client.factory.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,4 +1,4 @@
-"""Tests for the OPNsense device-ID replacement repair flow."""
+"""Tests for the OPNsense Device ID replacement repair flow."""
 
 from types import SimpleNamespace
 from typing import Any
@@ -1316,7 +1316,7 @@ async def test_fix_flow_factory_validates_issue_suffix_and_payload(
     data: dict[str, str | int | float | None],
     expects_replacement_flow: bool,
 ) -> None:
-    """Only well-formed device-ID issues should construct the destructive flow."""
+    """Only well-formed Device ID issues should construct the destructive flow."""
     hass = MagicMock()
     flow = await repairs.async_create_fix_flow(hass, "entry-1_device_id_mismatched", data)
     if expects_replacement_flow:

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -291,39 +291,7 @@ async def test_old_device_id_mismatch_aborts_without_mutations(
 async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Duplicate replacement IDs must abort before any destructive mutation."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
-    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
-    _configure_hass(hass, entry)
-    hass.config_entries.async_entries.return_value = [entry, duplicate]
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-    _patch_probe_client(monkeypatch)
-    issue_delete = MagicMock()
-    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
-    flow = _make_flow(hass, entry)
-
-    result = await flow.async_step_confirm({})
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    hass.config_entries.async_unload.assert_not_awaited()
-    entity_registry.async_remove.assert_not_called()
-    device_registry.async_update_device.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_schedule_reload.assert_not_called()
-    issue_delete.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_duplicate_entry_created_during_unload_aborts_without_mutation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A duplicate created during unload must abort before config or registry mutation."""
+    """Duplicates created during unload must abort before config or registry mutation."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED)
     duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
@@ -353,9 +321,10 @@ async def test_duplicate_entry_created_during_unload_aborts_without_mutation(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
-    hass.config_entries.async_update_entry.assert_not_called()
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
     issue_delete.assert_not_called()
     assert entry.data[CONF_DEVICE_UNIQUE_ID] == "dev1"
     assert entry.unique_id == "dev1"

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,7 +1,7 @@
 """Tests for the OPNsense Device ID replacement repair flow."""
 
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, call
 
 from aiopnsense.exceptions import (
@@ -19,7 +19,13 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import repair_reconciliation, repairs
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN, TRACKED_MACS
+from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_ENTRY_TYPE,
+    DOMAIN,
+    ENTRY_TYPE_CARP,
+    TRACKED_MACS,
+)
 from custom_components.opnsense.repair_reconciliation import REPAIR_MARKER_KEY, build_repair_marker
 
 
@@ -43,6 +49,21 @@ def _make_entry(
     object.__setattr__(entry, "unique_id", unique_id)
     object.__setattr__(entry, "state", state)
     object.__setattr__(entry, "options", options or {"scan_interval": 30})
+    return entry
+
+
+def _make_carp_entry(*, entry_id: str = "carp-entry", unique_id: str = "other") -> MockConfigEntry:
+    """Build a device-ID-less CARP config entry for repair boundary tests."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "url": "https://carp.example",
+            CONF_ENTRY_TYPE: ENTRY_TYPE_CARP,
+        },
+        title="OPNsense CARP VIP",
+        unique_id=unique_id,
+    )
+    object.__setattr__(entry, "entry_id", entry_id)
     return entry
 
 
@@ -451,6 +472,26 @@ async def test_observed_duplicate_id_aborts_before_unload_or_mutation(
 
 
 @pytest.mark.asyncio
+async def test_carp_entry_with_matching_unique_id_is_not_device_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CARP entry identity must not block a physical-device ID repair."""
+    hass = MagicMock()
+    entry = _make_entry()
+    carp_entry = _make_carp_entry()
+    _configure_hass(hass, entry)
+    hass.config_entries.async_entries.return_value = [entry, carp_entry]
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch, observed_device_id="other")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_loaded_entry_unloads_before_marker_update_and_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -469,6 +510,7 @@ async def test_loaded_entry_unloads_before_marker_update_and_reload(
         """Duplicate-scan candidate whose ID access is observable."""
 
         entry_id = "entry-2"
+        data: ClassVar[dict[str, Any]] = {}
 
         @property
         def unique_id(self) -> str:
@@ -1328,6 +1370,25 @@ async def test_fix_flow_factory_validates_issue_suffix_and_payload(
 
 
 @pytest.mark.asyncio
+async def test_fix_flow_factory_rejects_carp_entry() -> None:
+    """Device ID repair issues cannot target device-ID-less CARP entries."""
+    hass = MagicMock()
+    hass.config_entries.async_get_entry.return_value = _make_carp_entry()
+
+    flow = await repairs.async_create_fix_flow(
+        hass,
+        "carp-entry_device_id_mismatched",
+        {
+            "entry_id": "carp-entry",
+            "old_device_id": "dev1",
+            "new_device_id": "other",
+        },
+    )
+
+    assert isinstance(flow, ConfirmRepairFlow)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("entry_device_id", "observed_device_id", "expect_issue"),
     [
@@ -1362,6 +1423,21 @@ async def test_async_create_device_id_mismatch_issue_ignores_invalid_ids(
     else:
         assert called["count"] == 0
         assert issue_created is False
+
+
+def test_async_create_device_id_mismatch_issue_ignores_carp_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CARP entries do not participate in physical Device ID mismatch repairs."""
+    issue_create = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_create_issue", issue_create)
+
+    issue_created = repairs.async_create_device_id_mismatch_issue(
+        MagicMock(), _make_carp_entry(), "other"
+    )
+
+    assert issue_created is False
+    issue_create.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1270,6 +1270,7 @@ async def test_expected_id_retry_rechecks_snapshot_after_unload(
         pytest.param(False, id="false-result"),
         pytest.param(HomeAssistantError("entry removed"), id="homeassistant-error"),
         pytest.param(KeyError("entry key"), id="key-error"),
+        pytest.param(TimeoutError("raw timeout"), id="raw-timeout-error"),
     ],
 )
 async def test_reload_failure_keeps_entry_update_and_keeps_issue(
@@ -1337,7 +1338,12 @@ async def test_reload_failure_keeps_entry_update_and_keeps_issue(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "reload_result",
-    [False, HomeAssistantError("reload failed"), KeyError("entry key")],
+    [
+        pytest.param(False, id="false-result"),
+        pytest.param(HomeAssistantError("reload failed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry key"), id="key-error"),
+        pytest.param(TimeoutError("raw timeout"), id="raw-timeout-error"),
+    ],
 )
 async def test_retry_keeps_issue_when_recovery_reload_fails(
     monkeypatch: pytest.MonkeyPatch,
@@ -1507,8 +1513,13 @@ def test_async_create_device_id_mismatch_issue_ignores_carp_entry(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reload_result",
+    [False, TimeoutError("raw timeout")],
+)
 async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
     monkeypatch: pytest.MonkeyPatch,
+    reload_result: bool | Exception,
 ) -> None:
     """An unloaded expected-ID retry should still keep recovery reload on failure."""
     hass = MagicMock()
@@ -1518,7 +1529,10 @@ async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
         unique_id="dev1",
     )
     _configure_hass(hass, entry)
-    hass.config_entries.async_reload.return_value = False
+    if isinstance(reload_result, bool):
+        hass.config_entries.async_reload.return_value = reload_result
+    else:
+        hass.config_entries.async_reload.side_effect = reload_result
     _patch_registries(monkeypatch)
     _patch_probe_client(monkeypatch, observed_device_id="dev1")
     flow = _make_flow(hass, entry, new_device_id="dev1")

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1,0 +1,1481 @@
+"""Tests for the OPNsense device-ID replacement repair flow."""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+from aiopnsense.exceptions import OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.exceptions import HomeAssistantError
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.opnsense import repairs
+from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, DOMAIN
+
+
+def _make_entry(
+    *,
+    entry_id: str = "entry-1",
+    device_id: str = "dev1",
+    unique_id: str | None = "dev1",
+    state: ConfigEntryState = ConfigEntryState.NOT_LOADED,
+    options: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Build a config entry with connection data used by the repair tests."""
+    data: dict[str, Any] = {
+        "url": "https://router.example",
+        "username": "api-user",
+        "password": "api-password",
+        CONF_DEVICE_UNIQUE_ID: device_id,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data, title="OPNsense Test")
+    object.__setattr__(entry, "entry_id", entry_id)
+    object.__setattr__(entry, "unique_id", unique_id)
+    object.__setattr__(entry, "state", state)
+    object.__setattr__(entry, "options", options or {"scan_interval": 30})
+    return entry
+
+
+def _make_flow(
+    hass: Any,
+    entry: MockConfigEntry,
+    *,
+    old_device_id: str | None = None,
+    new_device_id: str = "other",
+) -> repairs.DeviceIDMismatchRepairFlow:
+    """Create a configured repair flow for direct step testing."""
+    if old_device_id is None:
+        old_device_id = entry.data[CONF_DEVICE_UNIQUE_ID]
+    flow = repairs.DeviceIDMismatchRepairFlow(
+        entry_id=entry.entry_id,
+        old_device_id=old_device_id,
+        new_device_id=new_device_id,
+    )
+    flow.hass = hass
+    flow.handler = DOMAIN
+    flow.issue_id = f"{entry.entry_id}_device_id_mismatched"
+    flow.flow_id = "flow-1"
+    return flow
+
+
+def _configure_hass(hass: Any, entry: MockConfigEntry) -> None:
+    """Configure the config-entry manager methods shared by flow tests."""
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry.return_value = entry
+    hass.config_entries.async_entries.return_value = [entry]
+    hass.config_entries.async_unload = AsyncMock(return_value=True)
+    hass.config_entries.async_update_entry = MagicMock(return_value=True)
+    hass.config_entries.async_reload = AsyncMock(return_value=True)
+    hass.config_entries.async_schedule_reload = MagicMock()
+
+
+def _patch_registries(
+    monkeypatch: pytest.MonkeyPatch,
+    entities: list[Any] | None = None,
+    devices: list[Any] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Patch entity/device registry lookups and return the fake registries."""
+    entity_registry = MagicMock()
+    device_registry = MagicMock()
+    monkeypatch.setattr(repairs.er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        repairs.er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: entities or [],
+    )
+    monkeypatch.setattr(repairs.dr, "async_get", lambda hass: device_registry)
+    monkeypatch.setattr(
+        repairs.dr,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: devices or [],
+    )
+    return entity_registry, device_registry
+
+
+def _patch_issue_registry(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch issue lookups used to render confirmation placeholders."""
+    issue_registry = MagicMock()
+    issue_registry.async_get_issue.return_value = SimpleNamespace(
+        translation_placeholders={
+            "entry_title": "OPNsense Test",
+            "old_device_id": "dev1",
+            "new_device_id": "other",
+        }
+    )
+    monkeypatch.setattr(repairs.ir, "async_get", lambda hass: issue_registry)
+    return issue_registry
+
+
+def _patch_probe_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    observed_device_id: Any = "other",
+    probe_error: BaseException | None = None,
+    events: list[str] | None = None,
+) -> MagicMock:
+    """Patch strict client construction and return the client mock."""
+    client = MagicMock()
+
+    async def _probe() -> Any:
+        """Return the configured replacement identifier."""
+        if events is not None:
+            events.append("probe")
+        return observed_device_id
+
+    async def _validate() -> None:
+        """Record strict client validation."""
+        if events is not None:
+            events.append("validate")
+
+    async def _close() -> None:
+        """Record strict probe client closure."""
+        if events is not None:
+            events.append("close")
+
+    client.get_device_unique_id = AsyncMock(
+        side_effect=probe_error if probe_error is not None else _probe
+    )
+    client.validate = AsyncMock(side_effect=_validate)
+    client.async_close = AsyncMock(side_effect=_close)
+    factory = MagicMock(return_value=client)
+    client.factory = factory
+    monkeypatch.setattr(repairs, "create_opnsense_client_from_config_entry", factory)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_initial_flow_renders_replacement_ids_and_confirmation_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial step should show old/new IDs and a destructive-rebuild confirmation."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _patch_issue_registry(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_init()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {
+        "entry_title": entry.title,
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+    data_schema = result["data_schema"]
+    assert data_schema is not None
+    assert data_schema({}) == {}
+
+
+@pytest.mark.asyncio
+async def test_confirmation_reprobes_with_strict_client_and_closes_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confirmation should re-probe the current ID with throw_errors enabled."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    client = _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    client.factory.assert_called_once_with(hass=hass, config_entry=entry, throw_errors=True)
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_awaited_once_with()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_stale_observed_device_id_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale issue with matching observed ID should abort without destructive work."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch, observed_device_id="dev1")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_observed_device_id_mismatch_with_issue_expected_id_aborts_before_unload_or_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Observed IDs that do not match issue expectation must abort without mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch, observed_device_id="third")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_old_device_id_mismatch_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale issue with mismatched old_device_id should abort without mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(
+        hass,
+        entry,
+        old_device_id="stale-old-device-id",
+        new_device_id="other",
+    )
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    client.factory.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    client.validate.assert_not_awaited()
+    client.get_device_unique_id.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_entry_aborts_before_unload_or_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate replacement IDs must abort before any destructive mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    hass.config_entries.async_entries.return_value = [entry, duplicate]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    issue_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_unloads_before_registry_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded entry must unload before entities or devices are removed."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    events: list[str] = []
+    _configure_hass(hass, entry)
+
+    def _unload(entry_id: str) -> bool:
+        """Record unload before returning success."""
+        events.append("unload")
+        return True
+
+    class _OtherEntry:
+        """Duplicate-scan candidate whose ID access is observable."""
+
+        entry_id = "entry-2"
+
+        @property
+        def unique_id(self) -> str:
+            """Record the duplicate candidate comparison."""
+            events.append("duplicate_check")
+            return "different"
+
+    def _entries(domain: str) -> list[Any]:
+        """Record the duplicate scan and return only non-conflicting entries."""
+        events.append("duplicate_scan")
+        return [entry, _OtherEntry()]
+
+    hass.config_entries.async_entries.side_effect = _entries
+    hass.config_entries.async_unload.side_effect = _unload
+    entity = SimpleNamespace(entity_id="sensor.old", disabled_by=None)
+    device = SimpleNamespace(id="device")
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch, entities=[entity], devices=[device]
+    )
+    entity_registry.async_remove.side_effect = lambda entity_id: events.append("entity")
+    device_registry.async_update_device.side_effect = lambda device_id, **kwargs: events.append(
+        "device"
+    )
+
+    def _update_entry(*args: Any, **kwargs: Any) -> bool:
+        """Record the config update and report that it changed the entry."""
+        del args, kwargs
+        events.append("config_update")
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    async def _reload(entry_id: str) -> bool:
+        """Record reload scheduling and signal success."""
+        del entry_id
+        events.append("reload")
+        return True
+
+    hass.config_entries.async_reload.side_effect = _reload
+    _patch_probe_client(monkeypatch, events=events)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", lambda *args: events.append("delete"))
+    flow = _make_flow(hass, entry)
+
+    def _create_entry(**_: Any) -> dict[str, str]:
+        """Record creation after the reload was scheduled."""
+        events.append("create")
+        return {"type": "create_entry"}
+
+    object.__setattr__(
+        flow,
+        "async_create_entry",
+        _create_entry,
+    )
+
+    await flow.async_step_confirm({})
+
+    assert events == [
+        "validate",
+        "probe",
+        "close",
+        "duplicate_scan",
+        "duplicate_check",
+        "unload",
+        "config_update",
+        "entity",
+        "device",
+        "reload",
+        "create",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("probe_error", "observed_device_id"),
+    [
+        pytest.param(aiohttp.ClientError("transport"), None, id="transport-error"),
+        pytest.param(TimeoutError("timeout"), None, id="timeout-error"),
+        pytest.param(None, None, id="missing-device-id"),
+        pytest.param(None, "", id="blank-device-id"),
+    ],
+)
+async def test_invalid_probe_result_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+    probe_error: BaseException | None,
+    observed_device_id: str | None,
+) -> None:
+    """Invalid strict-probe results should abort and close the client."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(
+        monkeypatch,
+        observed_device_id=observed_device_id,
+        probe_error=probe_error,
+    )
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    client.async_close.assert_awaited_once_with()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "validation_error",
+    [
+        pytest.param(OPNsenseBelowMinFirmware("unsupported"), id="below-minimum"),
+        pytest.param(OPNsenseUnknownFirmware("unknown"), id="unknown-firmware"),
+    ],
+)
+async def test_firmware_validation_failure_aborts_before_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+    validation_error: BaseException,
+) -> None:
+    """Firmware validation failures must stop the repair before any mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    client.validate.side_effect = validation_error
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    client.validate.assert_awaited_once_with()
+    client.get_device_unique_id.assert_not_awaited()
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unload_failure_aborts_before_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed unload must leave entity/device registries and entry data intact."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_unload.return_value = False
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        ConfigEntryState.FAILED_UNLOAD,
+        ConfigEntryState.SETUP_IN_PROGRESS,
+        ConfigEntryState.UNLOAD_IN_PROGRESS,
+    ],
+)
+async def test_nonrecoverable_entry_state_aborts_before_unload_or_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    state: ConfigEntryState,
+) -> None:
+    """Non-recoverable entry states must not reach unload or repair mutation."""
+    hass = MagicMock()
+    entry = _make_entry(state=state)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    client.async_close.assert_awaited_once_with()
+    hass.config_entries.async_unload.assert_not_awaited()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_removed_during_unload_aborts_before_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A removed entry after unload must not allow stale registry mutations."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_get_entry.side_effect = [entry, entry, None]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutation_stage", ["probe", "unload"])
+@pytest.mark.parametrize("field", ["url", "username", "password", "options", "unique_id"])
+async def test_entry_changed_during_probe_or_unload_aborts_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    mutation_stage: str,
+    field: str,
+) -> None:
+    """Config-entry changes during awaited work must stop the destructive repair."""
+    hass = MagicMock()
+    entry = _make_entry(
+        state=ConfigEntryState.LOADED if mutation_stage == "unload" else ConfigEntryState.NOT_LOADED
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    def _mutate_entry() -> None:
+        """Apply one persisted-entry mutation while the repair is awaiting."""
+        if field in {"url", "username", "password"}:
+            object.__setattr__(entry, "data", {**entry.data, field: f"changed-{field}"})
+        elif field == "options":
+            entry.options["scan_interval"] = 99
+        else:
+            object.__setattr__(entry, "unique_id", "changed-unique-id")
+
+    if mutation_stage == "probe":
+
+        async def _probe_and_mutate() -> str:
+            """Mutate the entry before the probe completes."""
+            _mutate_entry()
+            return "other"
+
+        client.get_device_unique_id.side_effect = _probe_and_mutate
+    else:
+
+        def _unload_and_mutate(entry_id: str) -> bool:
+            """Mutate the entry while unloading it."""
+            _mutate_entry()
+            return True
+
+        hass.config_entries.async_unload.side_effect = _unload_and_mutate
+
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    if mutation_stage == "probe":
+        hass.config_entries.async_unload.assert_not_awaited()
+    else:
+        hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_nested_mutable_options_mutation_during_probe_aborts_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mutating a nested options list in-place during probe must still abort safely."""
+    hass = MagicMock()
+    nested_devices = ["aa:bb:cc:dd:ee:01"]
+    entry = _make_entry(
+        state=ConfigEntryState.NOT_LOADED,
+        options={"scan_interval": 30, "devices": nested_devices},
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    async def _probe_and_mutate() -> str:
+        nested_devices.append("aa:bb:cc:dd:ee:02")
+        return "other"
+
+    client.get_device_unique_id.side_effect = _probe_and_mutate
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert nested_devices == ["aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02"]
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_disabled_entities_directly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entity cleanup should remove all entries, including integration/user-disabled ones."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entities = [
+        SimpleNamespace(entity_id="sensor.enabled", disabled_by=None),
+        SimpleNamespace(entity_id="sensor.integration_disabled", disabled_by="integration"),
+        SimpleNamespace(entity_id="sensor.user_disabled", disabled_by="user"),
+    ]
+    entity_registry, _ = _patch_registries(monkeypatch, entities=entities)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    assert [call.args[0] for call in entity_registry.async_remove.call_args_list] == [
+        "sensor.enabled",
+        "sensor.integration_disabled",
+        "sensor.user_disabled",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_only_this_config_entry_from_shared_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shared devices should retain associations with other config entries."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    devices = [
+        SimpleNamespace(id="device-only", config_entries={entry.entry_id}),
+        SimpleNamespace(id="device-shared", config_entries={entry.entry_id, "entry-2"}),
+    ]
+    _, device_registry = _patch_registries(monkeypatch, devices=devices)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    assert device_registry.async_update_device.call_args_list == [
+        (("device-only",), {"remove_config_entry_id": entry.entry_id}),
+        (("device-shared",), {"remove_config_entry_id": entry.entry_id}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_connection_and_options_while_replacing_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry update should replace only the device ID and unique ID."""
+    hass = MagicMock()
+    entry = _make_entry(options={"scan_interval": 45})
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", MagicMock())
+    flow = _make_flow(hass, entry)
+
+    await flow.async_step_confirm({})
+
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    assert entry.data["url"] == "https://router.example"
+    assert entry.data["username"] == "api-user"
+    assert entry.data["password"] == "api-password"
+    assert entry.options == {"scan_interval": 45}
+
+
+@pytest.mark.asyncio
+async def test_success_deletes_issue_and_reloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Successful rebuild should async-reload and let the manager delete the issue."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_entry_update_failure_aborts_without_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Entry-update failure must abort before any registry mutation."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    client = _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.side_effect = HomeAssistantError("entry update")
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    issue_delete.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    client.async_close.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_entry_update_false_aborts_before_registry_mutation_and_recovers_loaded_entry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A no-op entry update must leave registries untouched and reload a prior loaded entry."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.return_value = False
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        data={**entry.data, CONF_DEVICE_UNIQUE_ID: "other"},
+        unique_id="other",
+    )
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_update_exception_recovers_without_registry_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An update exception after unload should schedule guarded recovery."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch)
+    hass.config_entries.async_update_entry.side_effect = HomeAssistantError("entry update")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_expected_id_retry_rechecks_snapshot_after_unload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry must not clean registries after its entry changes during unload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+
+    def _unload_and_mutate(entry_id: str) -> bool:
+        """Mutate persisted data while the retry is awaiting unload."""
+        del entry_id
+        object.__setattr__(entry, "data", {**entry.data, "url": "https://changed.example"})
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload_and_mutate
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_loaded_entry_retry_cleanup_failure_recovers_with_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loaded retry cleanup failures should stay available without scheduling reload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED, device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+
+    def _unload(entry_id: str) -> bool:
+        """Record unload and transition to an unloaded state."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+
+    def _remove_entity(entity_id: str) -> None:
+        """Fail entity cleanup to exercise retry recovery behavior."""
+        del entity_id
+        raise HomeAssistantError("entity remove")
+
+    entity_registry.async_remove.side_effect = _remove_entity
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+    issue_delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["entity", "device"])
+async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_point: str,
+) -> None:
+    """Cleanup failure keeps replacement ID for a retry that reruns cleanup."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    observed_device_id = "other"
+    client = _patch_probe_client(monkeypatch, observed_device_id=observed_device_id)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+
+    old_data = dict(entry.data)
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the requested entry mutation to the in-memory test object."""
+        del config_entry
+        object.__setattr__(entry, "data", dict(data))
+        object.__setattr__(entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    if failure_point == "entity":
+
+        def _remove(entity_id: str) -> None:
+            """Fail entity cleanup to exercise recovery reload behavior."""
+            del entity_id
+            raise HomeAssistantError("entity remove")
+
+        entity_registry.async_remove.side_effect = _remove
+    else:
+
+        def _update_device(device_id: str, **_: Any) -> None:
+            """Fail device cleanup to exercise recovery reload behavior."""
+            del device_id
+            raise HomeAssistantError("device update")
+
+        device_registry.async_update_device.side_effect = _update_device
+
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    assert entry.data == expected_updated_data
+    assert entry.unique_id == observed_device_id
+    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+    hass.config_entries.async_reload.reset_mock()
+    entity_registry.async_remove.side_effect = None
+    device_registry.async_update_device.side_effect = None
+    client.get_device_unique_id.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    client.get_device_unique_id.assert_not_awaited()
+    assert hass.config_entries.async_reload.await_count == 1
+    assert hass.config_entries.async_update_entry.call_count == 1
+    if failure_point == "entity":
+        assert entity_registry.async_remove.call_count == 2
+        assert device_registry.async_update_device.call_count == 2
+    else:
+        assert entity_registry.async_remove.call_count == 2
+        assert device_registry.async_update_device.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reload_result", "reload_label"),
+    [
+        pytest.param(False, "reload-false", id="false-result"),
+        pytest.param(
+            HomeAssistantError("entry removed"), "homeassistant-error", id="homeassistant-error"
+        ),
+        pytest.param(KeyError("entry key"), "key-error", id="key-error"),
+    ],
+)
+async def test_reload_failure_keeps_entry_update_and_keeps_issue(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_result: bool | Exception,
+    reload_label: str,
+) -> None:
+    """Reload failures should keep the new ID and schedule a follow-up reload."""
+    del reload_label
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    observed_device_id = "other"
+    _patch_probe_client(monkeypatch, observed_device_id=observed_device_id)
+    issue_delete = MagicMock()
+    monkeypatch.setattr(repairs.ir, "async_delete_issue", issue_delete)
+
+    old_data = dict(entry.data)
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the requested entry mutation to the in-memory test object."""
+        del config_entry
+        object.__setattr__(entry, "data", dict(data))
+        object.__setattr__(entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    if isinstance(reload_result, bool):
+        hass.config_entries.async_reload.return_value = reload_result
+    else:
+        hass.config_entries.async_reload.side_effect = reload_result
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    expected_updated_data = {**old_data, CONF_DEVICE_UNIQUE_ID: observed_device_id}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    entity_registry.async_remove.assert_called_once_with("sensor.old")
+    device_registry.async_update_device.assert_called_once()
+    assert hass.config_entries.async_update_entry.call_args_list[0].kwargs == {
+        "data": expected_updated_data,
+        "unique_id": observed_device_id,
+    }
+    assert entry.data == expected_updated_data
+    assert entry.unique_id == observed_device_id
+    assert len(hass.config_entries.async_update_entry.call_args_list) == 1
+    issue_delete.assert_not_called()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_retry_recovers_when_reload_scheduling_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retry an updated repair by loading the entry and rerunning cleanup."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    entities = [SimpleNamespace(entity_id="sensor.old")]
+    device = SimpleNamespace(id="device")
+    devices = [device]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=entities,
+        devices=devices,
+    )
+    entity_scan_calls: list[str] = []
+    device_scan_calls: list[str] = []
+
+    def _entity_scan(registry: Any, config_entry_id: str) -> list[Any]:
+        """Track entity scan attempts across retries."""
+        del registry
+        entity_scan_calls.append(config_entry_id)
+        return entities
+
+    def _device_scan(registry: Any, config_entry_id: str) -> list[Any]:
+        """Track device scan attempts across retries."""
+        del registry
+        device_scan_calls.append(config_entry_id)
+        return devices
+
+    monkeypatch.setattr(repairs.er, "async_entries_for_config_entry", _entity_scan)
+    monkeypatch.setattr(repairs.dr, "async_entries_for_config_entry", _device_scan)
+    client = _patch_probe_client(monkeypatch)
+
+    def _remove_entity(entity_id: str) -> None:
+        """Remove an entity from the fake registry after successful cleanup."""
+        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
+
+    def _remove_device(device_id: str, **_: Any) -> None:
+        """Remove a device from the fake registry after successful cleanup."""
+        devices[:] = [device for device in devices if device.id != device_id]
+
+    entity_registry.async_remove.side_effect = _remove_entity
+    device_registry.async_update_device.side_effect = _remove_device
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the replacement identity to the in-memory entry."""
+        object.__setattr__(config_entry, "data", dict(data))
+        object.__setattr__(config_entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    hass.config_entries.async_reload.side_effect = [
+        HomeAssistantError("reload failed"),
+        True,
+    ]
+    hass.config_entries.async_schedule_reload.side_effect = HomeAssistantError("schedule failed")
+    flow = _make_flow(hass, entry)
+
+    first_result = await flow.async_step_confirm({})
+
+    assert first_result["type"] is FlowResultType.ABORT
+    assert first_result["reason"] == "repair_failed"
+    assert entry.data[CONF_DEVICE_UNIQUE_ID] == "other"
+
+    hass.config_entries.async_update_entry.reset_mock()
+    entity_registry.async_remove.reset_mock()
+    device_registry.async_update_device.reset_mock()
+    client.get_device_unique_id.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_not_called()
+    assert entity_scan_calls == [entry.entry_id, entry.entry_id]
+    assert device_scan_calls == [entry.entry_id, entry.entry_id]
+    client.get_device_unique_id.assert_not_awaited()
+    assert hass.config_entries.async_reload.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_repeats_registry_cleanup_after_partial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retry should clean up registry entries left after a failed cleanup pass."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    entities = [SimpleNamespace(entity_id="sensor.old")]
+    device = SimpleNamespace(id="device")
+    devices = [device]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=entities,
+        devices=devices,
+    )
+    client = _patch_probe_client(monkeypatch)
+
+    async def _unload(entry_id: str) -> bool:
+        """Unload the entry so each cleanup pass starts at the hardware boundary."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.NOT_LOADED)
+        return True
+
+    hass.config_entries.async_unload.side_effect = _unload
+
+    async def _reload(entry_id: str) -> bool:
+        """Reload the entry after each cleanup attempt."""
+        del entry_id
+        object.__setattr__(entry, "state", ConfigEntryState.LOADED)
+        return True
+
+    hass.config_entries.async_reload.side_effect = _reload
+
+    def _update_entry(
+        config_entry: MockConfigEntry,
+        *,
+        data: dict[str, Any],
+        unique_id: str,
+    ) -> bool:
+        """Apply the replacement identity to the in-memory entry."""
+        object.__setattr__(config_entry, "data", dict(data))
+        object.__setattr__(config_entry, "unique_id", unique_id)
+        return True
+
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+
+    def _remove_entity(entity_id: str) -> None:
+        """Remove an entity from the fake registry."""
+        entities[:] = [entity for entity in entities if entity.entity_id != entity_id]
+
+    entity_registry.async_remove.side_effect = _remove_entity
+
+    def _remove_device(device_id: str, **_: Any) -> None:
+        """Remove a device from the fake registry."""
+        devices[:] = [device for device in devices if device.id != device_id]
+
+    cleanup_attempts = 0
+
+    def _update_device(device_id: str, **kwargs: Any) -> None:
+        """Fail the first device cleanup and allow the retry to finish it."""
+        nonlocal cleanup_attempts
+        cleanup_attempts += 1
+        if cleanup_attempts == 1:
+            raise HomeAssistantError("device update")
+        _remove_device(device_id, **kwargs)
+
+    device_registry.async_update_device.side_effect = _update_device
+    flow = _make_flow(hass, entry)
+
+    first_result = await flow.async_step_confirm({})
+
+    assert first_result["type"] is FlowResultType.ABORT
+    assert first_result["reason"] == "repair_failed"
+    assert entities == []
+    assert devices == [device]
+    assert device_registry.async_update_device.call_count == 1
+    assert hass.config_entries.async_reload.await_count == 0
+
+    hass.config_entries.async_update_entry.reset_mock()
+    entity_registry.async_remove.reset_mock()
+
+    retry_result = await flow.async_step_confirm({})
+
+    assert retry_result["type"] is FlowResultType.CREATE_ENTRY
+    hass.config_entries.async_update_entry.assert_not_called()
+    entity_registry.async_remove.assert_not_called()
+    assert device_registry.async_update_device.call_count == 2
+    device_registry.async_update_device.assert_called_with(
+        "device", remove_config_entry_id=entry.entry_id
+    )
+    client.get_device_unique_id.assert_awaited_once_with()
+    assert hass.config_entries.async_unload.await_count == 1
+    assert hass.config_entries.async_reload.await_count == 1
+    assert devices == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reload_result",
+    [False, HomeAssistantError("reload failed"), KeyError("entry key")],
+)
+async def test_retry_keeps_issue_when_recovery_reload_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_result: bool | Exception,
+) -> None:
+    """Keep the repair available when reloading an already-updated entry fails."""
+    hass = MagicMock()
+    entry = _make_entry(device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(monkeypatch)
+    client = _patch_probe_client(monkeypatch)
+    if isinstance(reload_result, bool):
+        hass.config_entries.async_reload.return_value = reload_result
+    else:
+        hass.config_entries.async_reload.side_effect = reload_result
+    flow = _make_flow(hass, entry, old_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_update_entry.assert_not_called()
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    client.factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_removed_entry_aborts_without_mutations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted config entry should abort before creating a strict client."""
+    hass = MagicMock()
+    entry = _make_entry()
+    _configure_hass(hass, entry)
+    hass.config_entries.async_get_entry.return_value = None
+    client_factory = MagicMock()
+    monkeypatch.setattr(repairs, "create_opnsense_client_from_config_entry", client_factory)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_not_found"
+    client_factory.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fix_flow_factory_validates_issue_suffix_and_payload() -> None:
+    """Only well-formed device-ID issues should construct the destructive flow."""
+    hass = MagicMock()
+    data: dict[str, str | int | float | None] = {
+        "entry_id": "entry-1",
+        "old_device_id": "dev1",
+        "new_device_id": "other",
+    }
+
+    flow = await repairs.async_create_fix_flow(hass, "entry-1_device_id_mismatched", data)
+
+    assert isinstance(flow, repairs.DeviceIDMismatchRepairFlow)
+    unknown_flow = await repairs.async_create_fix_flow(hass, "unrelated", None)
+    assert isinstance(unknown_flow, ConfirmRepairFlow)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_reload_false_retries_recovery_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded entry with matching expected ID should recover when resume reload fails."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.return_value = False
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unloaded expected-ID retry should still keep recovery reload on failure."""
+    hass = MagicMock()
+    entry = _make_entry(
+        state=ConfigEntryState.NOT_LOADED,
+        device_id="dev1",
+        unique_id="dev1",
+    )
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.return_value = False
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reload_error",
+    [HomeAssistantError("reload failed"), KeyError("entry-key")],
+)
+async def test_stored_expected_id_resume_exception_recovers_reloaded_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    reload_error: BaseException,
+) -> None:
+    """Handled exceptions during resume should leave a recovery-reload trace."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_reload.side_effect = reload_error
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "repair_failed"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_stored_expected_id_snapshot_change_aborts_before_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A changed retry entry must abort before destructive registry cleanup."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    updated_entry = _make_entry(
+        entry_id=entry.entry_id,
+        device_id="mutated",
+        unique_id="mutated",
+    )
+    _configure_hass(hass, entry)
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    hass.config_entries.async_get_entry.side_effect = [entry, updated_entry]
+    flow = _make_flow(hass, entry, new_device_id="dev1")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_changed"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_reload.assert_not_awaited()
+    hass.config_entries.async_schedule_reload.assert_not_called()

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1077,32 +1077,24 @@ async def test_cleanup_failure_keeps_entry_update_and_recovers_with_reload(
     client.get_device_unique_id.assert_not_awaited()
     assert hass.config_entries.async_reload.await_count == 1
     assert hass.config_entries.async_update_entry.call_count == 1
-    if failure_point == "entity":
-        assert entity_registry.async_remove.call_count == 2
-        assert device_registry.async_update_device.call_count == 2
-    else:
-        assert entity_registry.async_remove.call_count == 2
-        assert device_registry.async_update_device.call_count == 2
+    assert entity_registry.async_remove.call_count == 2
+    assert device_registry.async_update_device.call_count == 2
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("reload_result", "reload_label"),
+    "reload_result",
     [
-        pytest.param(False, "reload-false", id="false-result"),
-        pytest.param(
-            HomeAssistantError("entry removed"), "homeassistant-error", id="homeassistant-error"
-        ),
-        pytest.param(KeyError("entry key"), "key-error", id="key-error"),
+        pytest.param(False, id="false-result"),
+        pytest.param(HomeAssistantError("entry removed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry key"), id="key-error"),
     ],
 )
 async def test_reload_failure_keeps_entry_update_and_keeps_issue(
     monkeypatch: pytest.MonkeyPatch,
     reload_result: bool | Exception,
-    reload_label: str,
 ) -> None:
     """Reload failures should keep the new ID and schedule a follow-up reload."""
-    del reload_label
     hass = MagicMock()
     entry = _make_entry()
     _configure_hass(hass, entry)

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 from aiopnsense.exceptions import (
     OPNsenseBelowMinFirmware,
     OPNsenseConnectionError,
+    OPNsenseError,
     OPNsenseTimeoutError,
     OPNsenseUnknownFirmware,
 )
@@ -357,6 +358,35 @@ async def test_loaded_entry_duplicate_after_unload_schedules_changed_entry_reloa
     entity_registry.async_remove.assert_not_called()
     device_registry.async_update_device.assert_not_called()
     hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_observed_duplicate_id_aborts_before_unload_or_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An existing entry with the observed ID should abort before unload."""
+    hass = MagicMock()
+    entry = _make_entry()
+    duplicate = _make_entry(entry_id="entry-2", device_id="other", unique_id="other")
+    _configure_hass(hass, entry)
+    hass.config_entries.async_entries.return_value = [entry, duplicate]
+    entity_registry, device_registry = _patch_registries(
+        monkeypatch,
+        entities=[SimpleNamespace(entity_id="sensor.old")],
+        devices=[SimpleNamespace(id="device")],
+    )
+    _patch_probe_client(monkeypatch, observed_device_id="other")
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    entity_registry.async_remove.assert_not_called()
+    device_registry.async_update_device.assert_not_called()
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1171,6 +1201,89 @@ async def test_stored_expected_id_unloaded_entry_retries_recovery_reload(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "schedule_error",
+    [
+        pytest.param(HomeAssistantError("reload schedule failed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry_id"), id="key-error"),
+    ],
+)
+async def test_schedule_changed_entry_reload_handles_schedule_errors(
+    schedule_error: Exception,
+) -> None:
+    """Recovery scheduling for changed entries should tolerate schedule failures."""
+    hass = MagicMock()
+    entry = _make_entry()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry.return_value = entry
+    hass.config_entries.async_schedule_reload.side_effect = schedule_error
+    flow = _make_flow(hass, entry)
+
+    flow._schedule_changed_entry_reload(entry_id=entry.entry_id, entry_title=entry.title)
+
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_schedule_recovery_reload_skips_when_snapshot_changes() -> None:
+    """Recovery scheduling should be skipped when entry snapshot checks fail."""
+    hass = MagicMock()
+    entry = _make_entry()
+    entry_data_snapshot = dict(entry.data)
+    entry_options_snapshot = dict(entry.options)
+    current_entry = _make_entry()
+    object.__setattr__(
+        current_entry,
+        "data",
+        {**current_entry.data, "url": "https://changed.example"},
+    )
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry.return_value = current_entry
+    hass.config_entries.async_schedule_reload = MagicMock()
+    flow = _make_flow(hass, entry)
+
+    flow._schedule_recovery_reload(
+        data_snapshot=entry_data_snapshot,
+        options_snapshot=entry_options_snapshot,
+        unique_id_snapshot=entry.unique_id,
+        entry_id=entry.entry_id,
+        entry_title=entry.title,
+    )
+
+    hass.config_entries.async_schedule_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "schedule_error",
+    [
+        pytest.param(HomeAssistantError("schedule failed"), id="homeassistant-error"),
+        pytest.param(KeyError("entry-id"), id="key-error"),
+    ],
+)
+async def test_schedule_recovery_reload_ignores_schedule_errors(
+    schedule_error: HomeAssistantError | KeyError,
+) -> None:
+    """Failure to schedule recovery should not crash the flow."""
+    hass = MagicMock()
+    entry = _make_entry()
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_get_entry.return_value = entry
+    hass.config_entries.async_schedule_reload.side_effect = schedule_error
+    flow = _make_flow(hass, entry)
+
+    flow._schedule_recovery_reload(
+        data_snapshot=dict(entry.data),
+        options_snapshot=dict(entry.options),
+        unique_id_snapshot=entry.unique_id,
+        entry_id=entry.entry_id,
+        entry_title=entry.title,
+    )
+
+    hass.config_entries.async_schedule_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
 async def test_repair_persists_marker_without_registry_mutation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1220,6 +1333,77 @@ async def test_valid_marker_retry_reprobes_and_reloads(
     client.validate.assert_awaited_once_with()
     client.get_device_unique_id.assert_awaited_once_with()
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("probe_error", "observed_device_id", "expected_reason"),
+    [
+        (OPNsenseConnectionError("transport"), None, "cannot_connect"),
+        (OPNsenseTimeoutError("timeout"), None, "cannot_connect"),
+        (None, "", "cannot_connect"),
+        (None, "dev1", "entry_changed"),
+    ],
+)
+async def test_marker_retry_reprobe_error_and_id_checks_abort_without_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+    probe_error: OPNsenseError | None,
+    observed_device_id: Any | None,
+    expected_reason: str,
+) -> None:
+    """Marker retries should abort safely for probe failures and ID mismatches."""
+    hass = MagicMock()
+    entry = _make_entry(device_id="other", unique_id="other")
+    object.__setattr__(
+        entry,
+        "data",
+        {**entry.data, REPAIR_MARKER_KEY: build_repair_marker("dev1", "other")},
+    )
+    _configure_hass(hass, entry)
+    _patch_probe_client(
+        monkeypatch,
+        observed_device_id=observed_device_id,
+        probe_error=probe_error,
+    )
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_reason
+    hass.config_entries.async_unload.assert_not_awaited()
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_marker_retry_reprobe_match_but_cannot_unload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a marker retry reprobe matches, unload failures must yield cannot_unload."""
+    hass = MagicMock()
+    entry = _make_entry(
+        device_id="other",
+        unique_id="other",
+        state=ConfigEntryState.LOADED,
+    )
+    object.__setattr__(
+        entry,
+        "data",
+        {**entry.data, REPAIR_MARKER_KEY: build_repair_marker("dev1", "other")},
+    )
+    _configure_hass(hass, entry)
+    hass.config_entries.async_unload.return_value = False
+    _patch_probe_client(monkeypatch, observed_device_id="other")
+    _patch_registries(monkeypatch)
+    flow = _make_flow(hass, entry, old_device_id="dev1", new_device_id="other")
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_update_entry.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -536,51 +536,26 @@ async def test_firmware_validation_failure_aborts_before_mutations(
 
 
 @pytest.mark.asyncio
-async def test_unload_failure_aborts_before_registry_mutation(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A failed unload must leave entity/device registries and entry data intact."""
-    hass = MagicMock()
-    entry = _make_entry(state=ConfigEntryState.LOADED)
-    _configure_hass(hass, entry)
-    hass.config_entries.async_unload.return_value = False
-    entity_registry, device_registry = _patch_registries(
-        monkeypatch,
-        entities=[SimpleNamespace(entity_id="sensor.old")],
-        devices=[SimpleNamespace(id="device")],
-    )
-    client = _patch_probe_client(monkeypatch)
-    flow = _make_flow(hass, entry)
-
-    result = await flow.async_step_confirm({})
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_unload"
-    client.async_close.assert_awaited_once_with()
-    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
-    entity_registry.async_remove.assert_not_called()
-    device_registry.async_update_device.assert_not_called()
-    hass.config_entries.async_update_entry.assert_not_called()
-    hass.config_entries.async_schedule_reload.assert_not_called()
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "unload_error",
+    "unload_result",
     [
+        pytest.param(False, id="unload-false"),
         pytest.param(HomeAssistantError("transport"), id="homeassistant-error"),
         pytest.param(KeyError("entry key"), id="key-error"),
     ],
 )
-async def test_unload_exception_aborts_before_registry_mutation(
+async def test_unload_failure_aborts_before_registry_mutation(
     monkeypatch: pytest.MonkeyPatch,
-    unload_error: BaseException,
+    unload_result: bool | BaseException,
 ) -> None:
-    """Exceptions when unloading a loaded entry should abort the repair with cannot_unload."""
+    """Unloading failures must abort before mutating registries or reload state."""
     hass = MagicMock()
     entry = _make_entry(state=ConfigEntryState.LOADED)
     _configure_hass(hass, entry)
-    hass.config_entries.async_unload.side_effect = unload_error
+    if isinstance(unload_result, BaseException):
+        hass.config_entries.async_unload.side_effect = unload_result
+    else:
+        hass.config_entries.async_unload.return_value = unload_result
     entity_registry, device_registry = _patch_registries(
         monkeypatch,
         entities=[SimpleNamespace(entity_id="sensor.old")],

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -4,8 +4,12 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import aiohttp
-from aiopnsense.exceptions import OPNsenseBelowMinFirmware, OPNsenseUnknownFirmware
+from aiopnsense.exceptions import (
+    OPNsenseBelowMinFirmware,
+    OPNsenseConnectionError,
+    OPNsenseTimeoutError,
+    OPNsenseUnknownFirmware,
+)
 from homeassistant.components.repairs import ConfirmRepairFlow
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.data_entry_flow import FlowResultType
@@ -409,8 +413,8 @@ async def test_loaded_entry_unloads_before_registry_cleanup(
 @pytest.mark.parametrize(
     ("probe_error", "observed_device_id"),
     [
-        pytest.param(aiohttp.ClientError("transport"), None, id="transport-error"),
-        pytest.param(TimeoutError("timeout"), None, id="timeout-error"),
+        pytest.param(OPNsenseConnectionError("transport"), None, id="connection-error"),
+        pytest.param(OPNsenseTimeoutError("timeout"), None, id="timeout-error"),
         pytest.param(None, None, id="missing-device-id"),
         pytest.param(None, "", id="blank-device-id"),
         pytest.param(None, "   ", id="whitespace-device-id"),

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -1865,3 +1865,26 @@ def test_entry_matches_snapshot_invariants(
         )
         == expected_match
     )
+
+
+@pytest.mark.asyncio
+async def test_confirmation_cannot_unload_timeout_aborts_with_cannot_unload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """TimeoutError from async_unload should abort repair as cannot_unload."""
+    hass = MagicMock()
+    entry = _make_entry(state=ConfigEntryState.LOADED)
+    _configure_hass(hass, entry)
+    hass.config_entries.async_unload.side_effect = TimeoutError("timed out")
+    _patch_registries(monkeypatch)
+    _patch_probe_client(monkeypatch)
+    flow = _make_flow(hass, entry)
+
+    result = await flow.async_step_confirm({})
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_unload"
+    hass.config_entries.async_unload.assert_awaited_once_with(entry.entry_id)
+    hass.config_entries.async_update_entry.assert_not_called()
+    hass.config_entries.async_reload.assert_not_called()
+    hass.config_entries.async_schedule_reload.assert_not_called()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -15,6 +15,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.opnsense import const as const_module, sensor as sensor_module
 from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
     CONF_SYNC_CARP,
     CONF_SYNC_CERTIFICATES,
     CONF_SYNC_DHCP_LEASES,
@@ -3181,6 +3182,326 @@ async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_pay
         assert matched.entity_description.name == expected_name
     for entity_class in absent_classes:
         assert not any(isinstance(entity, entity_class) for entity in created)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_gateway_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing gateway inventory keeps sensor platform reconciliation incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: True,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_gateway_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty gateway container is still authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: True,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"gateways": {}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing VPN payload keeps sensor platform reconciliation incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty VPN container is still authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"openvpn": {}, "wireguard": {}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_vnstat_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing vnStat payload keeps sensor platform reconciliation incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: True,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_vnstat_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty vnStat container is still authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: True,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"vnstat": {}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_speedtest_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing speedtest payload keeps sensor platform reconciliation incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: True,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_speedtest_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty speedtest container is still authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: True,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"speedtest": {}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3294,6 +3294,109 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
 
 
 @pytest.mark.parametrize(
+    ("state", "sync_option", "expected_key"),
+    [
+        (
+            {"vnstat": {"interfaces": {None: {}, "wan": {}}}},
+            "sync_vnstat",
+            "vnstat.wan.vnstat_today",
+        ),
+        (
+            {"smart": [None, {"device": ""}, {"device": "nvme0"}], "smart_info": {}},
+            "sync_smart",
+            "smart.nvme0.temperature",
+        ),
+        (
+            {"telemetry": {"filesystems": [None, {"mountpoint": "/"}], "temps": {}}},
+            "sync_telemetry",
+            "telemetry.filesystems.root",
+        ),
+        (
+            {
+                "telemetry": {
+                    "filesystems": [],
+                    "temps": {"bad": None, "cpu": {"temperature": 42}},
+                }
+            },
+            "sync_telemetry",
+            "telemetry.temps.cpu",
+        ),
+        (
+            {"interfaces": {"bad": None, "wan": {"name": "WAN"}}},
+            "sync_interfaces",
+            "interface.wan.status",
+        ),
+        (
+            {"gateways": {"bad": None, "wan": {"status": "online"}}},
+            "sync_gateways",
+            "gateway.wan.status",
+        ),
+        (
+            {"carp": {"interfaces": [None, {"subnet": ""}, {"interface": "wan", "subnet": "1"}]}},
+            "sync_carp",
+            "carp.interface.wan.1",
+        ),
+        (
+            {
+                "openvpn": {"servers": {"bad": None, "good": {"status": "up"}}},
+                "wireguard": {"clients": {}, "servers": {}},
+            },
+            "sync_vpn",
+            "openvpn.servers.good.status",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_marks_malformed_sensor_rows_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    sync_option: str,
+    expected_key: str,
+) -> None:
+    """Malformed rows prevent reconciliation while valid sibling rows still compile."""
+    config_entry = setup_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data=state,
+        **{sync_option: True},
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+    created: list[Any] = []
+
+    await async_setup_entry(
+        MagicMock(),
+        config_entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: created.extend(entities)),
+    )
+
+    assert captured["entities"] is None
+    assert expected_key in {entity.entity_description.key for entity in created}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_ignores_unconsumed_openvpn_client_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """OpenVPN client rows do not affect sensor reconciliation or compilation."""
+    config_entry = setup_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data={
+            "openvpn": {"clients": {"bad": None}, "servers": {}},
+            "wireguard": {"clients": {}, "servers": {}},
+        },
+        sync_vpn=True,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda entities, _=False: None)
+    )
+
+    assert captured["entities"] == []
+
+
+@pytest.mark.parametrize(
     (
         "state",
         "sync_telemetry",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import PERCENTAGE, UnitOfDataRate, UnitOfInformation, UnitOfTemperature
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -4368,7 +4369,7 @@ async def test_generated_sensor_entity_contract(
     expected_contracts: dict[str, dict[str, Any]] = {
         "telemetry.filesystems.root": {
             "name": "Filesystem Used Percentage root",
-            "native_unit_of_measurement": sensor_module.PERCENTAGE,
+            "native_unit_of_measurement": PERCENTAGE,
             "device_class": None,
             "state_class": SensorStateClass.MEASUREMENT,
             "entity_registry_enabled_default": True,
@@ -4377,32 +4378,32 @@ async def test_generated_sensor_entity_contract(
             "name": "vnStat: WAN: Today",
             "device_class": SensorDeviceClass.DATA_SIZE,
             "state_class": SensorStateClass.TOTAL_INCREASING,
-            "suggested_unit_of_measurement": sensor_module.UnitOfInformation.GIBIBYTES,
+            "suggested_unit_of_measurement": UnitOfInformation.GIBIBYTES,
             "suggested_display_precision": 1,
             "entity_registry_enabled_default": False,
         },
         "speedtest.last.download": {
             "name": "Speedtest Last Download",
-            "native_unit_of_measurement": sensor_module.UnitOfDataRate.MEGABITS_PER_SECOND,
+            "native_unit_of_measurement": UnitOfDataRate.MEGABITS_PER_SECOND,
             "device_class": SensorDeviceClass.DATA_RATE,
             "state_class": SensorStateClass.MEASUREMENT,
             "entity_registry_enabled_default": False,
         },
         "smart.nvme0.temperature": {
             "name": "SMART nvme0 Temperature",
-            "native_unit_of_measurement": sensor_module.UnitOfTemperature.CELSIUS,
+            "native_unit_of_measurement": UnitOfTemperature.CELSIUS,
             "device_class": SensorDeviceClass.TEMPERATURE,
             "state_class": SensorStateClass.MEASUREMENT,
-            "suggested_unit_of_measurement": sensor_module.UnitOfTemperature.CELSIUS,
+            "suggested_unit_of_measurement": UnitOfTemperature.CELSIUS,
             "suggested_display_precision": 1,
             "entity_registry_enabled_default": False,
         },
         "interface.wan.inbytes": {
             "name": "Interface WAN inbytes",
-            "native_unit_of_measurement": sensor_module.UnitOfInformation.BYTES,
+            "native_unit_of_measurement": UnitOfInformation.BYTES,
             "device_class": SensorDeviceClass.DATA_SIZE,
             "state_class": SensorStateClass.TOTAL_INCREASING,
-            "suggested_unit_of_measurement": sensor_module.UnitOfInformation.GIGABYTES,
+            "suggested_unit_of_measurement": UnitOfInformation.GIGABYTES,
             "suggested_display_precision": 1,
             "entity_registry_enabled_default": False,
         },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3072,6 +3072,61 @@ def test_dhcp_leases_per_interface_handles_exceptions(
     assert any(w is False for w in writes), f"expected a False write captured, got {writes}"
 
 
+def capture_reconciled_desired_entities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    """Capture reconciliation desired entities during setup."""
+    captured: dict[str, Any] = {}
+
+    def capture(
+        _entry: MockConfigEntry,
+        _platform: str,
+        entities: Any | None = None,
+    ) -> None:
+        """Capture entities passed to ``record_desired_entities``."""
+        captured["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+    return captured
+
+
+def setup_sensor_reconciliation_entry(
+    make_config_entry: Callable[..., MockConfigEntry],
+    coordinator_data: dict[str, Any],
+    *,
+    sync_telemetry: bool = False,
+    sync_vnstat: bool = False,
+    sync_speedtest: bool = False,
+    sync_smart: bool = False,
+    sync_gateways: bool = False,
+    sync_interfaces: bool = False,
+    sync_carp: bool = False,
+    sync_dhcp_leases: bool = False,
+    sync_vpn: bool = False,
+    sync_certificates: bool = False,
+) -> MockConfigEntry:
+    """Create a sensor test entry with coordinator/runtime pre-wired."""
+    entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: sync_telemetry,
+            CONF_SYNC_VNSTAT: sync_vnstat,
+            CONF_SYNC_SPEEDTEST: sync_speedtest,
+            CONF_SYNC_SMART: sync_smart,
+            CONF_SYNC_GATEWAYS: sync_gateways,
+            CONF_SYNC_INTERFACES: sync_interfaces,
+            CONF_SYNC_CARP: sync_carp,
+            CONF_SYNC_DHCP_LEASES: sync_dhcp_leases,
+            CONF_SYNC_VPN: sync_vpn,
+            CONF_SYNC_CERTIFICATES: sync_certificates,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = coordinator_data
+    setattr(entry.runtime_data, COORDINATOR, coordinator)
+    return entry
+
+
 def _setup_entry_with_all_syncs(
     state: dict, make_config_entry: Callable[..., MockConfigEntry]
 ) -> Any:
@@ -3184,166 +3239,6 @@ async def test_async_setup_entry_handles_partial_or_malformed_dynamic_sensor_pay
         assert not any(isinstance(entity, entity_class) for entity in created)
 
 
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_gateway_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing gateway inventory keeps sensor platform reconciliation incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: True,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_gateway_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty gateway container is still authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: True,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"gateways": {}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_vpn_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing VPN payload keeps sensor platform reconciliation incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: True,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty VPN container is still authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: True,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"openvpn": {}, "wireguard": {}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
 @pytest.mark.parametrize(
     ("state", "description"),
     [
@@ -3393,520 +3288,230 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert recorded["entities"] is None, description
 
 
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_vnstat_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing vnStat payload keeps sensor platform reconciliation incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: True,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_vnstat_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty vnStat container is still authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: True,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"vnstat": {}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_speedtest_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing speedtest payload keeps sensor platform reconciliation incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: True,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_speedtest_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty speedtest container is still authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: True,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"speedtest": {}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_incomplete_telemetry_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing telemetry dynamic containers keep sensor platform incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: True,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_telemetry_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Typed-empty telemetry containers remain authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: True,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"telemetry": {"filesystems": [], "temps": {}}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    entities = recorded["entities"]
-    assert isinstance(entities, list)
-    keys = {entity.entity_description.key for entity in entities}
-    assert "telemetry.cpu.usage_total" in keys
-    assert "telemetry.pfstate.used" in keys
-    assert not any(key.startswith("telemetry.filesystems.") for key in keys)
-    assert not any(key.startswith("telemetry.temps.") for key in keys)
-
-
 @pytest.mark.parametrize(
-    "state",
+    (
+        "state",
+        "sync_telemetry",
+        "sync_vnstat",
+        "sync_speedtest",
+        "sync_smart",
+        "sync_gateways",
+        "sync_interfaces",
+        "sync_carp",
+        "sync_dhcp_leases",
+        "sync_vpn",
+        "expected",
+    ),
     [
-        {"smart": []},
-        {"smart": [], "smart_info": "bad"},
+        # Gateway
+        ({}, False, False, False, False, True, False, False, False, False, None),
+        ({"gateways": {}}, False, False, False, False, True, False, False, False, False, []),
+        # VPN
+        ({}, False, False, False, False, False, False, False, False, True, None),
+        (
+            {"openvpn": {}, "wireguard": {}},
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            [],
+        ),
+        # vnStat
+        ({}, False, True, False, False, False, False, False, False, False, None),
+        ({"vnstat": {}}, False, True, False, False, False, False, False, False, False, []),
+        # Speedtest
+        ({}, False, False, True, False, False, False, False, False, False, None),
+        ({"speedtest": {}}, False, False, True, False, False, False, False, False, False, []),
+        # Telemetry
+        ({}, True, False, False, False, False, False, False, False, False, None),
+        (
+            {
+                "telemetry": {"filesystems": [], "temps": {}},
+                "interfaces": {},
+                "gateways": {},
+                "openvpn": {"servers": {}},
+            },
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            "telemetry_authoritative_empty",
+        ),
+        # SMART
+        ({"smart": []}, False, False, False, True, False, False, False, False, False, None),
+        (
+            {"smart": [], "smart_info": "bad"},
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            None,
+        ),
+        (
+            {"smart": [], "smart_info": {}},
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            False,
+            False,
+            False,
+            [],
+        ),
+        # CARP
+        (
+            {"carp": {"interfaces": "bad"}},
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            None,
+        ),
+        ({}, False, False, False, False, False, False, True, False, False, None),
+        (
+            {"carp": {"interfaces": []}},
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            False,
+            "carp_authoritative_empty",
+        ),
+        # DHCP leases
+        (
+            {
+                "dhcp_leases": {"leases": {"lan": []}},
+            },
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            None,
+        ),
+        ({"dhcp_leases": {}}, False, False, False, False, False, False, False, True, False, None),
+        (
+            {"dhcp_leases": {"leases": {}, "lease_interfaces": {}}},
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+            True,
+            False,
+            "dhcp_authoritative_empty",
+        ),
+    ],
+    ids=[
+        "missing_gateway_inventory",
+        "empty_gateway_inventory",
+        "missing_vpn_inventory",
+        "empty_vpn_inventory",
+        "missing_vnstat_inventory",
+        "empty_vnstat_inventory",
+        "missing_speedtest_inventory",
+        "empty_speedtest_inventory",
+        "missing_telemetry_inventory",
+        "empty_telemetry_inventory",
+        "incomplete_smart_inventory_missing_smart_info",
+        "incomplete_smart_inventory_bad_smart_info",
+        "empty_smart_inventory",
+        "incomplete_carp_inventory_bad_interfaces",
+        "missing_carp_inventory",
+        "empty_carp_inventory",
+        "incomplete_dhcp_lease_inventory_missing_leases",
+        "incomplete_dhcp_lease_inventory_missing_dhcp_block",
+        "empty_dhcp_lease_inventory",
     ],
 )
 @pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_incomplete_smart_inventory(
+async def test_async_setup_entry_records_none_or_authoritative_empty_for_inventory(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
-    state: Any,
+    state: dict[str, Any],
+    sync_telemetry: bool,
+    sync_vnstat: bool,
+    sync_speedtest: bool,
+    sync_smart: bool,
+    sync_gateways: bool,
+    sync_interfaces: bool,
+    sync_carp: bool,
+    sync_dhcp_leases: bool,
+    sync_vpn: bool,
+    expected: str | list[Any] | None,
 ) -> None:
-    """Missing smart companion shape keeps sensor platform incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: True,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
+    """Track missing vs authoritative-empty inventories across sensor sync payloads."""
+    config_entry = setup_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data=state,
+        sync_telemetry=sync_telemetry,
+        sync_vnstat=sync_vnstat,
+        sync_speedtest=sync_speedtest,
+        sync_smart=sync_smart,
+        sync_gateways=sync_gateways,
+        sync_interfaces=sync_interfaces,
+        sync_carp=sync_carp,
+        sync_dhcp_leases=sync_dhcp_leases,
+        sync_vpn=sync_vpn,
     )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = state
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+    captured = capture_reconciled_desired_entities(monkeypatch)
 
     await async_setup_entry(
         MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
     )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
+    assert "entities" in captured
+    entities = captured["entities"]
+    if expected is None or expected == []:
+        assert entities == expected
+        return
 
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_smart_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """A typed-empty smart inventory remains authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: True,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"smart": [], "smart_info": {}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        {"carp": {"interfaces": "bad"}},
-        {"carp": {}},
-    ],
-)
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_incomplete_carp_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-    state: Any,
-) -> None:
-    """Malformed or incomplete CARP inventory keeps sensor platform incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: True,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = state
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_carp_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Typed-empty CARP interfaces remain authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: True,
-            CONF_SYNC_DHCP_LEASES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"carp": {"interfaces": []}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    entities = recorded["entities"]
     assert isinstance(entities, list)
     keys = {entity.entity_description.key for entity in entities}
-    assert keys == {"carp.status_summary"}
-
-
-@pytest.mark.parametrize(
-    "state",
-    [
-        {"dhcp_leases": {"leases": {"lan": []}}},
-        {"dhcp_leases": {}},
-    ],
-)
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_incomplete_dhcp_lease_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-    state: Any,
-) -> None:
-    """Malformed or missing DHCP lease-interface inventory keeps sensor platform incomplete."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: True,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = state
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_dhcp_lease_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Typed-empty DHCP lease interface inventory remains authoritative."""
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_TELEMETRY: False,
-            CONF_SYNC_VNSTAT: False,
-            CONF_SYNC_SPEEDTEST: False,
-            CONF_SYNC_SMART: False,
-            CONF_SYNC_GATEWAYS: False,
-            CONF_SYNC_INTERFACES: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_DHCP_LEASES: True,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CERTIFICATES: False,
-        }
-    )
-    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coordinator.data = {"dhcp_leases": {"leases": {}, "lease_interfaces": {}}}
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
-
-    await async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    entities = recorded["entities"]
-    assert isinstance(entities, list)
-    keys = {entity.entity_description.key for entity in entities}
-    assert keys == {"dhcp_leases.all"}
+    if expected == "telemetry_authoritative_empty":
+        assert "telemetry.cpu.usage_total" in keys
+        assert "telemetry.pfstate.used" in keys
+        assert not any(key.startswith("telemetry.filesystems.") for key in keys)
+        assert not any(key.startswith("telemetry.temps.") for key in keys)
+        return
+    if expected == "carp_authoritative_empty":
+        assert keys == {"carp.status_summary"}
+        return
+    if expected == "dhcp_authoritative_empty":
+        assert keys == {"dhcp_leases.all"}
+        return
+    pytest.fail(f"Unhandled expected marker: {expected}")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3344,6 +3344,55 @@ async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
     assert recorded["entities"] == []
 
 
+@pytest.mark.parametrize(
+    ("state", "description"),
+    [
+        ({"openvpn": {}}, "Missing wireguard inventory"),
+        ({"wireguard": {}, "openvpn": "bad"}, "Malformed wireguard inventory"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    description: str,
+) -> None:
+    """A valid VPN side alone must not mark sensor reconciliation complete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded, description
+    assert recorded["entities"] is None, description
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_records_none_for_missing_vnstat_inventory(
     monkeypatch: pytest.MonkeyPatch,
@@ -3502,6 +3551,362 @@ async def test_async_setup_entry_records_empty_authoritative_speedtest_inventory
     )
     assert "entities" in recorded
     assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_incomplete_telemetry_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing telemetry dynamic containers keep sensor platform incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: True,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_telemetry_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Typed-empty telemetry containers remain authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: True,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"telemetry": {"filesystems": [], "temps": {}}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    entities = recorded["entities"]
+    assert isinstance(entities, list)
+    keys = {entity.entity_description.key for entity in entities}
+    assert "telemetry.cpu.usage_total" in keys
+    assert "telemetry.pfstate.used" in keys
+    assert not any(key.startswith("telemetry.filesystems.") for key in keys)
+    assert not any(key.startswith("telemetry.temps.") for key in keys)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"smart": []},
+        {"smart": [], "smart_info": "bad"},
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_incomplete_smart_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: Any,
+) -> None:
+    """Missing smart companion shape keeps sensor platform incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: True,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_smart_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """A typed-empty smart inventory remains authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: True,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"smart": [], "smart_info": {}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"carp": {"interfaces": "bad"}},
+        {"carp": {}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_incomplete_carp_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: Any,
+) -> None:
+    """Malformed or incomplete CARP inventory keeps sensor platform incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: True,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_carp_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Typed-empty CARP interfaces remain authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: True,
+            CONF_SYNC_DHCP_LEASES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"carp": {"interfaces": []}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    entities = recorded["entities"]
+    assert isinstance(entities, list)
+    keys = {entity.entity_description.key for entity in entities}
+    assert keys == {"carp.status_summary"}
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"dhcp_leases": {"leases": {"lan": []}}},
+        {"dhcp_leases": {}},
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_incomplete_dhcp_lease_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: Any,
+) -> None:
+    """Malformed or missing DHCP lease-interface inventory keeps sensor platform incomplete."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: True,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = state
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_dhcp_lease_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Typed-empty DHCP lease interface inventory remains authoritative."""
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_TELEMETRY: False,
+            CONF_SYNC_VNSTAT: False,
+            CONF_SYNC_SPEEDTEST: False,
+            CONF_SYNC_SMART: False,
+            CONF_SYNC_GATEWAYS: False,
+            CONF_SYNC_INTERFACES: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_DHCP_LEASES: True,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CERTIFICATES: False,
+        }
+    )
+    coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
+    coordinator.data = {"dhcp_leases": {"leases": {}, "lease_interfaces": {}}}
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(sensor_module, "record_desired_entities", capture)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    entities = recorded["entities"]
+    assert isinstance(entities, list)
+    keys = {entity.entity_description.key for entity in entities}
+    assert keys == {"dhcp_leases.all"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, UnitOfDataRate, UnitOfInformation, UnitOfTemperature
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -131,9 +132,7 @@ async def test_carp_entry_setup_has_exact_read_only_vip_inventory(
         sensor_module._build_carp_vip_sensor_key("1", "192.0.2.1"),
         sensor_module._build_carp_vip_sensor_key("2", "198.51.100.1"),
     }
-    expected_unique_ids = {
-        sensor_module.slugify(f"{entry.entry_id}_{key}") for key in expected_keys
-    }
+    expected_unique_ids = {slugify(f"{entry.entry_id}_{key}") for key in expected_keys}
     assert keys == expected_keys
     assert {entity.unique_id for entity in created} == expected_unique_ids
     descriptions = {entity.entity_description.key: entity.entity_description for entity in created}
@@ -572,10 +571,10 @@ async def test_compile_gateway_sensors_keeps_gateway_id_in_entity_key(
         entity for entity in entities if entity.entity_description.key == "gateway.wan.status"
     )
     assert address_entity.entity_description.name == "Gateway WAN_GW address"
-    assert address_entity._attr_unique_id == sensor_module.slugify(
+    assert address_entity._attr_unique_id == slugify(
         f"{entry.data['device_unique_id']}_gateway.WAN_GW.address"
     )
-    assert status_entity._attr_unique_id == sensor_module.slugify(
+    assert status_entity._attr_unique_id == slugify(
         f"{entry.data['device_unique_id']}_gateway.WAN_GW.status"
     )
 
@@ -597,7 +596,7 @@ def test_carp_sensor_unavailable_variants(
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = f"carp.interface.lan0.{sensor_module.slugify(desc_subnet)}"
+    desc.key = f"carp.interface.lan0.{slugify(desc_subnet)}"
     desc.name = "CARP"
 
     s = OPNsenseCarpInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
@@ -615,7 +614,7 @@ def test_carp_sensor_state_wrong_type(make_config_entry: Callable[..., MockConfi
     entry = make_config_entry()
 
     desc = MagicMock()
-    desc.key = f"carp.interface.wan.{sensor_module.slugify('10.10.10.10')}"
+    desc.key = f"carp.interface.wan.{slugify('10.10.10.10')}"
     desc.name = "CARP WrongType"
 
     s = OPNsenseCarpInterfaceSensor(config_entry=entry, coordinator=coord, entity_description=desc)
@@ -1036,8 +1035,8 @@ def test_carp_sensor_attributes_and_icon(
     desc = MagicMock()
     desc.key = (
         f"carp.interface."
-        f"{sensor_module.slugify(carp_entry.get('interface', 'unknown'))}."
-        f"{sensor_module.slugify(carp_entry['subnet'])}"
+        f"{slugify(carp_entry.get('interface', 'unknown'))}."
+        f"{slugify(carp_entry['subnet'])}"
     )
     desc.name = "CARP Test"
 
@@ -1532,7 +1531,7 @@ def test_carp_interface_sensor_disambiguates_same_subnet_by_interface(
     ("desc_key", "cls", "main_check", "extra_check"),
     [
         (
-            f"carp.interface.{sensor_module.slugify('lan0')}.{sensor_module.slugify('10.0.0.1')}",
+            f"carp.interface.{slugify('lan0')}.{slugify('10.0.0.1')}",
             OPNsenseCarpInterfaceSensor,
             lambda s: s.native_value == "MASTER",
             lambda s: s.icon == "mdi:check-network",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1844,27 +1844,6 @@ def test_vpn_sensor_handles_exceptions_from_instance_get(
     assert s.available is False
 
 
-def test_vpn_sensor_fails_closed_for_malformed_instance_collection(
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """VPN sensor should mark unavailable when the instance collection is malformed."""
-    entry = make_config_entry()
-    coord = MagicMock(spec=OPNsenseDataUpdateCoordinator)
-    coord.data = {"openvpn": {"servers": "not-a-mapping"}}
-    desc = MagicMock()
-    desc.key = "openvpn.servers.uuid1.status"
-    desc.name = "VPN Malformed"
-
-    s = OPNsenseVPNSensor(config_entry=entry, coordinator=coord, entity_description=desc)
-    s.hass = MagicMock()
-    s.entity_id = "sensor.vpn_malformed"
-    object.__setattr__(s, "async_write_ha_state", lambda: None)
-
-    s._handle_coordinator_update()
-
-    assert s.available is False
-
-
 @pytest.mark.parametrize(
     ("coord_data", "key"),
     [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3293,6 +3293,46 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert recorded["entities"] is None, description
 
 
+def test_vnstat_rows_are_complete_defaults_and_rejects_falsy_rows() -> None:
+    """VnStat inventories should treat missing keys as empty and falsy payloads as incomplete."""
+    assert sensor_module._vnstat_rows_are_complete({}) is True
+    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": {}}}) is True
+    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": False}}) is False
+    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": 0}}) is False
+    assert sensor_module._vnstat_rows_are_complete({"vnstat": {"interfaces": []}}) is False
+
+
+def test_vpn_sensor_rows_are_complete_defaults_and_rejects_falsy_rows() -> None:
+    """VPN inventories should default missing client/server groups to {} and reject falsy groups."""
+    assert (
+        sensor_module._vpn_sensor_rows_are_complete(
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": {}, "servers": {}},
+            }
+        )
+        is True
+    )
+    assert (
+        sensor_module._vpn_sensor_rows_are_complete(
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": [], "servers": {}},
+            }
+        )
+        is False
+    )
+    assert (
+        sensor_module._vpn_sensor_rows_are_complete(
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": {}, "servers": False},
+            }
+        )
+        is False
+    )
+
+
 @pytest.mark.parametrize(
     ("state", "sync_option", "expected_key"),
     [

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -27,6 +27,7 @@ from custom_components.opnsense.const import (
     CONF_SYNC_VNSTAT,
     CONF_SYNC_VPN,
     COORDINATOR,
+    OPNSENSE_CLIENT,
 )
 from custom_components.opnsense.coordinator import OPNsenseDataUpdateCoordinator
 from custom_components.opnsense.sensor import (
@@ -3104,6 +3105,7 @@ def setup_sensor_reconciliation_entry(
     sync_dhcp_leases: bool = False,
     sync_vpn: bool = False,
     sync_certificates: bool = False,
+    opnsense_client: object | None = None,
 ) -> MockConfigEntry:
     """Create a sensor test entry with coordinator/runtime pre-wired."""
     entry = make_config_entry(
@@ -3124,6 +3126,8 @@ def setup_sensor_reconciliation_entry(
     coordinator = MagicMock(spec=OPNsenseDataUpdateCoordinator)
     coordinator.data = coordinator_data
     setattr(entry.runtime_data, COORDINATOR, coordinator)
+    if opnsense_client is not None:
+        setattr(entry.runtime_data, OPNSENSE_CLIENT, opnsense_client)
     return entry
 
 
@@ -3512,6 +3516,51 @@ async def test_async_setup_entry_records_none_or_authoritative_empty_for_invento
         assert keys == {"dhcp_leases.all"}
         return
     pytest.fail(f"Unhandled expected marker: {expected}")
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_desired_entities_for_smart_without_info_support(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sync remains complete when client supports `get_smart` but not `get_smart_info`."""
+    client = MagicMock(spec=["get_smart"])
+    client.get_smart = MagicMock()
+    config_entry = setup_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data={"smart": [{"device": "nvme0"}]},
+        sync_smart=True,
+        opnsense_client=client,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert captured["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_when_smart_info_is_required(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """SMART sync remains incomplete when `get_smart_info` is supported but payload is missing."""
+    client = MagicMock(spec=["get_smart", "get_smart_info"])
+    client.get_smart = MagicMock()
+    client.get_smart_info = MagicMock()
+    config_entry = setup_sensor_reconciliation_entry(
+        make_config_entry,
+        coordinator_data={"smart": [{"device": "nvme0"}]},
+        sync_smart=True,
+        opnsense_client=client,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+
+    await async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert captured["entities"] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -205,10 +205,22 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
 
     await services_mod.async_setup_services(hass)
 
-    registrations = {
-        call.kwargs["service"]: call.kwargs for call in hass.services.async_register.call_args_list
-    }
+    registrations_by_service: dict[str, list[dict[str, Any]]] = {}
+    for call in hass.services.async_register.call_args_list:
+        kwargs = call.kwargs
+        registrations_by_service.setdefault(kwargs["service"], []).append(kwargs)
 
+    duplicate_services = [
+        service
+        for service, registrations in registrations_by_service.items()
+        if len(registrations) > 1
+    ]
+    assert not duplicate_services, f"Duplicate service registrations: {duplicate_services}"
+
+    registrations: dict[str, dict[str, Any]] = {
+        service: entries[0] for service, entries in registrations_by_service.items()
+    }
+    assert len(hass.services.async_register.call_args_list) == len(registrations)
     assert set(registrations) == {
         SERVICE_CLOSE_NOTICE,
         SERVICE_START_SERVICE,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 from aiopnsense.exceptions import OPNsenseVoucherServerError
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.yaml import load_yaml_dict
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -119,7 +120,7 @@ def _patch_device_registry_entry(
     )
     device_registry = MagicMock()
     device_registry.async_get.return_value = device_entry
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda _hass: device_registry)
 
 
 def _patch_entity_registry_entry(
@@ -135,7 +136,7 @@ def _patch_entity_registry_entry(
     entity_entry = SimpleNamespace(config_entry_id=config_entry_id)
     entity_registry = MagicMock()
     entity_registry.async_get.return_value = entity_entry
-    monkeypatch.setattr(services_mod.er, "async_get", lambda _hass: entity_registry)
+    monkeypatch.setattr(er, "async_get", lambda _hass: entity_registry)
 
 
 def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,7 +147,7 @@ def _patch_missing_device_registry_entry(monkeypatch: pytest.MonkeyPatch) -> Non
     """
     device_registry = MagicMock()
     device_registry.async_get.return_value = None
-    monkeypatch.setattr(services_mod.dr, "async_get", lambda _hass: device_registry)
+    monkeypatch.setattr(dr, "async_get", lambda _hass: device_registry)
 
 
 def _add_entry_for_client(
@@ -422,8 +423,8 @@ async def test_get_clients_registry_errors_raise_for_explicit_targets(
 
         return _r
 
-    monkeypatch.setattr(services_mod.dr, "async_get", _raises(TypeError()))
-    monkeypatch.setattr(services_mod.er, "async_get", _raises(AttributeError()))
+    monkeypatch.setattr(dr, "async_get", _raises(TypeError()))
+    monkeypatch.setattr(er, "async_get", _raises(AttributeError()))
     with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,7 +6,6 @@ for operations such as starting/stopping services and generating vouchers.
 
 from collections.abc import Awaitable, Callable
 import json
-import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Never
@@ -394,7 +393,7 @@ async def test_get_clients_only_carp_entries_reject_explicit_targets(
 
 @pytest.mark.asyncio
 async def test_get_clients_registry_errors_raise_for_explicit_targets(
-    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Registry lookup errors must not broaden explicit targets to all clients."""
     hass_local = MagicMock(spec=HomeAssistant)
@@ -425,19 +424,8 @@ async def test_get_clients_registry_errors_raise_for_explicit_targets(
 
     monkeypatch.setattr(services_mod.dr, "async_get", _raises(TypeError()))
     monkeypatch.setattr(services_mod.er, "async_get", _raises(AttributeError()))
-    with (
-        caplog.at_level(logging.DEBUG, logger=services_mod._LOGGER.name),
-        pytest.raises(ServiceValidationError),
-    ):
+    with pytest.raises(ServiceValidationError):
         await services_mod._get_clients(hass_local, opndevice_id="d", opnentity_id="e")
-
-    debug_args = [
-        record.args
-        for record in caplog.records
-        if record.name == services_mod._LOGGER.name and isinstance(record.args, tuple)
-    ]
-    assert any(args[0] == "d" for args in debug_args)
-    assert any(args[0] == "e" for args in debug_args)
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -208,7 +208,7 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
         call.kwargs["service"]: call.kwargs for call in hass.services.async_register.call_args_list
     }
 
-    assert list(registrations) == [
+    assert set(registrations) == {
         SERVICE_CLOSE_NOTICE,
         SERVICE_START_SERVICE,
         SERVICE_STOP_SERVICE,
@@ -222,7 +222,7 @@ async def test_async_setup_services_registers_expected_service_contracts() -> No
         SERVICE_RUN_SPEEDTEST,
         SERVICE_GET_VNSTAT_METRICS,
         SERVICE_TOGGLE_ALIAS,
-    ]
+    }
     assert registrations[SERVICE_GENERATE_VOUCHERS]["supports_response"] == SupportsResponse.ONLY
     assert registrations[SERVICE_KILL_STATES]["supports_response"] == SupportsResponse.OPTIONAL
     assert registrations[SERVICE_RUN_SPEEDTEST]["supports_response"] == SupportsResponse.ONLY

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -561,7 +561,7 @@ async def test_service_start_stop_restart_success_and_failure(
 
 @pytest.mark.asyncio
 async def test_service_restart_only_if_running_and_reload_interface(
-    monkeypatch: pytest.MonkeyPatch, ph_hass: Any, caplog: pytest.LogCaptureFixture
+    monkeypatch: pytest.MonkeyPatch, ph_hass: Any
 ) -> None:
     """Restart service honors only_if_running and reload_interface behavior."""
     c1 = MagicMock()
@@ -575,11 +575,8 @@ async def test_service_restart_only_if_running_and_reload_interface(
     call = _service_call({"service_id": "svc", "only_if_running": True})
 
     _patch_clients(monkeypatch, [c1])
-    caplog.set_level("DEBUG", logger=services_mod.__name__)
     await services_mod._service_restart_service(hass, call)
     c1.restart_service_if_running.assert_awaited_once_with("svc")
-    assert "[service_restart_service] restart_service_if_running, client: c1" in caplog.text
-    assert "[service_restart_service] restart_service_if_running] client: c1" not in caplog.text
     c1.restart_service.assert_not_awaited()
 
     c1.restart_service_if_running = AsyncMock(return_value=False)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3650,39 +3650,6 @@ async def test_vpn_entries_skip_non_mapping_and_missing_enabled(
     assert ents == []
 
 
-def test_service_switch_initializes_property_name(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Service switches extract the property name from their entity key."""
-    desc = SwitchEntityDescription(key="service.svcx.status", name="SvcX")
-    config_entry_srv = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry_srv.runtime_data, COORDINATOR, coordinator)
-    ent = OPNsenseServiceSwitch(
-        config_entry=config_entry_srv,
-        coordinator=coordinator,
-        entity_description=desc,
-    )
-    assert ent._prop_name == "status"
-
-
-def test_vpn_instance_key_parsing(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """VPNSwitch parses its entity_description.key into type, section, and uuid."""
-    # ensure VPNSwitch parses key parts without raising
-    desc = SwitchEntityDescription(key="openvpn.clients.c1", name="VPNC")
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    ent = OPNsenseVPNSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=desc,
-    )
-    assert ent._vpn_type == "openvpn"
-    assert ent._clients_servers == "clients"
-    assert ent._uuid == "c1"
-
-
 @pytest.mark.parametrize("exc_type", [TypeError, KeyError, AttributeError])
 def test_vpn_handle_exceptions_sets_unavailable(
     exc_type: type[Exception],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -141,7 +141,15 @@ def setup_switch_reconciliation_entry(
         ({}, False, True, False, False, None),
         ({"services": []}, False, True, False, False, []),
         ({}, True, False, False, False, None),
-        ({"firewall": {}}, True, False, False, False, []),
+        ({"firewall": {}}, True, False, False, False, None),
+        (
+            {"firewall": {"rules": {"r1": {"uuid": "r1", "description": "r1"}}}},
+            True,
+            False,
+            False,
+            False,
+            None,
+        ),
         ({}, False, False, True, False, None),
         ({"openvpn": {}, "wireguard": {}}, False, False, True, False, []),
         ({}, False, False, False, True, None),
@@ -152,6 +160,7 @@ def setup_switch_reconciliation_entry(
         "empty_service",
         "missing_firewall",
         "empty_firewall",
+        "partial_firewall-without-nat",
         "missing_vpn",
         "empty_vpn",
         "missing_unbound",
@@ -245,6 +254,93 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert created
     keys = {entity.entity_description.key for entity in created}
     assert keys == {"openvpn.clients.client-uuid"}, description
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_malformed_firewall_nat_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing NAT subsections should force incomplete firewall reconciliation."""
+    state = {
+        "firewall": {
+            "rules": {"r1": {"uuid": "r1", "description": "Rule", "%interface": "wan"}},
+            "nat": {"source_nat": {}, "d_nat": {}, "one_to_one": {}},
+        }
+    }
+    config_entry = setup_switch_reconciliation_entry(
+        make_config_entry,
+        coordinator=make_coord(state),
+        sync_firewall_and_nat=True,
+    )
+    recorded: dict[str, Any] = {}
+    created: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup."""
+        created.extend(ents)
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", add_entities)
+    )
+
+    assert recorded.get("entities") is None
+    assert created
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_entities"),
+    [
+        ({}, None),
+        ({"carp": {}}, None),
+        ({"carp": {"status_summary": []}}, None),
+        ({"carp": {"status_summary": {"maintenance_mode": False, "enabled": True}}}, 1),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_invalid_carp_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    expected_entities: int | None,
+) -> None:
+    """CARP reconciliation should be incomplete without a status_summary mapping."""
+    config_entry = setup_switch_reconciliation_entry(
+        make_config_entry,
+        coordinator=make_coord(state),
+        sync_carp=True,
+    )
+    captured: dict[str, Any] = {}
+    created: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        captured["entities"] = entities
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup."""
+        created.extend(ents)
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", add_entities)
+    )
+
+    assert "entities" in captured
+    if expected_entities is None:
+        assert captured["entities"] is None
+        assert len(created) == 0
+    else:
+        assert isinstance(captured["entities"], list)
+        assert len(captured["entities"]) == expected_entities
+        assert len(created) == 1
 
 
 async def collect_setup_carp_switches(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1841,6 +1841,28 @@ async def test_compile_unbound_extended_and_toggle(
 
 
 @pytest.mark.asyncio
+async def test_compile_unbound_switches_skips_empty_rows(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Empty legacy and extended Unbound rows should be skipped during compile."""
+    state = {
+        "unbound_blocklist": {
+            "legacy": {},
+            "u1": {},
+            "u2": {"enabled": "1", "description": "Two"},
+        },
+    }
+    coordinator.data = state
+    config_entry = make_config_entry(data={CONF_DEVICE_UNIQUE_ID: "dev1", "url": "http://example"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    ents = await _compile_unbound_switches(config_entry, coordinator, state)
+
+    assert len(ents) == 1
+    assert {ent.entity_description.key for ent in ents} == {"unbound_blocklist.switch.u2"}
+
+
+@pytest.mark.asyncio
 async def test_compile_unbound_switches_handles_legacy_and_extended_payloads(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
 ) -> None:
@@ -1860,6 +1882,40 @@ async def test_compile_unbound_switches_handles_legacy_and_extended_payloads(
     assert len(ents) == 2
     assert any(isinstance(ent, OPNsenseUnboundBlocklistSwitchLegacy) for ent in ents)
     assert any(isinstance(ent, OPNsenseUnboundBlocklistSwitch) for ent in ents)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_marks_empty_unbound_rows_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Empty Unbound rows should not be authoritative while valid siblings still compile."""
+    state = {
+        "unbound_blocklist": {
+            "legacy": {},
+            "u1": {},
+            "good": {"enabled": "1", "description": "Good Row"},
+        },
+    }
+    coordinator = make_coord(state)
+    config_entry = setup_switch_reconciliation_entry(
+        make_config_entry,
+        coordinator=coordinator,
+        sync_unbound=True,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+    created: list[Any] = []
+
+    await switch_mod.async_setup_entry(
+        MagicMock(),
+        config_entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: created.extend(entities)),
+    )
+
+    assert captured["entities"] is None
+    assert {entity.entity_description.key for entity in created} == {
+        "unbound_blocklist.switch.good"
+    }
 
 
 @pytest.mark.asyncio
@@ -1988,13 +2044,14 @@ async def test_unbound_missing_sets_unavailable(
     """Unbound switch becomes unavailable when expected data is missing."""
     config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1", "url": "http://example"})
     setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    state: dict[str, Any] = {"unbound_blocklist": {"legacy": {}}}
-    coordinator.data = state
-    ent = (await _compile_unbound_switches(config_entry, coordinator, state))[0]
+    initial_state = {"unbound_blocklist": {"legacy": {"enabled": "1"}}}
+    coordinator.data = initial_state
+    ent = (await _compile_unbound_switches(config_entry, coordinator, initial_state))[0]
+    missing_state: dict[str, Any] = {"unbound_blocklist": {"legacy": {}}}
     # use PHCC-provided hass fixture
     hass = ph_hass
     ent.hass = hass
-    ent.coordinator = make_coord(state)
+    ent.coordinator = make_coord(missing_state)
     ent.entity_id = f"switch.{ent._attr_unique_id}"
     stub_async_write_ha_state(ent)
     ent._handle_coordinator_update()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -92,208 +92,99 @@ def make_carp_maintenance_switch(
     return entity
 
 
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_service_inventory(
+def capture_reconciled_desired_entities(
     monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    """Capture reconciliation desired entities during setup."""
+    captured: dict[str, Any] = {}
+
+    def capture(
+        _entry: MockConfigEntry,
+        _platform: str,
+        entities: Any | None = None,
+    ) -> None:
+        """Capture entities passed to ``record_desired_entities``."""
+        captured["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+    return captured
+
+
+def setup_switch_reconciliation_entry(
     make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing service payload keeps switch platform reconciliation incomplete."""
-    coordinator = make_coord({})
+    coordinator: Any,
+    *,
+    sync_firewall_and_nat: bool = False,
+    sync_services: bool = False,
+    sync_vpn: bool = False,
+    sync_carp: bool = False,
+    sync_unbound: bool = False,
+) -> MockConfigEntry:
+    """Create a switch test entry with coordinator/runtime pre-wired."""
     config_entry = make_config_entry(
         {
             CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: True,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
+            CONF_SYNC_FIREWALL_AND_NAT: sync_firewall_and_nat,
+            CONF_SYNC_SERVICES: sync_services,
+            CONF_SYNC_VPN: sync_vpn,
+            CONF_SYNC_CARP: sync_carp,
+            CONF_SYNC_UNBOUND: sync_unbound,
         }
     )
     setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    return config_entry
 
-    recorded: dict[str, Any] = {}
 
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+@pytest.mark.parametrize(
+    ("state", "sync_firewall_and_nat", "sync_services", "sync_vpn", "sync_unbound", "expected"),
+    [
+        ({}, False, True, False, False, None),
+        ({"services": []}, False, True, False, False, []),
+        ({}, True, False, False, False, None),
+        ({"firewall": {}}, True, False, False, False, []),
+        ({}, False, False, True, False, None),
+        ({"openvpn": {}, "wireguard": {}}, False, False, True, False, []),
+        ({}, False, False, False, True, None),
+        ({"unbound_blocklist": {}}, False, False, False, True, []),
+    ],
+    ids=[
+        "missing_service",
+        "empty_service",
+        "missing_firewall",
+        "empty_firewall",
+        "missing_vpn",
+        "empty_vpn",
+        "missing_unbound",
+        "empty_unbound",
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_or_authoritative_empty_for_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    sync_firewall_and_nat: bool,
+    sync_services: bool,
+    sync_vpn: bool,
+    sync_unbound: bool,
+    expected: Any,
+) -> None:
+    """Track missing vs authoritative-empty inventories across switch sync payloads."""
+    config_entry = setup_switch_reconciliation_entry(
+        make_config_entry,
+        coordinator=make_coord(state),
+        sync_firewall_and_nat=sync_firewall_and_nat,
+        sync_services=sync_services,
+        sync_vpn=sync_vpn,
+        sync_unbound=sync_unbound,
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
 
     await switch_mod.async_setup_entry(
         MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
     )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_service_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty service container is still authoritative."""
-    coordinator = make_coord({"services": []})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: True,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_firewall_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing firewall payload keeps switch platform reconciliation incomplete."""
-    coordinator = make_coord({})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: True,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_firewall_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty firewall container is still authoritative."""
-    coordinator = make_coord({"firewall": {}})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: True,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_vpn_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing VPN payload keeps switch platform reconciliation incomplete."""
-    coordinator = make_coord({})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: True,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty VPN container is still authoritative."""
-    coordinator = make_coord({"openvpn": {}, "wireguard": {}})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: True,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: False,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
+    assert "entities" in captured
+    assert captured["entities"] == expected
 
 
 @pytest.mark.parametrize(
@@ -354,74 +245,6 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert created
     keys = {entity.entity_description.key for entity in created}
     assert keys == {"openvpn.clients.client-uuid"}, description
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_none_for_missing_unbound_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Missing unbound payload keeps switch platform reconciliation incomplete."""
-    coordinator = make_coord({})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: True,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] is None
-
-
-@pytest.mark.asyncio
-async def test_async_setup_entry_records_empty_authoritative_unbound_inventory(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """An explicit empty unbound container is still authoritative."""
-    coordinator = make_coord({"unbound_blocklist": {}})
-    config_entry = make_config_entry(
-        {
-            CONF_DEVICE_UNIQUE_ID: "id",
-            CONF_SYNC_FIREWALL_AND_NAT: False,
-            CONF_SYNC_SERVICES: False,
-            CONF_SYNC_VPN: False,
-            CONF_SYNC_CARP: False,
-            CONF_SYNC_UNBOUND: True,
-        }
-    )
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-
-    recorded: dict[str, Any] = {}
-
-    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
-        """Capture the desired-entity payload sent to reconciliation."""
-        recorded["entities"] = entities
-
-    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
-
-    await switch_mod.async_setup_entry(
-        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
-    )
-    assert "entities" in recorded
-    assert recorded["entities"] == []
 
 
 async def collect_setup_carp_switches(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,7 +5,7 @@ async setup flows for the integration's switch platform.
 """
 
 import asyncio
-from collections.abc import Callable, Iterable, MutableMapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
 import contextlib
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
@@ -4146,3 +4146,71 @@ async def test_async_setup_entry_records_none_for_malformed_service_identity_row
     )
     assert recorded["entities"] is None
     assert [entity.entity_description.key for entity in created] == ["service.svc.status"]
+
+
+def test_service_switch_get_service_matches_normalized_identity(
+    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
+) -> None:
+    """Service switch should remain available when service ids need normalization."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = {
+        "services": [
+            {"id": "  svc1  ", "name": "svc1", "status": True},
+        ]
+    }
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Svc 1"),
+    )
+    ent.entity_id = "switch.svc1"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._handle_coordinator_update()
+
+    assert ent.available is True
+    assert ent.is_on is True
+
+
+@pytest.mark.parametrize(
+    ("service", "identity"),
+    [
+        ({"id": "  svc-padded  ", "name": "svc-padded", "status": False}, "svc-padded"),
+        ({"name": "svc-name-only", "status": False}, "svc-name-only"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_service_switch_controls_normalized_identity(
+    coordinator: MagicMock,
+    ph_hass: Any,
+    service: Mapping[str, Any],
+    identity: str,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Service switch should control services when identity is trimmed id or fallback name."""
+    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+    coordinator.data = {"services": [service]}
+    ent = OPNsenseServiceSwitch(
+        config_entry=config_entry,
+        coordinator=coordinator,
+        entity_description=SwitchEntityDescription(key=f"service.{identity}.status", name="Svc"),
+    )
+    ent.hass = ph_hass
+    ent.coordinator = make_coord({"services": [service]})
+    ent.entity_id = f"switch.service.{identity}"
+    object.__setattr__(ent, "async_write_ha_state", lambda: None)
+
+    ent._client = MagicMock()
+    ent._client.start_service = AsyncMock(return_value=True)
+    ent._client.stop_service = AsyncMock(return_value=True)
+
+    ent._handle_coordinator_update()
+    assert ent.available is True
+
+    await ent.async_turn_on()
+    ent._client.start_service.assert_awaited_once_with(identity)
+
+    await ent.async_turn_off()
+    ent._client.stop_service.assert_awaited_once_with(identity)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2006,22 +2006,20 @@ async def test_vpn_turn_on_off_noops_when_preconditions_fail(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("client_result", "expected_is_on", "expected_delay", "expect_error"),
+    ("client_result", "expected_is_on", "expected_delay"),
     [
-        (True, False, True, False),  # client succeeds -> turned off
-        (False, True, False, True),  # client fails -> remains on, error logged
-        (None, True, False, False),  # no client -> no-op
+        pytest.param(True, False, True, id="success"),
+        pytest.param(False, True, False, id="client-failure"),
+        pytest.param(None, True, False, id="missing-client"),
     ],
 )
 async def test_vpn_async_turn_off_variations(
     monkeypatch: pytest.MonkeyPatch,
     coordinator: MagicMock,
     ph_hass: Any,
-    caplog: pytest.LogCaptureFixture,
     client_result: Any,
     expected_is_on: Any,
     expected_delay: Any,
-    expect_error: Any,
     make_config_entry: Callable[..., MockConfigEntry],
 ) -> None:
     """Parameterize async_turn_off behavior for success, failure, and missing client."""
@@ -2055,20 +2053,10 @@ async def test_vpn_async_turn_off_variations(
         ent._client = MagicMock()
         ent._client.toggle_vpn_instance = AsyncMock(return_value=client_result)
 
-    # capture logs
-    caplog.clear()
-    caplog.set_level("INFO")
-
     await ent.async_turn_off()
 
     assert ent.is_on is expected_is_on
     assert ent.delay_update is expected_delay
-
-    if expect_error:
-        assert "Failed to turn off VPN" in caplog.text
-    else:
-        # on success or when no client is present, there should be no failure log
-        assert "Failed to turn off VPN" not in caplog.text
 
     # If already off, async_turn_off should do nothing (no additional client calls)
     ent._attr_is_on = False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1764,8 +1764,6 @@ def test_delay_update_setter(
 
         ent.delay_update = True
         assert ent.delay_update is True
-        # ensure async_call_later returned remover was captured
-        assert callable(getattr(ent, "_delay_update_remove", None))
         ent.delay_update = False
         assert called["removed"] is True
     finally:
@@ -2841,9 +2839,9 @@ def test_reset_delay_calls_existing_remover(
         lambda hass, delay, action: new_remover,
     )
     ent._reset_delay()
-    # old remover should have been called and replaced
     assert called["old_removed"] is True
-    assert ent._delay_update_remove == new_remover
+    ent.delay_update = False
+    assert called["new_removed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4175,13 +4175,6 @@ async def test_nat_rule_switch_with_dotted_rule_key_uses_full_rule_id(
     ent.entity_id = "switch.source_nat_fallback_rule_key_with_dots"
     stub_async_write_ha_state(ent)
 
-    assert ent._rule_id == "fallback.key.with.dots"
-    assert ent._opnsense_get_rule() == {
-        "description": "Source NAT Rule",
-        "%interface": "wan",
-        "enabled": "1",
-    }
-
     ent._client = MagicMock()
     ent._client.toggle_nat_rule = AsyncMock(return_value=True)
     await ent.async_turn_on()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2585,40 +2585,6 @@ def test_rule_switch_handlers_fail_closed_when_enabled_lookup_raises(
     assert ent.available is False
 
 
-def test_service_switch_ignores_malformed_service_rows(
-    coordinator: MagicMock,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Service lookup should skip non-mapping service rows without raising."""
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    coordinator.data = {"services": ["not-a-mapping"]}
-    ent = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Service"),
-    )
-
-    assert ent._opnsense_get_service() is None
-
-
-def test_service_switch_ignores_non_mapping_state(
-    coordinator: MagicMock,
-    make_config_entry: Callable[..., MockConfigEntry],
-) -> None:
-    """Service lookup should return None when coordinator state is malformed."""
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    coordinator.data = []
-    ent = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc1.status", name="Service"),
-    )
-
-    assert ent._opnsense_get_service() is None
-
-
 @pytest.mark.asyncio
 async def test_service_switch_malformed_services_container_on_update(
     coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
@@ -3040,79 +3006,6 @@ async def test_dynamic_switch_compile_helpers_skip_malformed_containers(
     coordinator.data = state
 
     assert await compile_helper(config_entry, coordinator, state) == []
-
-
-def test_opnsense_get_service_skips_malformed_service_rows(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Malformed service rows should be ignored while matching a valid service."""
-    coordinator.data = {
-        "services": [
-            "bad-row",
-            {"id": "svc", "name": "service"},
-        ]
-    }
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
-    )
-    found = entity._opnsense_get_service()
-    assert isinstance(found, MutableMapping)
-    assert found.get("name") == "service"
-
-
-def test_opnsense_get_service_with_malformed_services_container(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Malformed service containers should return None instead of iterating."""
-    coordinator.data = {
-        "services": "bad-services",
-    }
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
-    )
-    assert entity._opnsense_get_service() is None
-
-
-def test_opnsense_get_service_returns_none_when_state_is_malformed(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Malformed top-level service state should return None."""
-    coordinator.data = []
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
-    )
-    assert entity._opnsense_get_service() is None
-
-
-def test_opnsense_get_service_returns_none_when_service_id_is_missing(
-    coordinator: MagicMock, make_config_entry: Callable[..., MockConfigEntry]
-) -> None:
-    """Missing service IDs should return None after scanning valid service rows."""
-    coordinator.data = {
-        "services": [
-            {"id": "other", "name": "other-service"},
-        ],
-    }
-    config_entry = make_config_entry({CONF_DEVICE_UNIQUE_ID: "dev1"})
-    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
-    entity = OPNsenseServiceSwitch(
-        config_entry=config_entry,
-        coordinator=coordinator,
-        entity_description=SwitchEntityDescription(key="service.svc.status", name="Service"),
-    )
-    assert entity._opnsense_get_service() is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -296,6 +296,66 @@ async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
     assert recorded["entities"] == []
 
 
+@pytest.mark.parametrize(
+    ("state", "description"),
+    [
+        (
+            {"openvpn": {"clients": {"client-uuid": {"enabled": True}}}},
+            "Missing wireguard inventory",
+        ),
+        (
+            {
+                "openvpn": {"clients": {"client-uuid": {"enabled": True}}},
+                "wireguard": "bad-wireguard",
+            },
+            "Malformed wireguard inventory",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    description: str,
+) -> None:
+    """A valid VPN side alone must not mark switch reconciliation complete."""
+    coordinator = make_coord(state)
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    created: list[Any] = []
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture switch entities emitted by setup."""
+        created.extend(ents)
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", add_entities)
+    )
+    assert "entities" in recorded, description
+    assert recorded["entities"] is None, description
+    assert created
+    keys = {entity.entity_description.key for entity in created}
+    assert keys == {"openvpn.clients.client-uuid"}, description
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_records_none_for_missing_unbound_inventory(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -295,6 +295,96 @@ async def test_async_setup_entry_records_none_for_malformed_firewall_nat_invento
 
 
 @pytest.mark.parametrize(
+    ("state", "sync_option", "expected_key"),
+    [
+        (
+            {"services": [None, {"locked": 1}, {"id": "svc", "locked": 0}]},
+            "sync_services",
+            "service.svc.status",
+        ),
+        (
+            {
+                "openvpn": {
+                    "clients": {"bad": {}, "good": {"enabled": False}},
+                    "servers": {},
+                },
+                "wireguard": {"clients": {}, "servers": {}},
+            },
+            "sync_vpn",
+            "openvpn.clients.good",
+        ),
+        (
+            {
+                ATTR_UNBOUND_BLOCKLIST: {
+                    "legacy": {},
+                    "bad": None,
+                    "good": {"description": "Good"},
+                }
+            },
+            "sync_unbound",
+            "unbound_blocklist.switch.good",
+        ),
+        (
+            {
+                "firewall": {
+                    "rules": {
+                        "bad": None,
+                        "good": {"uuid": "good", "%interface": ""},
+                    },
+                    "nat": {"source_nat": {}, "d_nat": {}, "one_to_one": {}, "npt": {}},
+                }
+            },
+            "sync_firewall_and_nat",
+            "firewall.rule.good",
+        ),
+        (
+            {
+                "firewall": {
+                    "rules": {},
+                    "nat": {
+                        "source_nat": {
+                            "bad": {"uuid": "bad", "%interface": ""},
+                            "good": {"uuid": "good", "%interface": "wan"},
+                        },
+                        "d_nat": {},
+                        "one_to_one": {},
+                        "npt": {},
+                    },
+                }
+            },
+            "sync_firewall_and_nat",
+            "firewall.nat.source_nat.good",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_async_setup_entry_marks_malformed_switch_rows_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+    state: dict[str, Any],
+    sync_option: str,
+    expected_key: str,
+) -> None:
+    """Malformed rows prevent reconciliation while valid sibling rows still compile."""
+    config_entry = setup_switch_reconciliation_entry(
+        make_config_entry,
+        coordinator=make_coord(state),
+        **{sync_option: True},
+    )
+    captured = capture_reconciled_desired_entities(monkeypatch)
+    created: list[Any] = []
+
+    await switch_mod.async_setup_entry(
+        MagicMock(),
+        config_entry,
+        cast("AddEntitiesCallback", lambda entities, _=False: created.extend(entities)),
+    )
+
+    assert captured["entities"] is None
+    assert expected_key in {entity.entity_description.key for entity in created}
+
+
+@pytest.mark.parametrize(
     ("state", "expected_entities"),
     [
         ({}, None),

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -92,6 +92,278 @@ def make_carp_maintenance_switch(
     return entity
 
 
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_service_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing service payload keeps switch platform reconciliation incomplete."""
+    coordinator = make_coord({})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: True,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_service_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty service container is still authoritative."""
+    coordinator = make_coord({"services": []})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: True,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_firewall_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing firewall payload keeps switch platform reconciliation incomplete."""
+    coordinator = make_coord({})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: True,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_firewall_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty firewall container is still authoritative."""
+    coordinator = make_coord({"firewall": {}})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: True,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing VPN payload keeps switch platform reconciliation incomplete."""
+    coordinator = make_coord({})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_vpn_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty VPN container is still authoritative."""
+    coordinator = make_coord({"openvpn": {}, "wireguard": {}})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: True,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_missing_unbound_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Missing unbound payload keeps switch platform reconciliation incomplete."""
+    coordinator = make_coord({})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: True,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_empty_authoritative_unbound_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """An explicit empty unbound container is still authoritative."""
+    coordinator = make_coord({"unbound_blocklist": {}})
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: False,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: True,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture the desired-entity payload sent to reconciliation."""
+        recorded["entities"] = entities
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", lambda ents, _=False: None)
+    )
+    assert "entities" in recorded
+    assert recorded["entities"] == []
+
+
 async def collect_setup_carp_switches(
     ph_hass: HomeAssistant,
     make_config_entry: Callable[..., MockConfigEntry],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -154,6 +154,8 @@ def setup_switch_reconciliation_entry(
         ({"openvpn": {}, "wireguard": {}}, False, False, True, False, []),
         ({}, False, False, False, True, None),
         ({"unbound_blocklist": {}}, False, False, False, True, []),
+        ({"unbound_blocklist": {"legacy": {}}}, False, False, False, True, []),
+        ({"unbound_blocklist": {"legacy": None}}, False, False, False, True, []),
     ],
     ids=[
         "missing_service",
@@ -165,6 +167,8 @@ def setup_switch_reconciliation_entry(
         "empty_vpn",
         "missing_unbound",
         "empty_unbound",
+        "empty_legacy_unbound",
+        "empty_scalar_legacy_unbound",
     ],
 )
 @pytest.mark.asyncio
@@ -256,6 +260,37 @@ async def test_async_setup_entry_records_none_for_partial_vpn_inventory(
     assert keys == {"openvpn.clients.client-uuid"}, description
 
 
+def test_vpn_switch_rows_are_complete_defaults_and_rejects_falsy_rows() -> None:
+    """VPN switch completeness should default missing groups to {} and reject falsy rows."""
+    assert (
+        switch_mod._vpn_switch_rows_are_complete(
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": {}, "servers": {}},
+            }
+        )
+        is True
+    )
+    assert (
+        switch_mod._vpn_switch_rows_are_complete(
+            {
+                "openvpn": {"clients": [], "servers": {}},
+                "wireguard": {"clients": {}, "servers": {}},
+            }
+        )
+        is False
+    )
+    assert (
+        switch_mod._vpn_switch_rows_are_complete(
+            {
+                "openvpn": {"clients": {}, "servers": {}},
+                "wireguard": {"clients": {}, "servers": 0},
+            }
+        )
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_records_none_for_malformed_firewall_nat_inventory(
     monkeypatch: pytest.MonkeyPatch,
@@ -317,6 +352,17 @@ async def test_async_setup_entry_records_none_for_malformed_firewall_nat_invento
             {
                 ATTR_UNBOUND_BLOCKLIST: {
                     "legacy": {},
+                    "bad": None,
+                    "good": {"description": "Good"},
+                }
+            },
+            "sync_unbound",
+            "unbound_blocklist.switch.good",
+        ),
+        (
+            {
+                ATTR_UNBOUND_BLOCKLIST: {
+                    "legacy": None,
                     "bad": None,
                     "good": {"description": "Good"},
                 }

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4260,3 +4260,50 @@ async def test_compile_new_api_empty_state(
 
     ents = await _compile_nat_source_rules_switches(config_entry, coordinator, state)
     assert ents == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_records_none_for_malformed_service_identity_row(
+    monkeypatch: pytest.MonkeyPatch,
+    make_config_entry: Callable[..., MockConfigEntry],
+) -> None:
+    """Service identity must be stable even if some rows are malformed."""
+    coordinator = make_coord(
+        {
+            "services": [
+                {"id": "locked", "name": "Locked", "locked": 1},
+                {},
+                {"id": "svc", "name": "svc", "locked": 0, "status": True},
+            ]
+        }
+    )
+    config_entry = make_config_entry(
+        {
+            CONF_DEVICE_UNIQUE_ID: "id",
+            CONF_SYNC_FIREWALL_AND_NAT: False,
+            CONF_SYNC_SERVICES: True,
+            CONF_SYNC_VPN: False,
+            CONF_SYNC_CARP: False,
+            CONF_SYNC_UNBOUND: False,
+        }
+    )
+    setattr(config_entry.runtime_data, COORDINATOR, coordinator)
+
+    recorded: dict[str, Any] = {}
+    created: list[Any] = []
+
+    def capture(_entry: MockConfigEntry, _platform: str, entities: Any | None = None) -> None:
+        """Capture desired entities input for reconciliation."""
+        recorded["entities"] = entities
+
+    def add_entities(ents: Iterable[Any], _update_before_add: bool = False) -> None:
+        """Capture compiled switch entities."""
+        created.extend(ents)
+
+    monkeypatch.setattr(switch_mod, "record_desired_entities", capture)
+
+    await switch_mod.async_setup_entry(
+        MagicMock(), config_entry, cast("AddEntitiesCallback", add_entities)
+    )
+    assert recorded["entities"] is None
+    assert [entity.entity_description.key for entity in created] == ["service.svc.status"]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -928,12 +928,21 @@ async def test_async_install_stops_after_four_invalid_polling_responses(
 
 
 @pytest.mark.asyncio
-async def test_async_install_timeout_polling_error_raises(
+@pytest.mark.parametrize(
+    ("error_type", "message"),
+    [
+        pytest.param(OPNsenseTimeoutError, "fail", id="timeout"),
+        pytest.param(OPNsenseError, "unexpected", id="generic"),
+    ],
+)
+async def test_async_install_polling_error_raises(
     monkeypatch: pytest.MonkeyPatch,
     make_config_entry: Callable[..., MockConfigEntry],
     dummy_coordinator: MagicMock,
+    error_type: type[OPNsenseError],
+    message: str,
 ) -> None:
-    """async_install should not hide timeout errors raised by aiopnsense."""
+    """async_install should not hide errors raised by aiopnsense while polling."""
     entry = make_config_entry()
     ent = OPNsenseFirmwareUpdatesAvailableUpdate(
         config_entry=entry,
@@ -943,37 +952,12 @@ async def test_async_install_timeout_polling_error_raises(
         ),
     )
 
-    bad: Any = _FirmwareInstallClient(status_error=OPNsenseTimeoutError("fail"))
+    bad: Any = _FirmwareInstallClient(status_error=error_type(message))
     object.__setattr__(ent, "_client", bad)
     ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
     monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
 
-    with pytest.raises(OPNsenseTimeoutError, match="fail"):
-        await ent.async_install()
-
-
-@pytest.mark.asyncio
-async def test_async_install_generic_opnsense_polling_error_raises(
-    monkeypatch: pytest.MonkeyPatch,
-    make_config_entry: Callable[..., MockConfigEntry],
-    dummy_coordinator: MagicMock,
-) -> None:
-    """async_install should not hide generic errors raised by aiopnsense."""
-    entry = make_config_entry()
-    ent = OPNsenseFirmwareUpdatesAvailableUpdate(
-        config_entry=entry,
-        coordinator=dummy_coordinator,
-        entity_description=UpdateEntityDescription(
-            key="firmware.update_available", name="Firmware"
-        ),
-    )
-
-    bad: Any = _FirmwareInstallClient(status_error=OPNsenseError("unexpected"))
-    object.__setattr__(ent, "_client", bad)
-    ent.coordinator.data = {"firmware_update_info": {"status": "update"}}
-    monkeypatch.setattr(asyncio, "sleep", AsyncMock(return_value=None))
-
-    with pytest.raises(OPNsenseError, match="unexpected"):
+    with pytest.raises(error_type, match=message):
         await ent.async_install()
 
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -14,9 +14,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.opnsense import update as update_module
-from custom_components.opnsense.const import CONF_DEVICE_UNIQUE_ID, CONF_SYNC_FIRMWARE_UPDATES
-from custom_components.opnsense.update import OPNsenseFirmwareUpdatesAvailableUpdate
+from custom_components.opnsense.const import (
+    CONF_DEVICE_UNIQUE_ID,
+    CONF_SYNC_FIRMWARE_UPDATES,
+    COORDINATOR,
+)
+from custom_components.opnsense.update import (
+    OPNsenseFirmwareUpdatesAvailableUpdate,
+    _affected_package_count,
+    async_setup_entry,
+)
 
 
 def _firmware_update_state(
@@ -137,7 +144,7 @@ async def test_async_setup_entry_adds_firmware_update_entity_contract(
             CONF_SYNC_FIRMWARE_UPDATES: True,
         }
     )
-    setattr(entry.runtime_data, update_module.COORDINATOR, dummy_coordinator)
+    setattr(entry.runtime_data, COORDINATOR, dummy_coordinator)
     added_entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
 
     def async_add_entities(
@@ -147,9 +154,7 @@ async def test_async_setup_entry_adds_firmware_update_entity_contract(
         """Capture entities added by the platform setup callback."""
         added_entities.extend(entities)
 
-    await update_module.async_setup_entry(
-        hass, entry, cast("AddEntitiesCallback", async_add_entities)
-    )
+    await async_setup_entry(hass, entry, cast("AddEntitiesCallback", async_add_entities))
 
     assert len(added_entities) == 1
     entity = added_entities[0]
@@ -177,7 +182,7 @@ async def test_async_setup_entry_skips_disabled_firmware_update_sync(
             CONF_SYNC_FIRMWARE_UPDATES: False,
         }
     )
-    setattr(entry.runtime_data, update_module.COORDINATOR, dummy_coordinator)
+    setattr(entry.runtime_data, COORDINATOR, dummy_coordinator)
     added_entities: list[OPNsenseFirmwareUpdatesAvailableUpdate] = []
 
     def async_add_entities(
@@ -187,9 +192,7 @@ async def test_async_setup_entry_skips_disabled_firmware_update_sync(
         """Capture entities added by the platform setup callback."""
         added_entities.extend(entities)
 
-    await update_module.async_setup_entry(
-        hass, entry, cast("AddEntitiesCallback", async_add_entities)
-    )
+    await async_setup_entry(hass, entry, cast("AddEntitiesCallback", async_add_entities))
 
     assert added_entities == []
 
@@ -265,7 +268,7 @@ def test_is_update_available_true_for_valid_status(
 
 def test_affected_package_count_counts_lists() -> None:
     """Affected package count should count list-shaped package collections."""
-    assert update_module._affected_package_count(["base", "kernel"]) == 2
+    assert _affected_package_count(["base", "kernel"]) == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds a guided, restart-safe repair flow for replacing OPNsense hardware when the configured device ID changes. Home Assistant can reconcile the replacement device's inventory while preserving registry identity and customizations for compatible entities and devices.

## What Changed

- Detects device-ID mismatches during setup and runtime and surfaces a fixable Home Assistant repair issue
- Re-probes the replacement device before mutation, validates stored and observed IDs, and rejects duplicate ownership or stale entry state
- Unloads the config entry before registry changes and persists a reconciliation marker so interrupted cleanup can resume safely
- Migrates matching entity and device identifiers in place, removes inventory absent from the replacement, and allows newly discovered inventory to be created
- Requires complete, well-formed dynamic inventory across enabled platforms before destructive stale-record cleanup
- Recovers predictably from probe, unload, registry-cleanup, and reload failures without hiding the repair
- Updates replacement-hardware documentation and repair translations
- Adds comprehensive regression coverage for setup, runtime detection, reconciliation, retry, race, validation, and partial-inventory scenarios

## Why

Replacing an OPNsense appliance can change interfaces, services, gateways, disks, and other discovered inventory even when its URL, credentials, and integration options remain valid. Requiring users to remove and reinstall the integration discards useful registry continuity and makes recovery unnecessarily disruptive.

This repair preserves compatible entity IDs, device identities, customizations, dashboards, and automations while explicitly reconciling inventory that genuinely changed. Snapshot checks, authoritative-inventory gates, and a persistent retry marker keep the process safe and recoverable.

## Testing

- `.venv/bin/prek run -a`
- `.venv/bin/pytest` — 1,017 passed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a guided “Device ID mismatch” repair flow with structured replacement-hardware confirmation and fix routing.
  * Implemented restart-safe reconciliation for device-ID repairs and identity migration while preserving matching customizations/connections.
  * Added reconciliation-aware “desired entity” tracking across multiple platforms (sensors, binary sensors, device tracker, switches, updates).
* **Documentation**
  * Updated the hardware replacement guide and table of contents to document the new repair/reconciliation workflow.
* **Bug Fixes / Reliability**
  * Hardened mismatch detection, marker handling, platform completion checks, and safer cleanup/abort behavior on malformed or partial data.
* **Tests**
  * Expanded and added reconciliation/repair flow test coverage across success, abort, cleanup, retry/resume, and malformed cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR introduces a guided, restart-safe Device ID replacement repair flow for OPNsense integration. When hardware is replaced and OPNsense reports a new device ID, users are now presented with a fixable HA repair issue that reconciles entity and device registry identities in-place, preserving existing customizations and automations, instead of requiring a full remove-and-reinstall.

- Adds `repairs.py` with the `DeviceIDMismatchRepairFlow` class, robust snapshot-and-guard validation, and unload/reprobe safety across both fresh and retry paths.
- Adds `repair_reconciliation.py` for the multi-phase reconciliation lifecycle (`prepare → record_desired_entities → require_platforms_complete → finalize → mark_complete`) gated behind a persistent `REPAIR_MARKER_KEY` that survives restarts.
- Updates all platform `async_setup_entry` handlers (sensor, binary_sensor, switch, device_tracker, update) with per-platform inventory completeness checks that gate the `record_desired_entities` call, so the finalizer only cleans up stale records when the full authoritative inventory is available.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The repair and reconciliation machinery is well-guarded: snapshot checks, duplicate-entry detection, recovery-reload scheduling, and TimeoutError handling are all present on every abort path reviewed.

Previous review threads identified several exception-handling gaps and missing recovery-reload calls; the current HEAD addresses all of them. No new blocking defects were found in this pass.

device_tracker.py — _track_all_arp_entries_are_complete still returns False for non-MutableMapping ARP rows while the compiler skips them, tracked in an existing review thread.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/opnsense/repairs.py | New repair flow class with thorough snapshot validation, pre/post-unload probes catching OPNsenseError and TimeoutError, and recovery-reload scheduling on every abort path. |
| custom_components/opnsense/repair_reconciliation.py | Well-structured reconciliation lifecycle: pre-flight collision detection in prepare(), per-platform desired-entity recording, platform-completeness gate, and conservative finalize() that removes only undesired stale entries. |
| custom_components/opnsense/__init__.py | Setup path correctly gates reconciliation behind marker validation, creates marker-backed repair issue on coordinator refresh failures, and preserves runtime data (keep_reconciliation_runtime) when platform cleanup itself fails. |
| custom_components/opnsense/sensor.py | Extensive per-subsystem completeness checks added; SMART check also validates client capability flags, which is intentionally stricter than the binary_sensor platform's equivalent check. |
| custom_components/opnsense/switch.py | Completeness checks correctly exclude the legacy key when iterating Unbound blocklist rows, mirroring the compiler's explicit skip; VPN, firewall, NAT, CARP, and service rows all have symmetric validators. |
| custom_components/opnsense/device_tracker.py | Reconciliation completeness bypassed correctly when configured MACs are present; _track_all_arp_entries_are_complete returns False for non-mapping ARP rows while the compiler just skips them (tracked in a prior review comment). |
| custom_components/opnsense/binary_sensor.py | Correctly adds state-presence guard before calling compilation helpers and records desired entities with None when interface or SMART inventory is incomplete; static Notices entity correctly excluded from completeness gating. |
| custom_components/opnsense/coordinator.py | Mismatch detection upgraded to use is_valid_device_id, now creates a fixable repair issue after 3 consecutive mismatches and deletes any stale issue when IDs agree and no repair marker is present. |
| custom_components/opnsense/update.py | Minimal change: unconditionally records desired update entities (always complete since update entities are static, not dynamic inventory). |
| custom_components/opnsense/translations/en.json | Repair flow strings added for confirm step and all abort reasons; old non-fixable description replaced with actionable repair UI copy. |

</details>

<sub>Reviews (21): Last reviewed commit: ["Handle repair reload timeouts"](https://github.com/snuffy2/hass-opnsense/commit/963110e1e75839a91d185d66a36de9963852ef1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44679178)</sub>

<!-- /greptile_comment -->