### PR TITLE
Allow migration without firewall privileges

### DIFF
--- a/custom_components/opnsense/migrate.py
+++ b/custom_components/opnsense/migrate.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any
 
 from aiopnsense import OPNsenseClient
-from aiopnsense.exceptions import OPNsenseError
+from aiopnsense.exceptions import OPNsenseError, OPNsensePrivilegeMissing
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
@@ -497,6 +497,12 @@ async def _migrate_4_to_5(
             return False
         try:
             firewall = await migration_client.get_firewall()
+        except OPNsensePrivilegeMissing:
+            _LOGGER.warning(
+                "Migration to version 5 skipping native rule pruning because firewall "
+                "privileges are unavailable"
+            )
+            firewall = None
         except OPNsenseError as e:
             _LOGGER.warning(
                 "Migration to version 5 deferred because current firewall rules are "
@@ -505,12 +511,12 @@ async def _migrate_4_to_5(
             )
             return False
 
-        if not isinstance(firewall, Mapping):
+        if firewall is not None and not isinstance(firewall, Mapping):
             _LOGGER.warning(
                 "Migration to version 5 skipping native rule pruning because firewall payload is "
                 "unavailable"
             )
-        else:
+        elif isinstance(firewall, Mapping):
             rules = firewall.get("rules")
             if isinstance(rules, Mapping):
                 current_firewall_unique_ids = firewall_rule_switch_unique_ids_from_payload(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2052,6 +2052,56 @@ async def test_migrate_4_to_5_defers_when_firewall_rules_unavailable(
 
 
 @pytest.mark.asyncio
+async def test_migrate_4_to_5_completes_when_firewall_privileges_are_missing(
+    monkeypatch: pytest.MonkeyPatch, ph_hass: HomeAssistant
+) -> None:
+    """Migration should not block unrelated entities on missing firewall privileges."""
+    update_entry = MagicMock(return_value=True)
+    monkeypatch.setattr(ph_hass.config_entries, "async_update_entry", update_entry)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DEVICE_UNIQUE_ID: "device-id",
+            CONF_URL: "http://1.2.3.4",
+            CONF_USERNAME: "u",
+            CONF_PASSWORD: "p",
+        },
+        version=4,
+    )
+    entry.add_to_hass(ph_hass)
+    client = MagicMock()
+    client.get_firewall = AsyncMock(side_effect=OPNsensePrivilegeMissing("forbidden"))
+    client.async_close = AsyncMock()
+    monkeypatch.setattr(
+        init_mod, "create_opnsense_client_from_config_entry", MagicMock(return_value=client)
+    )
+
+    entry_prefix = slugify("device-id")
+    legacy_filter = _RegistryEntity("switch.filter", f"{entry_prefix}_filter_123")
+    native_firewall = _RegistryEntity(
+        "switch.firewall_rule", f"{entry_prefix}_firewall_rule_current"
+    )
+    native_nat = _RegistryEntity(
+        "switch.firewall_nat", f"{entry_prefix}_firewall_nat_source_nat_current"
+    )
+
+    entity_registry = MagicMock()
+    entity_registry.async_remove = MagicMock()
+    monkeypatch.setattr(er, "async_get", lambda hass: entity_registry)
+    monkeypatch.setattr(
+        er,
+        "async_entries_for_config_entry",
+        lambda registry, config_entry_id: [legacy_filter, native_firewall, native_nat],
+    )
+
+    res = await init_mod.async_migrate_entry(ph_hass, entry)
+
+    assert res is True
+    entity_registry.async_remove.assert_called_once_with(legacy_filter.entity_id)
+    update_entry.assert_called_once_with(entry, version=5)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "firewall_payload",
     [


### PR DESCRIPTION
## Summary
Allows config-entry migration to complete when the OPNsense API user lacks firewall privileges, preventing unrelated entities such as device trackers from remaining unavailable.

## What Changed
- Treat `OPNsensePrivilegeMissing` as feature-scoped firewall data unavailability during migration from version 4 to 5.
- Preserve native firewall and NAT entities when their current state cannot be verified while still removing safe legacy rule entities.
- Keep generic OPNsense API failures retryable and add regression coverage for the missing-privilege path.

## Why
Firewall access is optional for installations that do not use firewall or NAT rule switches. A permanent 403 from those endpoints should not block the entire config entry from loading.

This approach narrows graceful handling to the privilege-specific failure, while retaining migration retries for transient or broader API failures.

## Related Issues
Refs https://github.com/travisghansen/hass-opnsense/issues/666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OPNsense configuration migration when firewall privileges are unavailable.
  * Migrations now complete successfully without incorrectly attempting native firewall rule cleanup.
  * Legacy filter entities continue to be removed as expected during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR lets version 4-to-5 migration continue when firewall privileges are unavailable. The main changes are:

- Handles missing firewall privileges separately from retryable API failures.
- Preserves native firewall and NAT entities when current rules cannot be checked.
- Adds a test for successful migration without firewall privileges.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The privilege-specific exception is handled before the generic API failure path.
- Native firewall and NAT entities remain preserved when firewall data is unavailable.
- No blocking issues were found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/opnsense/migrate.py | Adds privilege-specific migration handling while preserving native entities when firewall state is unknown. |
| tests/test_init.py | Covers successful migration, legacy entity removal, and native entity preservation when firewall privileges are missing. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Allow migration without firewall privile..."](https://github.com/snuffy2/hass-opnsense/commit/2a91b6d04a225fc4ee54a70464204ca8422b848b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46267701)</sub>

<!-- /greptile_comment -->